### PR TITLE
Added gedcomtune and performance improvements. Fixes #60

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -117,10 +117,10 @@ func (dec *Decoder) readLine() (string, error) {
 	return string(buf.Bytes()), nil
 }
 
+var lineRegexp = regexp.MustCompile(`^(\d) (@\w+@ )?(\w+)( .*)?$`)
+
 func parseLine(line string) (Node, int) {
-	parts := regexp.
-		MustCompile(`^(\d) (@\w+@ )?(\w+)( .*)?$`).
-		FindStringSubmatch(line)
+	parts := lineRegexp.FindStringSubmatch(line)
 
 	indent := 0
 	if len(parts) > 1 {
@@ -143,6 +143,9 @@ func parseLine(line string) (Node, int) {
 	}
 
 	switch tag {
+	case TagDate:
+		return NewDateNode(value, pointer, []Node{}), indent
+
 	case TagFamily:
 		return NewFamilyNode(pointer, []Node{}), indent
 

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -214,10 +214,10 @@ var tests = map[string]*gedcom.Document{
 		Nodes: []gedcom.Node{
 			gedcom.NewIndividualNode("", "P221", []gedcom.Node{
 				gedcom.NewSimpleNode(gedcom.TagBirth, "", "", []gedcom.Node{
-					gedcom.NewSimpleNode(gedcom.TagDate, "1851", "", []gedcom.Node{}),
+					gedcom.NewDateNode("1851", "", []gedcom.Node{}),
 				}),
 				gedcom.NewSimpleNode(gedcom.TagDeath, "", "", []gedcom.Node{
-					gedcom.NewSimpleNode(gedcom.TagDate, "1856", "", []gedcom.Node{}),
+					gedcom.NewDateNode("1856", "", []gedcom.Node{}),
 				}),
 			}),
 		},
@@ -228,6 +228,11 @@ var tests = map[string]*gedcom.Document{
 				gedcom.NewSimpleNode(gedcom.TagHusband, "@P2@", "", []gedcom.Node{}),
 				gedcom.NewSimpleNode(gedcom.TagWife, "@P3@", "", []gedcom.Node{}),
 			}),
+		},
+	},
+	"0 DATE 1856": {
+		Nodes: []gedcom.Node{
+			gedcom.NewDateNode("1856", "", []gedcom.Node{}),
 		},
 	},
 }

--- a/family_node_test.go
+++ b/family_node_test.go
@@ -160,7 +160,7 @@ func TestFamilyNode_Similarity(t *testing.T) {
 					}),
 				},
 			},
-			expected: 0.8347467653467052,
+			expected: 0.8904318416381887,
 		},
 
 		// These ones are way off.
@@ -194,15 +194,16 @@ func TestFamilyNode_Similarity(t *testing.T) {
 					}),
 				},
 			},
-			expected: 0.36400720887980753,
+			expected: 0.37700025152486955,
 		},
 	}
 
+	options := gedcom.NewSimilarityOptions()
 	for _, test := range tests {
 		t.Run("", func(t *testing.T) {
 			family1 := test.doc.Families()[0]
 			family2 := test.doc.Families()[1]
-			got := family1.Similarity(test.doc, test.doc, family2, 0)
+			got := family1.Similarity(test.doc, test.doc, family2, 0, options)
 
 			assert.Equal(t, test.expected, got)
 		})

--- a/gedcom2html/individuals.go
+++ b/gedcom2html/individuals.go
@@ -8,6 +8,8 @@ import (
 
 var individualMap map[string]*gedcom.IndividualNode
 
+var alnumOrDashRegexp = regexp.MustCompile("[^a-z_0-9-]+")
+
 func getIndividuals(document *gedcom.Document) map[string]*gedcom.IndividualNode {
 	if individualMap == nil {
 		individualMap = map[string]*gedcom.IndividualNode{}
@@ -15,7 +17,7 @@ func getIndividuals(document *gedcom.Document) map[string]*gedcom.IndividualNode
 		for _, individual := range document.Individuals() {
 			name := individual.Name().String()
 
-			key := getUniqueKey(regexp.MustCompile("[^a-z_0-9-]+").
+			key := getUniqueKey(alnumOrDashRegexp.
 				ReplaceAllString(strings.ToLower(name), "-"))
 
 			individualMap[key] = individual

--- a/gedcom2html/places.go
+++ b/gedcom2html/places.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"github.com/elliotchance/gedcom"
-	"regexp"
 	"strings"
 )
 
@@ -33,7 +32,7 @@ func getPlaces(document *gedcom.Document) map[string]*place {
 				continue
 			}
 
-			key := regexp.MustCompile("[^a-z_0-9-]+").
+			key := alnumOrDashRegexp.
 				ReplaceAllString(strings.ToLower(prettyName), "-")
 
 			if _, ok := placesMap[key]; !ok {

--- a/gedcomtune/.gitignore
+++ b/gedcomtune/.gitignore
@@ -1,0 +1,3 @@
+*.ged
+*.prof
+gedcomtune

--- a/gedcomtune/main.go
+++ b/gedcomtune/main.go
@@ -1,0 +1,270 @@
+// Package gedcomtune is used to calculate the ideal weights and similarities
+// for the main gedcom package.
+//
+// It works by comparing two GEDCOM files that are mostly the same, but must
+// have the same pointers for individuals. It uses tries to calculate the best
+// values that would lead the Similarity functions to the highest number of
+// matches (which are confirmed by the individual pointers).
+//
+// The process works like this:
+//
+// 1. Load the two GEDCOM files.
+//
+// 2. Set predefined or random values for weightings.
+//
+// 3. Match the two files. One point is awarded to a successful match and one
+// point is removed for each unsuccessful match.
+//
+// 4. Steps 2 and 3 are repeated many more times with different weightings.
+//
+// 5. The weighting values that scored the highest points are returned.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"github.com/elliotchance/gedcom"
+	"log"
+	"math/rand"
+	"os"
+	"runtime/pprof"
+)
+
+var (
+	// Input files.
+	optionGedcomFile1 string
+	optionGedcomFile2 string
+	optionRandom      bool
+
+	// Profiling.
+	optionCPUProfileOutput string
+
+	// minimumSimilarity
+	optionSimilarityMin  float64
+	optionSimilarityMax  float64
+	optionSimilarityStep float64
+
+	// maxYears
+	optionYearsMin  float64
+	optionYearsMax  float64
+	optionYearsStep float64
+
+	// Weights
+	optionsWeightIndividualMin  float64
+	optionsWeightIndividualMax  float64
+	optionsWeightIndividualStep float64
+
+	// Name to date ratio
+	optionsNameToDateRatioMin  float64
+	optionsNameToDateRatioMax  float64
+	optionsNameToDateRatioStep float64
+
+	// Jaro boost threshold
+	optionsJaroBoostMin  float64
+	optionsJaroBoostMax  float64
+	optionsJaroBoostStep float64
+
+	// Jaro prefix size
+	optionsJaroPrefixSizeMin  int
+	optionsJaroPrefixSizeMax  int
+	optionsJaroPrefixSizeStep int
+)
+
+func main() {
+	parseCLIFlags()
+
+	// CPU profiler
+	if optionCPUProfileOutput != "" {
+		log.Printf("Starting CPU profiler.")
+		startCPUProfiler()
+
+		defer pprof.StopCPUProfile()
+	}
+
+	gedcom1, err := gedcom.NewDocumentFromGEDCOMFile(optionGedcomFile1)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	gedcom2, err := gedcom.NewDocumentFromGEDCOMFile(optionGedcomFile2)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Calculate ideal score.
+	idealScore := 0
+	for _, i1 := range gedcom1.Individuals() {
+		for _, i2 := range gedcom2.Individuals() {
+			if i1.Pointer() == i2.Pointer() {
+				idealScore += 1
+			}
+		}
+	}
+
+	// Run compare.
+	options := gedcom.NewSimilarityOptions()
+	if optionRandom {
+		for {
+			options.MinimumSimilarity = random(optionSimilarityMin, optionSimilarityMax)
+			options.MinimumWeightedSimilarity = random(optionSimilarityMin, optionSimilarityMax)
+			options.IndividualWeight = random(optionsWeightIndividualMin, optionsWeightIndividualMax)
+			options.SpousesWeight = (1.0 - options.IndividualWeight) / 3
+			options.ParentsWeight = (1.0 - options.IndividualWeight) / 3
+			options.ChildrenWeight = (1.0 - options.IndividualWeight) / 3
+			options.MaxYears = random(optionYearsMin, optionYearsMax)
+			options.NameToDateRatio = random(optionsNameToDateRatioMin, optionsNameToDateRatioMax)
+			options.JaroBoostThreshold = random(optionsJaroBoostMin, optionsJaroBoostMax)
+			options.JaroPrefixSize = int(random(float64(optionsJaroPrefixSizeMin), float64(optionsJaroPrefixSizeMax)))
+
+			run(gedcom1, gedcom2, idealScore, options)
+		}
+	}
+
+	runMinimumSimilarity(gedcom1, gedcom2, idealScore, options)
+}
+
+func parseCLIFlags() {
+	// Input files. Must be provided.
+	flag.StringVar(&optionGedcomFile1, "gedcom1", "", "First GEDCOM file.")
+	flag.StringVar(&optionGedcomFile2, "gedcom2", "", "Second GEDCOM file.")
+	flag.BoolVar(&optionRandom, "random", false, "Run forever with random values.")
+
+	// Profiling.
+	flag.StringVar(&optionCPUProfileOutput, "cpu-profile", "", "If enabled "+
+		"the CPU profile file will be created or replaced. This is needed to "+
+		"optimise the comparison process.")
+
+	// minimumSimilarity
+	flag.Float64Var(&optionSimilarityMin, "similarity-min",
+		gedcom.DefaultMinimumSimilarity, "Lower bound for minimumSimilarity.")
+	flag.Float64Var(&optionSimilarityMax, "similarity-max",
+		gedcom.DefaultMinimumSimilarity, "Upper bound for minimumSimilarity.")
+	flag.Float64Var(&optionSimilarityStep, "similarity-step", 0.1,
+		"Step size for minimumSimilarity.")
+
+	// maxYears
+	flag.Float64Var(&optionYearsMin, "years-min",
+		gedcom.DefaultMaxYearsForSimilarity, "Lower bound for maxYears.")
+	flag.Float64Var(&optionYearsMax, "years-max",
+		gedcom.DefaultMaxYearsForSimilarity, "Upper bound for maxYears.")
+	flag.Float64Var(&optionYearsStep, "years-step", 1,
+		"Step size for maxYears.")
+
+	// Weights
+	flag.Float64Var(&optionsWeightIndividualMin, "weight-individual-min", 0.8,
+		"Lower bound for individual weight.")
+	flag.Float64Var(&optionsWeightIndividualMax, "weight-individual-max", 0.8,
+		"Upper bound for individual weight.")
+	flag.Float64Var(&optionsWeightIndividualStep, "weight-individual-step", 0.05,
+		"Step size for individual weight.")
+
+	// Name ratio
+	flag.Float64Var(&optionsNameToDateRatioMin, "name-ratio-min", 0.5,
+		"Lower bound for name to date ratio.")
+	flag.Float64Var(&optionsNameToDateRatioMax, "name-ratio-max", 0.5,
+		"Upper bound for name to date ratio.")
+	flag.Float64Var(&optionsNameToDateRatioStep, "name-ratio-step", 0.1,
+		"Step size for name to date ratio.")
+
+	// Jaro boost threshold
+	flag.Float64Var(&optionsJaroBoostMin, "jaro-boost-min", 0.0,
+		"Lower bound for jaro boost threshold.")
+	flag.Float64Var(&optionsJaroBoostMax, "jaro-boost-max", 0.0,
+		"Upper bound for jaro boost threshold.")
+	flag.Float64Var(&optionsJaroBoostStep, "jaro-boost-step", 0.1,
+		"Step size for jaro boost threshold.")
+
+	// Jaro prefix size
+	flag.IntVar(&optionsJaroPrefixSizeMin, "jaro-prefix-min", 8,
+		"Lower bound for jaro prefix size.")
+	flag.IntVar(&optionsJaroPrefixSizeMax, "jaro-prefix-max", 8,
+		"Upper bound for jaro prefix size.")
+	flag.IntVar(&optionsJaroPrefixSizeStep, "jaro-prefix-step", 1,
+		"Step size for jaro prefix size.")
+
+	flag.Parse()
+}
+
+func random(min, max float64) float64 {
+	return min + rand.Float64()*(max-min)
+}
+
+func runMinimumSimilarity(gedcom1 *gedcom.Document, gedcom2 *gedcom.Document, idealScore int, options *gedcom.SimilarityOptions) {
+	for minimumSimilarity := optionSimilarityMin; minimumSimilarity <= optionSimilarityMax; minimumSimilarity += optionSimilarityStep {
+		options.MinimumWeightedSimilarity = minimumSimilarity
+		options.MinimumSimilarity = minimumSimilarity
+
+		runMaxYears(gedcom1, gedcom2, idealScore, options)
+	}
+}
+
+func runMaxYears(gedcom1 *gedcom.Document, gedcom2 *gedcom.Document, idealScore int, options *gedcom.SimilarityOptions) {
+	for maxYears := optionYearsMin; maxYears <= optionYearsMax; maxYears += optionYearsStep {
+		options.MaxYears = maxYears
+
+		runIndividualWeight(gedcom1, gedcom2, idealScore, options)
+	}
+}
+
+func runIndividualWeight(gedcom1 *gedcom.Document, gedcom2 *gedcom.Document, idealScore int, options *gedcom.SimilarityOptions) {
+	for x := optionsWeightIndividualMin; x <= optionsWeightIndividualMax; x += optionsWeightIndividualStep {
+		options.IndividualWeight = x
+		options.SpousesWeight = (1.0 - x) / 3
+		options.ParentsWeight = (1.0 - x) / 3
+		options.ChildrenWeight = (1.0 - x) / 3
+
+		runNameToDateRatio(gedcom1, gedcom2, idealScore, options)
+	}
+}
+
+func runNameToDateRatio(gedcom1 *gedcom.Document, gedcom2 *gedcom.Document, idealScore int, options *gedcom.SimilarityOptions) {
+	for x := optionsNameToDateRatioMin; x <= optionsNameToDateRatioMax; x += optionsNameToDateRatioStep {
+		options.NameToDateRatio = x
+
+		runJaroBoost(gedcom1, gedcom2, idealScore, options)
+	}
+}
+
+func runJaroBoost(gedcom1 *gedcom.Document, gedcom2 *gedcom.Document, idealScore int, options *gedcom.SimilarityOptions) {
+	for x := optionsJaroBoostMin; x <= optionsJaroBoostMax; x += optionsJaroBoostStep {
+		options.JaroBoostThreshold = x
+
+		runJaroPrefixSize(gedcom1, gedcom2, idealScore, options)
+	}
+}
+
+func runJaroPrefixSize(gedcom1 *gedcom.Document, gedcom2 *gedcom.Document, idealScore int, options *gedcom.SimilarityOptions) {
+	for x := optionsJaroPrefixSizeMin; x <= optionsJaroPrefixSizeMax; x += optionsJaroPrefixSizeStep {
+		options.JaroPrefixSize = x
+
+		run(gedcom1, gedcom2, idealScore, options)
+	}
+}
+
+func startCPUProfiler() {
+	f, err := os.Create(optionCPUProfileOutput)
+	if err != nil {
+		panic(err)
+	}
+	if err := pprof.StartCPUProfile(f); err != nil {
+		panic(err)
+	}
+}
+
+func run(gedcom1, gedcom2 *gedcom.Document, idealScore int, options *gedcom.SimilarityOptions) {
+	comparisons := gedcom1.Individuals().Compare(gedcom1, gedcom2,
+		gedcom2.Individuals(), options)
+
+	score := 0.0
+	for _, comparison := range comparisons {
+		if comparison.Left != nil && comparison.Right != nil {
+			if comparison.Left.Pointer() == comparison.Right.Pointer() {
+				score += 1
+			} else {
+				score -= 1
+			}
+		}
+	}
+
+	fmt.Printf("%s, Score:%.6f\n", options, score/float64(idealScore))
+}

--- a/individual_node_test.go
+++ b/individual_node_test.go
@@ -620,7 +620,13 @@ func TestIndividualNode_EstimatedBirthDate(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run("", func(t *testing.T) {
-			assert.Equal(t, test.node.EstimatedBirthDate(), test.expected)
+			got := test.node.EstimatedBirthDate()
+
+			if got == nil {
+				assert.Nil(t, test.expected)
+			} else {
+				assert.Equal(t, got.SimpleNode, test.expected.SimpleNode)
+			}
 		})
 	}
 }
@@ -708,7 +714,13 @@ func TestIndividualNode_EstimatedDeathDate(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run("", func(t *testing.T) {
-			assert.Equal(t, test.node.EstimatedDeathDate(), test.expected)
+			got := test.node.EstimatedDeathDate()
+
+			if got == nil {
+				assert.Nil(t, test.expected)
+			} else {
+				assert.Equal(t, got.SimpleNode, test.expected.SimpleNode)
+			}
 		})
 	}
 }
@@ -765,12 +777,12 @@ func TestIndividualNode_Similarity(t *testing.T) {
 		{
 			a:        individual("P1", "", "", ""),
 			b:        individual("P1", "", "", ""),
-			expected: 0.3333333333333333,
+			expected: 0.25,
 		},
 		{
 			a:        gedcom.NewIndividualNode("", "P1", []gedcom.Node{}),
 			b:        gedcom.NewIndividualNode("", "P1", []gedcom.Node{}),
-			expected: 0.3333333333333333,
+			expected: 0.25,
 		},
 
 		// Perfect cases.
@@ -832,7 +844,7 @@ func TestIndividualNode_Similarity(t *testing.T) {
 				born("4 Jan 1843"),
 				died("17 Mar 1907"),
 			}),
-			expected: 0.9663440860215053,
+			expected: 0.9831720430107527,
 		},
 		{
 			// Last name is similar.
@@ -846,7 +858,7 @@ func TestIndividualNode_Similarity(t *testing.T) {
 				born("4 Jan 1843"),
 				died("17 Mar 1907"),
 			}),
-			expected: 0.995766129032258,
+			expected: 0.997883064516129,
 		},
 		{
 			// Birth date is less specific.
@@ -860,7 +872,7 @@ func TestIndividualNode_Similarity(t *testing.T) {
 				born("Jan 1843"),
 				died("17 Mar 1907"),
 			}),
-			expected: 0.999996416733853,
+			expected: 0.9999701394487746,
 		},
 		{
 			// Death date is less specific.
@@ -874,7 +886,7 @@ func TestIndividualNode_Similarity(t *testing.T) {
 				born("4 Jan 1843"),
 				died("Mar 1907"),
 			}),
-			expected: 0.9999999751162073,
+			expected: 0.999999792635061,
 		},
 
 		// Estimated birth/death.
@@ -889,7 +901,7 @@ func TestIndividualNode_Similarity(t *testing.T) {
 				born("4 Jan 1843"),
 				died("Mar 1907"),
 			}),
-			expected: 0.9992026735146867,
+			expected: 0.9933556126223895,
 		},
 		{
 			a: gedcom.NewIndividualNode("", "P1", []gedcom.Node{
@@ -902,7 +914,7 @@ func TestIndividualNode_Similarity(t *testing.T) {
 				born("4 Jan 1843"),
 				buried("Aft. 20 Mar 1907"),
 			}),
-			expected: 0.9992024744443452,
+			expected: 0.9933539537028769,
 		},
 
 		// Missing dates.
@@ -915,7 +927,7 @@ func TestIndividualNode_Similarity(t *testing.T) {
 				name("Elliot Rupert /Chance/"),
 				died("1909"),
 			}),
-			expected: 0.7863440860215053,
+			expected: 0.7470609318996415,
 		},
 		{
 			a: gedcom.NewIndividualNode("", "P1", []gedcom.Node{
@@ -926,7 +938,7 @@ func TestIndividualNode_Similarity(t *testing.T) {
 				name("Elliot Rupert /Chance/"),
 				born("Between 1822 and 1823"),
 			}),
-			expected: 0.7980146283388829,
+			expected: 0.8443154512111212,
 		},
 		{
 			a: gedcom.NewIndividualNode("", "P1", []gedcom.Node{
@@ -935,7 +947,7 @@ func TestIndividualNode_Similarity(t *testing.T) {
 			b: gedcom.NewIndividualNode("", "P1", []gedcom.Node{
 				name("Elliot Rupert /Chance/"),
 			}),
-			expected: 0.633010752688172,
+			expected: 0.7331720430107527,
 		},
 
 		// These ones are way off.
@@ -948,13 +960,16 @@ func TestIndividualNode_Similarity(t *testing.T) {
 				name("Bob /Jones/"),
 				born("1627"),
 			}),
-			expected: 0.3194444444444444,
+			expected: 0.38125,
 		},
 	}
 
+	options := gedcom.NewSimilarityOptions()
 	for _, test := range tests {
 		t.Run("", func(t *testing.T) {
-			assert.Equal(t, test.a.Similarity(test.b), test.expected)
+			got := test.a.Similarity(test.b, options)
+
+			assert.Equal(t, test.expected, got)
 		})
 	}
 }
@@ -972,7 +987,7 @@ func TestIndividualNode_SurroundingSimilarity(t *testing.T) {
 			),
 			expected: gedcom.SurroundingSimilarity{
 				ParentsSimilarity:    0.5,
-				IndividualSimilarity: 0.3333333333333333,
+				IndividualSimilarity: 0.25,
 				SpousesSimilarity:    1.0,
 				ChildrenSimilarity:   1.0,
 			},
@@ -1000,7 +1015,7 @@ func TestIndividualNode_SurroundingSimilarity(t *testing.T) {
 			),
 			expected: gedcom.SurroundingSimilarity{
 				ParentsSimilarity:    0.5,
-				IndividualSimilarity: 0.9630708093204747,
+				IndividualSimilarity: 0.7433558199873285,
 				SpousesSimilarity:    1.0,
 				ChildrenSimilarity:   1.0,
 			},
@@ -1014,7 +1029,7 @@ func TestIndividualNode_SurroundingSimilarity(t *testing.T) {
 			),
 			expected: gedcom.SurroundingSimilarity{
 				ParentsSimilarity:    0.5,
-				IndividualSimilarity: 0.1341880341880342,
+				IndividualSimilarity: 0.20128205128205132,
 				SpousesSimilarity:    1.0,
 				ChildrenSimilarity:   1.0,
 			},
@@ -1053,8 +1068,8 @@ func TestIndividualNode_SurroundingSimilarity(t *testing.T) {
 				family("F2", "P5", "P6", "P2"),
 			),
 			expected: gedcom.SurroundingSimilarity{
-				ParentsSimilarity:    0.9962962962962962,
-				IndividualSimilarity: 0.9901098901098901,
+				ParentsSimilarity:    0.9981481481481481,
+				IndividualSimilarity: 0.9950549450549451,
 				SpousesSimilarity:    1.0,
 				ChildrenSimilarity:   1.0,
 			},
@@ -1074,7 +1089,7 @@ func TestIndividualNode_SurroundingSimilarity(t *testing.T) {
 			),
 			expected: gedcom.SurroundingSimilarity{
 				ParentsSimilarity:    0.75,
-				IndividualSimilarity: 0.9901098901098901,
+				IndividualSimilarity: 0.9950549450549451,
 				SpousesSimilarity:    1.0,
 				ChildrenSimilarity:   1.0,
 			},
@@ -1094,7 +1109,7 @@ func TestIndividualNode_SurroundingSimilarity(t *testing.T) {
 			),
 			expected: gedcom.SurroundingSimilarity{
 				ParentsSimilarity:    0.5,
-				IndividualSimilarity: 0.9901098901098901,
+				IndividualSimilarity: 0.9950549450549451,
 				SpousesSimilarity:    1.0,
 				ChildrenSimilarity:   1.0,
 			},
@@ -1125,11 +1140,12 @@ func TestIndividualNode_SurroundingSimilarity(t *testing.T) {
 		},
 	}
 
+	options := gedcom.NewSimilarityOptions()
 	for _, test := range tests {
 		t.Run("", func(t *testing.T) {
 			a := test.doc.Individuals()[0]
 			b := test.doc.Individuals()[1]
-			s := a.SurroundingSimilarity(test.doc, test.doc, b)
+			s := a.SurroundingSimilarity(test.doc, test.doc, b, options)
 
 			assert.Equal(t, test.expected, s)
 		})

--- a/individual_nodes_test.go
+++ b/individual_nodes_test.go
@@ -84,7 +84,7 @@ func TestIndividualNodes_Similarity(t *testing.T) {
 				}),
 			},
 			minSimilarity: gedcom.DefaultMinimumSimilarity,
-			expected:      0.8333333333333334,
+			expected:      0.875,
 		},
 		{
 			a: gedcom.IndividualNodes{
@@ -98,7 +98,7 @@ func TestIndividualNodes_Similarity(t *testing.T) {
 				}),
 			},
 			minSimilarity: gedcom.DefaultMinimumSimilarity,
-			expected:      0.5,
+			expected:      0.75,
 		},
 
 		// Similar matches but the same sized slice on both sides.
@@ -134,7 +134,7 @@ func TestIndividualNodes_Similarity(t *testing.T) {
 				}),
 			},
 			minSimilarity: gedcom.DefaultMinimumSimilarity,
-			expected:      0.8464260797907109,
+			expected:      0.872532146404072,
 		},
 
 		// The slices are different lengths. The same score should be returned
@@ -167,7 +167,7 @@ func TestIndividualNodes_Similarity(t *testing.T) {
 				}),
 			},
 			minSimilarity: gedcom.DefaultMinimumSimilarity,
-			expected:      0.7758258827110728,
+			expected:      0.7754008744441251,
 		},
 		{
 			a: gedcom.IndividualNodes{
@@ -197,7 +197,7 @@ func TestIndividualNodes_Similarity(t *testing.T) {
 				}),
 			},
 			minSimilarity: gedcom.DefaultMinimumSimilarity,
-			expected:      0.7758258827110728,
+			expected:      0.7754008744441251,
 		},
 
 		// Whenever one slice is empty the result will always be 0.5.
@@ -323,13 +323,17 @@ func TestIndividualNodes_Similarity(t *testing.T) {
 				}),
 			},
 			minSimilarity: 0.0,
-			expected:      0.4219135802469136,
+			expected:      0.45708333333333334,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run("", func(t *testing.T) {
-			assert.Equal(t, test.a.Similarity(test.b, test.minSimilarity), test.expected)
+			options := gedcom.NewSimilarityOptions()
+			options.MinimumSimilarity = test.minSimilarity
+			got := test.a.Similarity(test.b, options)
+
+			assert.Equal(t, test.expected, got)
 		})
 	}
 }
@@ -392,8 +396,8 @@ func TestIndividualNodes_Compare(t *testing.T) {
 			want: []gedcom.IndividualComparison{
 				// elliot and john match because the minimumSimilarity is so
 				// low.
-				{elliot, john, gedcom.SurroundingSimilarity{0.5, 0.16495726495726495, 1.0, 1.0}},
-				{jane, jane, gedcom.SurroundingSimilarity{0.5, 1.0, 1.0, 1.0}},
+				{jane, jane, gedcom.SurroundingSimilarity{0.5, 1, 1.0, 1.0}},
+				{elliot, john, gedcom.SurroundingSimilarity{0.5, 0.24743589743589745, 1.0, 1.0}},
 			},
 		},
 		{
@@ -401,8 +405,8 @@ func TestIndividualNodes_Compare(t *testing.T) {
 			doc2: document(jane, john),
 			min:  0.75,
 			want: []gedcom.IndividualComparison{
-				{elliot, nil, gedcom.SurroundingSimilarity{}},
 				{jane, jane, gedcom.SurroundingSimilarity{0.5, 1.0, 1.0, 1.0}},
+				{elliot, nil, gedcom.SurroundingSimilarity{}},
 				{nil, john, gedcom.SurroundingSimilarity{}},
 			},
 		},
@@ -421,9 +425,12 @@ func TestIndividualNodes_Compare(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run("", func(t *testing.T) {
+			options := gedcom.NewSimilarityOptions()
+			options.MinimumWeightedSimilarity = test.min
+
 			individuals1 := test.doc1.Individuals()
 			individuals2 := test.doc2.Individuals()
-			got := individuals1.Compare(test.doc1, test.doc2, individuals2, test.min)
+			got := individuals1.Compare(test.doc1, test.doc2, individuals2, options)
 
 			assert.Equal(t, test.want, got)
 		})

--- a/jaro_test.go
+++ b/jaro_test.go
@@ -49,7 +49,7 @@ var stringTests = []struct {
 func TestJaroWinkler(t *testing.T) {
 	for _, test := range stringTests {
 		t.Run(test.a+"_"+test.b, func(t *testing.T) {
-			assert.Equal(t, test.jaro, gedcom.JaroWinkler(test.a, test.b))
+			assert.Equal(t, test.jaro, gedcom.JaroWinkler(test.a, test.b, 0.7, 4))
 		})
 	}
 }
@@ -57,7 +57,7 @@ func TestJaroWinkler(t *testing.T) {
 func TestStringSimilarity(t *testing.T) {
 	for _, test := range stringTests {
 		t.Run(test.a+"_"+test.b, func(t *testing.T) {
-			assert.Equal(t, test.str, gedcom.StringSimilarity(test.a, test.b))
+			assert.Equal(t, test.str, gedcom.StringSimilarity(test.a, test.b, 0.7, 4))
 		})
 	}
 }

--- a/name_node.go
+++ b/name_node.go
@@ -23,9 +23,10 @@ func NewNameNode(value, pointer string, children []Node) *NameNode {
 	}
 }
 
+var nameRegexp = regexp.MustCompile("([^/]*)(/[^/]*/)?(.*)")
+
 func (node *NameNode) parts() []string {
-	return regexp.MustCompile("([^/]*)(/[^/]*/)?(.*)").
-		FindStringSubmatch(node.value)
+	return nameRegexp.FindStringSubmatch(node.value)
 }
 
 func (node *NameNode) trimSpaces(s string) string {

--- a/nodes.go
+++ b/nodes.go
@@ -1,8 +1,26 @@
 package gedcom
 
+// nodeCache is used by NodesWithTag. Even though the lookup of child tags are
+// fairly inexpensive it happens a lot and its common for the same paths to be
+// looked up many time. Especially when doing larger task like comparing GEDCOM
+// files.
+var nodeCache = map[Node]map[Tag][]Node{}
+
 // NodesWithTag returns the zero or more nodes that have a specific GEDCOM tag.
 // If the provided node is nil then an empty slice will always be returned.
-func NodesWithTag(node Node, tag Tag) []Node {
+func NodesWithTag(node Node, tag Tag) (result []Node) {
+	if v, ok := nodeCache[node][tag]; ok {
+		return v
+	}
+
+	defer func() {
+		if _, ok := nodeCache[node]; !ok {
+			nodeCache[node] = map[Tag][]Node{}
+		}
+
+		nodeCache[node][tag] = result
+	}()
+
 	nodes := []Node{}
 
 	if node != nil {

--- a/similarity_options.go
+++ b/similarity_options.go
@@ -1,0 +1,70 @@
+package gedcom
+
+import "fmt"
+
+// SimilarityOptions is used by all of the functions that calculate the
+// similarity or otherwise compare entities. This struct allows many things to
+// be tweaked. However, not all of the values are used by all of the functions.
+//
+// Use NewSimilarityOptions() to choose sensible defaults that are best for most
+// general cases.
+type SimilarityOptions struct {
+	// MinimumSimilarity is the threshold for matching individuals as the same
+	// person. This is used to compare only the individual (not surrounding
+	// family) like spouses and children. See DefaultMinimumSimilarity.
+	MinimumSimilarity float64
+
+	// MinimumWeightedSimilarity is the threshold for whether two individuals
+	// should be the seen as the same person when the surrounding immediate
+	// family is taken into consideration. See WeightedSimilarity().
+	MinimumWeightedSimilarity float64
+
+	// MaxYears is the maximum error margin (in years) that two dates can be
+	// different before they are assume to not be the same. See
+	// DefaultMaxYearsForSimilarity.
+	MaxYears float64
+
+	// All four of these must sum up to 1.0.
+	IndividualWeight, ParentsWeight, SpousesWeight, ChildrenWeight float64
+
+	// NameToDateRatio describes the ratio between the weight of the individuals
+	// name to their combined estimated birth and death dates. A value of 0.0
+	// would not take into account the individuals name at all, whereas 1.0
+	// would not take into account any dates. A sensible default is 0.5.
+	NameToDateRatio float64
+
+	// JaroBoostThreshold and JaroPrefixSize are used by the JaroWinkler
+	// function. They affect the properties of names are compared. The default
+	// values for each of these can be found in the constants
+	// DefaultJaroWinklerBoostThreshold and DefaultJaroWinklerPrefixSize. Their
+	// values have been chosen with gedcomtune.
+	JaroBoostThreshold float64
+	JaroPrefixSize     int
+}
+
+// NewSimilarityOptions returns sensible defaults that are used around many of
+// the similarity functions.
+func NewSimilarityOptions() *SimilarityOptions {
+	return &SimilarityOptions{
+		MaxYears:                  DefaultMaxYearsForSimilarity,
+		MinimumSimilarity:         DefaultMinimumSimilarity,
+		MinimumWeightedSimilarity: DefaultMinimumSimilarity,
+
+		// All four of these must sum up to 1.0.
+		IndividualWeight: 0.8,
+		ParentsWeight:    0.2 / 3,
+		SpousesWeight:    0.2 / 3,
+		ChildrenWeight:   0.2 - (0.4 / 3),
+
+		NameToDateRatio:    0.5,
+		JaroBoostThreshold: DefaultJaroWinklerBoostThreshold,
+		JaroPrefixSize:     DefaultJaroWinklerPrefixSize,
+	}
+}
+
+// String renders the options as a comma-separated string.
+func (options SimilarityOptions) String() string {
+	s := fmt.Sprintf("%#v", options)
+
+	return s[25 : len(s)-1]
+}

--- a/similarity_options_test.go
+++ b/similarity_options_test.go
@@ -1,0 +1,33 @@
+package gedcom_test
+
+import (
+	"github.com/elliotchance/gedcom"
+	"github.com/elliotchance/tf"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestSimilarityOptions_String(t *testing.T) {
+	String := tf.Function(t, gedcom.SimilarityOptions.String)
+	options := *gedcom.NewSimilarityOptions()
+
+	String(options).Returns("MinimumSimilarity:0.735, " +
+		"MinimumWeightedSimilarity:0.735, " +
+		"MaxYears:3, " +
+		"IndividualWeight:0.8, " +
+		"ParentsWeight:0.06666666666666667, " +
+		"SpousesWeight:0.06666666666666667, " +
+		"ChildrenWeight:0.06666666666666667, " +
+		"NameToDateRatio:0.5, " +
+		"JaroBoostThreshold:0, " +
+		"JaroPrefixSize:8")
+}
+
+func TestNewSimilarityOptions(t *testing.T) {
+	options := gedcom.NewSimilarityOptions()
+
+	shouldBeOne := options.IndividualWeight + options.ParentsWeight +
+		options.SpousesWeight + options.ChildrenWeight
+
+	assert.Equal(t, 1.0, shouldBeOne)
+}

--- a/surrounding_similarity.go
+++ b/surrounding_similarity.go
@@ -34,12 +34,14 @@ type SurroundingSimilarity struct {
 // WeightedSimilarity calculates a single similarity from all of the similarity
 // metrics with following weights:
 //
-//   IndividualSimilarity: 50%
-//   ParentsSimilarity: ~17%
-//   SpousesSimilarity: ~17%
-//   ChildrenSimilarity: ~17%
+//   IndividualSimilarity: 80%
+//   ParentsSimilarity: ~6.7%
+//   SpousesSimilarity: ~6.7%
+//   ChildrenSimilarity: ~6.7%
 //
-func (s SurroundingSimilarity) WeightedSimilarity() float64 {
-	return s.IndividualSimilarity/2.0 +
-		(s.ParentsSimilarity+s.SpousesSimilarity+s.ChildrenSimilarity)/6.0
+func (s SurroundingSimilarity) WeightedSimilarity(options *SimilarityOptions) float64 {
+	return (s.IndividualSimilarity * options.IndividualWeight) +
+		(s.ParentsSimilarity * options.ParentsWeight) +
+		(s.SpousesSimilarity * options.SpousesWeight) +
+		(s.ChildrenSimilarity * options.ChildrenWeight)
 }

--- a/surrounding_similarity_test.go
+++ b/surrounding_similarity_test.go
@@ -1,20 +1,22 @@
-package gedcom
+package gedcom_test
 
 import (
+	"github.com/elliotchance/gedcom"
 	"github.com/elliotchance/tf"
 	"testing"
 )
 
 func TestSurroundingSimilarity_WeightedSimilarity(t *testing.T) {
-	WS := tf.Function(t, SurroundingSimilarity.WeightedSimilarity)
+	WS := tf.Function(t, gedcom.SurroundingSimilarity.WeightedSimilarity)
+	options := gedcom.NewSimilarityOptions()
 
-	WS(SurroundingSimilarity{}).Returns(0.0)
-	WS(SurroundingSimilarity{0.0, 0.0, 0.0, 0.0}).Returns(0.0)
-	WS(SurroundingSimilarity{1.0, 0.0, 0.0, 0.0}).Returns(0.16666666666666666)
-	WS(SurroundingSimilarity{0.0, 1.0, 0.0, 0.0}).Returns(0.5)
-	WS(SurroundingSimilarity{0.0, 0.0, 1.0, 0.0}).Returns(0.16666666666666666)
-	WS(SurroundingSimilarity{0.0, 0.0, 0.0, 1.0}).Returns(0.16666666666666666)
-	WS(SurroundingSimilarity{1.0, 0.5, 1.0, 1.0}).Returns(0.75)
-	WS(SurroundingSimilarity{0.8, 0.8, 0.8, 0.8}).Returns(0.8)
-	WS(SurroundingSimilarity{1.0, 1.0, 1.0, 1.0}).Returns(1.0)
+	WS(gedcom.SurroundingSimilarity{}, options).Returns(0.0)
+	WS(gedcom.SurroundingSimilarity{0.0, 0.0, 0.0, 0.0}, options).Returns(0.0)
+	WS(gedcom.SurroundingSimilarity{1.0, 0.0, 0.0, 0.0}, options).Returns(0.06666666666666666)
+	WS(gedcom.SurroundingSimilarity{0.0, 1.0, 0.0, 0.0}, options).Returns(0.8)
+	WS(gedcom.SurroundingSimilarity{0.0, 0.0, 1.0, 0.0}, options).Returns(0.06666666666666666)
+	WS(gedcom.SurroundingSimilarity{0.0, 0.0, 0.0, 1.0}, options).Returns(0.06666666666666666)
+	WS(gedcom.SurroundingSimilarity{1.0, 0.5, 1.0, 1.0}, options).Returns(0.6)
+	WS(gedcom.SurroundingSimilarity{0.8, 0.8, 0.8, 0.8}, options).Returns(0.8000000000000002)
+	WS(gedcom.SurroundingSimilarity{1.0, 1.0, 1.0, 1.0}, options).Returns(1.0)
 }


### PR DESCRIPTION
This has several breaking changes to the API. Fixes #60.

- Added gedcomtune package that makes it easier to find ideal values for similarities.
- From the results of gedcomtune many constants have been changed and new constants created.
- The simialrity calculations can now be adjusted with SimilarityOptions.
- NodesWithTag caches results to improve performance.
- Vastly increased the performance of regexps by only compling them once in all cases.
- Fixed a bug where DATE was not decoded as DateNode.
- Increased the performance of date parsing by caching the result.