### PR TITLE
Added CompareNodes. Fixes #65

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,33 +5,47 @@ github.com/elliotchance/gedcom
 [![GoDoc](https://godoc.org/github.com/elliotchance/gedcom?status.svg)](https://godoc.org/github.com/elliotchance/gedcom)
 [![codecov](https://codecov.io/gh/elliotchance/gedcom/branch/master/graph/badge.svg)](https://codecov.io/gh/elliotchance/gedcom)
 
-`gedcom` provides a Go-style encoder and decoder for GEDCOM files.
+`gedcom` is an advanced Go-style library for encoding, decoding, traversing,
+exporting and diffing GEDCOM files.
 
-The goals of this project are:
-
-1. **Support all GEDCOM files by supporting the encoding and not the GEDCOM
-standard itself.** Many GEDCOM libraries that try to follow the standard run
-into trouble when applications do not follow the same standards or the standard
-is interpreted differently. `gedcom` retains all tags and structure in the
-original GEDCOM file.
-
-2. **Build some structures/types that provide a nicer API for common
-operations.** For example iterating through individuals in a file,
-accessing/formatting names, standardising dates, etc.
-
-3. **Provide a program to convert GEDCOM to JSON**. So that any GEDCOM file can
-be ingested and processed more easily in other applications. The bundled
-`gedcom2json` program does this (and offers several options).
-
-   * [Decoding and Encoding](#decoding-and-encoding)
-   * [Traversing a Document](#traversing-a-document)
-   * [Working With Dates](#working-with-dates)
+   * [Project Goals](#project-goals)
+   * [GEDCOM Document](#gedcom-document)
+      * [Decoding](#decoding)
+      * [Encoding](#encoding)
+      * [Traversing a Document](#traversing-a-document)
+   * [Comparing &amp; Diffing](#comparing--diffing)
+      * [Nodes](#nodes)
+   * [Nodes](#nodes-1)
+      * [Dates](#dates)
    * [Rendering as HTML](#rendering-as-html)
    * [Converting to JSON](#converting-to-json)
    * [Converting to Text](#converting-to-text)
+      * [Comparing Output](#comparing-output)
 
-Decoding and Encoding
-=====================
+Project Goals
+=============
+
+1. Support all GEDCOM files by supporting the encoding and not the GEDCOM
+standard itself. Many GEDCOM libraries that try to follow the standard run into
+trouble when applications do not follow the same standards or the standard is
+interpreted differently. `gedcom` retains all tags and structure in the original
+GEDCOM file.
+
+2. Build structures and functions that provide a nicer API for common
+operations. For example iterating through individuals in a file, traversing
+through family connections, understanding dates, etc.
+
+3. Export to other file formats. Such as HTML, JSON, text, etc. So that
+information can be manipulated and ingested by other applications.
+
+4. Provide more advanced functionality to deal with comparing and diffing GEDCOM
+files.
+
+GEDCOM Document
+===============
+
+Decoding
+--------
 
 Decoding a GEDCOM stream:
 
@@ -54,7 +68,8 @@ if err != nil {
 }
 ```
 
-Encoding works like this:
+Encoding
+--------
 
 ```go
 buf := bytes.NewBufferString("")
@@ -73,7 +88,7 @@ data := document.String()
 ```
 
 Traversing a Document
-=====================
+---------------------
 
 On top of the raw document is a powerful API that takes care of the complex
 traversing of the Document. Here is a simple example:
@@ -89,8 +104,47 @@ types, such as names, dates, families and more. See
 [godoc](https://godoc.org/github.com/elliotchance/gedcom) for a complete list of
 API methods.
 
-Working With Dates
-==================
+Comparing & Diffing
+===================
+
+Nodes
+-----
+
+The [`CompareNodes`][1] recursively compares two nodes. For example:
+
+```
+0 INDI @P3@           |  0 INDI @P4@
+1 NAME John /Smith/   |  1 NAME J. /Smith/
+1 BIRT                |  1 BIRT
+2 DATE 3 SEP 1943     |  2 DATE Abt. Sep 1943
+1 DEAT                |  1 BIRT
+2 PLAC England        |  2 DATE 3 SEP 1943
+1 BIRT                |  1 DEAT
+2 DATE Abt. Oct 1943  |  2 DATE Aft. 2001
+                      |  2 PLAC Surry, England
+```
+
+Produces a [`*NodeDiff`][2] than can be rendered with the [`String`][3] method:
+
+```
+LR 0 INDI @P3@
+L  1 NAME John /Smith/
+LR 1 BIRT
+L  2 DATE Abt. Oct 1943
+LR 2 DATE 3 SEP 1943
+ R 2 DATE Abt. Sep 1943
+LR 1 DEAT
+L  2 PLAC England
+ R 2 DATE Aft. 2001
+ R 2 PLAC Surry, England
+ R 1 NAME J. /Smith/
+```
+
+Nodes
+=====
+
+Dates
+-----
 
 Dates in GEDCOM files can be very complex as they can cater for many scenarios:
 
@@ -196,3 +250,7 @@ diff -bur out1/ out2/
 
 You can (and probably should) also use
 [more pretty diffing tools](https://en.wikipedia.org/wiki/Comparison_of_file_comparison_tools).
+
+[1]: https://godoc.org/github.com/elliotchance/gedcom#CompareNodes
+[2]: https://godoc.org/github.com/elliotchance/gedcom#NodeDiff
+[3]: https://godoc.org/github.com/elliotchance/gedcom#NodeDiff.String

--- a/document.go
+++ b/document.go
@@ -3,6 +3,7 @@ package gedcom
 import (
 	"bytes"
 	"os"
+	"strings"
 )
 
 // Document represents a whole GEDCOM document. It is possible for a
@@ -121,5 +122,15 @@ func NewDocumentFromGEDCOMFile(path string) (*Document, error) {
 	}
 
 	decoder := NewDecoder(file)
+	return decoder.Decode()
+}
+
+// NewDocumentFromString creates a document from a string containing GEDCOM
+// data.
+//
+// An error is returned if a line cannot be parsed.
+func NewDocumentFromString(gedcom string) (*Document, error) {
+	decoder := NewDecoder(strings.NewReader(gedcom))
+
 	return decoder.Decode()
 }

--- a/document_test.go
+++ b/document_test.go
@@ -2,9 +2,11 @@ package gedcom_test
 
 import (
 	"fmt"
+	"testing"
+
+	"errors"
 	"github.com/elliotchance/gedcom"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 var documentTests = []struct {
@@ -121,6 +123,41 @@ func TestDocument_Families(t *testing.T) {
 	for _, test := range documentTests {
 		t.Run("", func(t *testing.T) {
 			assert.Equal(t, test.doc.Families(), test.families)
+		})
+	}
+}
+
+func TestNewDocumentFromString(t *testing.T) {
+	for _, test := range []struct {
+		ged      string
+		expected *gedcom.Document
+		err      error
+	}{
+		{
+			"",
+			&gedcom.Document{Nodes: []gedcom.Node{}},
+			nil,
+		},
+		{
+			"AAA",
+			nil,
+			errors.New("line 1: could not parse: AAA"),
+		},
+		{
+			"0 INDI\nAAB",
+			nil,
+			errors.New("line 2: could not parse: AAB"),
+		},
+		{
+			"0 INDI\n\nAAA",
+			nil,
+			errors.New("line 3: could not parse: AAA"),
+		},
+	} {
+		t.Run(test.ged, func(t *testing.T) {
+			result, err := gedcom.NewDocumentFromString(test.ged)
+			assert.Equal(t, err, test.err)
+			assert.Equal(t, test.expected, result)
 		})
 	}
 }

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -1,0 +1,25 @@
+package gedcom_test
+
+import (
+	"github.com/elliotchance/gedcom"
+	"github.com/elliotchance/tf"
+	"testing"
+)
+
+func TestGedcomLine(t *testing.T) {
+	GedcomLine := tf.Function(t, gedcom.GedcomLine)
+
+	GedcomLine(0, (*gedcom.SimpleNode)(nil)).Returns("")
+
+	GedcomLine(0, gedcom.NewSimpleNode(nil, gedcom.TagBirth, "foo", "72", nil)).
+		Returns("0 @72@ BIRT foo")
+
+	GedcomLine(3, gedcom.NewSimpleNode(nil, gedcom.TagDeath, "bar", "baz", nil)).
+		Returns("3 @baz@ DEAT bar")
+
+	GedcomLine(2, gedcom.NewDateNode(nil, "3 SEP 1945", "", nil)).
+		Returns("2 DATE 3 SEP 1945")
+
+	GedcomLine(-1, gedcom.NewSimpleNode(nil, gedcom.TagBirth, "foo", "72", nil)).
+		Returns("@72@ BIRT foo")
+}

--- a/node.go
+++ b/node.go
@@ -1,6 +1,9 @@
 package gedcom
 
-import "fmt"
+import (
+	"fmt"
+	"reflect"
+)
 
 type Node interface {
 	fmt.Stringer
@@ -16,6 +19,17 @@ type Node interface {
 	Nodes() []Node
 	AddNode(node Node)
 
-	// gedcomLine is for rendering the GEDCOM lines.
-	gedcomLine() string
+	// Comparison.
+	Equals(node2 Node) bool
+}
+
+// IsNil is the safe and reliable way to check if a node is nil. You should not
+// compare Node values with an untyped nil as it will lead to unexpected
+// results.
+//
+// As a side node IsNil cannot be part of the Node interface because more
+// specific node types (such as DateNode) use SimpleNode as an instance variable
+// and that would cause a nil pointer panic.
+func IsNil(node Node) bool {
+	return node == nil || reflect.ValueOf(node).IsNil()
 }

--- a/node_diff.go
+++ b/node_diff.go
@@ -1,0 +1,311 @@
+package gedcom
+
+import (
+	"fmt"
+	"strings"
+)
+
+// NodeDiff is used to describe the difference when two nodes are compared.
+//
+// It is important to understand the semantics of what a "difference" (and
+// therefore "equality") means for GEDCOM data as this heavily factors into
+// influencing the way the algorithms and returned values represent.
+//
+// GEDCOM files are quite unbounded when it comes to events and facts. For
+// example, it's common to have multiple birth events (BIRT tag) for the same
+// individual. This is not necessarily a bug in the data but rather a way to
+// describe two possible known birth dates or locations.
+//
+// The order of nodes in the GEDCOM file is also insignificant. That is to say
+// that a birth event that appears before another birth event is no more
+// important than any other tag, including other birth events.
+//
+// Child nodes belonging to two parent nodes that are considered equal can be
+// merged. For example, all of the following examples are considered to be equal
+// because they share the same parent value:
+//
+//   BIRT               |  BIRT               |  BIRT
+//     DATE 3 SEP 1943  |    DATE 3 SEP 1943  |    PLAC England
+//   BIRT               |    PLAC England     |    DATE 3 SEP 1943
+//     PLAC England     |                     |  BIRT
+//
+// Finally, and perhaps the most important take away is that nodes are absolute
+// in value. They can only be absolutely equal or they must be considered
+// independent. No matter how similar the events or values they are never placed
+// against each other to describe a "difference".
+//
+// For example, two individuals that have a different birth dates would not
+// return a single DiffNode with the left and right side different values,
+// instead two NodeDiffs would be returned that describe each side having an
+// event that is not present in the other. Only when the nodes are absolutely
+// equal are they said to be the same.
+type NodeDiff struct {
+	// Left or Right may be nil, but never both. Only in the case of the root
+	// node may the Left and Right represent nodes of different values.
+	// Otherwise nodes with different values will be added as separate children.
+	//
+	// Since nodes may be compared from different documents it's important to
+	// retain the left and right nodes when they are both equal so they stay
+	// connected to their original document.
+	Left, Right Node
+
+	// Children represents each of the compared child nodes from both sides. See
+	// CompareNodes for a full explanation.
+	Children []*NodeDiff
+}
+
+// CompareNodes returns the recursive comparison of two root nodes. To properly
+// understand the motivations and expected result you should first understand
+// NodeDiff before you continue reading.
+//
+// The returned NodeDiff will have root node assigned to the Left and Right,
+// even if they different values. This is the only case where this is possible.
+// It was decided to do it this way to allow comparing of nodes that often have
+// a different root node value (like individuals with different pointers).
+//
+// If you need to be sure the root node are the same or different you can check
+// before-hand, or afterwards with (this is also nil safe):
+//
+//   GedcomLine(-1, d.Left) == GedcomLine(-1, d.Right)
+//
+// The process of comparison is easiest to explain by following an example. Keep
+// in mind that if any of the rules seem confusing you should refer to the
+// documentation of NodeDiff.
+//
+// Here are two individuals that have slightly different data:
+//
+//   0 INDI @P3@           |  0 INDI @P4@
+//   1 NAME John /Smith/   |  1 NAME J. /Smith/
+//   1 BIRT                |  1 BIRT
+//   2 DATE 3 SEP 1943     |  2 DATE Abt. Sep 1943
+//   1 DEAT                |  1 BIRT
+//   2 PLAC England        |  2 DATE 3 SEP 1943
+//   1 BIRT                |  1 DEAT
+//   2 DATE Abt. Oct 1943  |  2 DATE Aft. 2001
+//                         |  2 PLAC Surry, England
+//
+// In this case both of the root nodes are different (because of the different
+// pointer values). The returned left and right will have the respective root
+// nodes.
+//
+// The first step is to flatten the nodes. Each node is represented as an slice
+// containing all of its parent elements:
+//
+//   -- Left
+//   ["INDI @P3@"]
+//   ["INDI @P3@", "NAME John /Smith/"]
+//   ["INDI @P3@", "BIRT"]
+//   ["INDI @P3@", "BIRT", "DATE 3 SEP 1943"]
+//   ["INDI @P3@", "DEAT"]
+//   ["INDI @P3@", "DEAT", "PLAC England"]
+//   ["INDI @P3@", "BIRT"]
+//   ["INDI @P3@", "BIRT", "DATE Abt. Oct 1943"]
+//
+//   -- Right
+//   ["INDI @P4@"]
+//   ["INDI @P4@", "NAME J. /Smith/"]
+//   ["INDI @P4@", "BIRT"]
+//   ["INDI @P4@", "BIRT", "DATE Abt. Sep 1943"]
+//   ["INDI @P4@", "BIRT"]
+//   ["INDI @P4@", "BIRT", "DATE 3 SEP 1943"]
+//   ["INDI @P4@", "DEAT"]
+//   ["INDI @P4@", "DEAT", "DATE Aft. 2001"]
+//   ["INDI @P4@", "DEAT", "PLAC Surry, England"]
+//
+// Now we begin unflattening the data back into the nested structure. The "L"
+// and "R" represent which side is not nil in the DiffNode.
+//
+// Beginning with the Left items:
+//
+//   L  0 INDI @P3@
+//   L  1 NAME John /Smith/
+//   L  1 BIRT
+//   L  2 DATE Abt. Oct 1943
+//   L  2 DATE 3 SEP 1943
+//   L  1 DEAT
+//   L  2 PLAC England
+//
+// Then the Right items and applied on top. Equal nodes will be converted from
+// "L" -> "LR" (assign right):
+//
+//   LR 0 INDI @P3@            | = Assign right (notice the @P4@ is not shown)
+//   L  1 NAME John /Smith/    |
+//   LR 1 BIRT                 | = Assign right
+//   L  2 DATE Abt. Oct 1943   |
+//   LR 2 DATE 3 SEP 1943      | = Assign right
+//    R 2 DATE Abt. Sep 1943   | + Added
+//   LR 1 DEAT                 | = Assign right
+//   L  2 PLAC England         |
+//    R 2 DATE Aft. 2001       | + Added
+//    R 2 PLAC Surry, England  | + Added
+//    R 1 NAME J. /Smith/      | + Added
+//
+// The output format is the same as NodeDiff.String().
+func CompareNodes(left, right Node) *NodeDiff {
+	// Flatten the nodes. We use the left prefix when flattening the right nodes
+	// as to not interfere with the a root node on the right that may be
+	// different. At the end we will assign the right root node.
+	//
+	// The extra conditional check is to make sure that a nil left does not
+	// break the right only traversing.
+	prefix := []string{GedcomLine(-1, nodeCondition(IsNil(left), right, left))}
+	flatLeft := flattenNode(left, prefix)
+	flatRight := flattenNode(right, prefix)
+
+	// Unflatten the nodes back to the diff.
+	result := &NodeDiff{}
+	result.unflatten(flatLeft, false)
+	result.unflatten(flatRight, true)
+
+	// Fix up the right root node.
+	result.Right = right
+
+	return result
+}
+
+// nodeCondition is a convenience method for inline conditionals.
+func nodeCondition(condition bool, node1, node2 Node) Node {
+	if condition {
+		return node1
+	}
+
+	return node2
+}
+
+func (nd *NodeDiff) unflatten(flatNodes [][]string, assignRight bool) {
+	for _, item := range flatNodes {
+		nd.unflattenSingle(item, assignRight)
+	}
+}
+
+func (nd *NodeDiff) unflattenSingle(flatNode []string, assignRight bool) {
+	i := nd
+	for _, line := range flatNode {
+		// We can ignore the error here because we encoded the lines.
+		parsedLine, _, _ := parseLine(nil, "0 "+line)
+
+		switch {
+		case nd.Left == nil && nd.Right == nil:
+			// This is the first (root) node.
+
+			nd.Left = nodeCondition(!assignRight, parsedLine, nd.Left)
+			nd.Right = nodeCondition(assignRight, parsedLine, nd.Right)
+			i = nd
+
+		case GedcomLine(-1, i.Left) == line || GedcomLine(-1, i.Right) == line:
+			// We have found a match with an existing line, traverse down. This
+			// is not the same situation below were each of the children are
+			// checked.
+
+			if assignRight {
+				i.Right = parsedLine
+			}
+
+		default:
+			// We will be adding a new node. Search the children to see if there
+			// is a match, otherwise add it to the end.
+
+			child := &NodeDiff{
+				Left:  nodeCondition(!assignRight, parsedLine, nil),
+				Right: nodeCondition(assignRight, parsedLine, nil),
+			}
+
+			found := false
+			for _, n := range i.Children {
+				if GedcomLine(-1, n.Left) == line || GedcomLine(-1, n.Right) == line {
+					if assignRight {
+						n.Right = parsedLine
+					}
+					i = n
+					found = true
+					break
+				}
+			}
+
+			if !found {
+				i.Children = append(i.Children, child)
+				i = child
+			}
+		}
+	}
+}
+
+func flattenNode(node Node, prefix []string) [][]string {
+	if IsNil(node) {
+		return [][]string{}
+	}
+
+	children := node.Nodes()
+	if len(children) == 0 {
+		return [][]string{prefix}
+	}
+
+	r := [][]string{prefix}
+	for _, child := range children {
+		line := GedcomLine(-1, child)
+		r = append(r, flattenNode(child, append(prefix, line))...)
+	}
+
+	return r
+}
+
+func (nd *NodeDiff) lrLine(indent int) string {
+	left := GedcomLine(indent, nd.Left)
+	right := GedcomLine(indent, nd.Right)
+
+	if IsNil(nd.Left) {
+		return fmt.Sprintf(" R %s", right)
+	}
+
+	if IsNil(nd.Right) {
+		return fmt.Sprintf("L  %s", left)
+	}
+
+	// Only the root can have different values for the left and right node.
+	// We want to display this so we show it as two different LR root nodes.
+	if left != right {
+		return fmt.Sprintf("LR %s\nLR %s", left, right)
+	}
+
+	return fmt.Sprintf("LR %s", GedcomLine(indent, nd.Left))
+}
+
+func (nd *NodeDiff) string(indent int) string {
+	s := nd.lrLine(indent)
+
+	for _, child := range nd.Children {
+		s += "\n" + child.string(indent+1)
+	}
+
+	return s
+}
+
+// String returns a readable comparison of nodes, like:
+//
+//   LR 0 INDI @P3@
+//   L  1 NAME John /Smith/
+//   LR 1 BIRT
+//   L  2 DATE Abt. Oct 1943
+//   LR 2 DATE 3 SEP 1943
+//    R 2 DATE Abt. Sep 1943
+//   LR 1 DEAT
+//   L  2 PLAC England
+//    R 2 DATE Aft. 2001
+//    R 2 PLAC Surry, England
+//    R 1 NAME J. /Smith/
+//
+// The L/R/LR represent which side has the node, followed by the GEDCOM indent
+// and node line.
+//
+// There is a special case if both root nodes are different. They will be
+// displayed as two separate lines even though they both belong to the same
+// NodeDiff:
+//
+//   LR 0 INDI @P3@
+//   LR 0 INDI @P4@
+//
+// You should not rely on this format to be machine readable as it may change in
+// the future.
+func (nd *NodeDiff) String() string {
+	return strings.TrimSpace(nd.string(0))
+}

--- a/node_diff_test.go
+++ b/node_diff_test.go
@@ -1,0 +1,208 @@
+package gedcom_test
+
+import (
+	"github.com/elliotchance/gedcom"
+	"github.com/stretchr/testify/assert"
+	"strings"
+	"testing"
+)
+
+func parse(s ...string) []gedcom.Node {
+	doc, err := gedcom.NewDocumentFromString(strings.Join(s, "\n"))
+	if err != nil {
+		panic(err)
+	}
+
+	return doc.Nodes
+}
+
+func TestCompareNodes(t *testing.T) {
+	tests := []struct {
+		left, right gedcom.Node
+		expected    *gedcom.NodeDiff
+	}{
+		// Nils
+		//{
+		//	left:     nil,
+		//	right:    nil,
+		//	expected: &gedcom.NodeDiff{},
+		//},
+		//{
+		//	left:  parse("0 @P1@ BIRT foo")[0],
+		//	right: nil,
+		//	expected: &gedcom.NodeDiff{
+		//		Left: parse("0 @P1@ BIRT foo")[0],
+		//	},
+		//},
+		//{
+		//	left:  nil,
+		//	right: parse("0 @P1@ BIRT foo")[0],
+		//	expected: &gedcom.NodeDiff{
+		//		Right: parse("0 @P1@ BIRT foo")[0],
+		//	},
+		//},
+		//{
+		//	left:  parse("0 INDI @P1@", "1 BIRT")[0],
+		//	right: nil,
+		//	expected: &gedcom.NodeDiff{
+		//		Left:  parse("0 INDI @P1@")[0],
+		//		Right: nil,
+		//		Children: []*gedcom.NodeDiff{
+		//			{
+		//				Left: parse("0 BIRT")[0],
+		//			},
+		//		},
+		//	},
+		//},
+		{
+			left:  nil,
+			right: parse("0 INDI @P1@", "1 DEAT")[0],
+			expected: &gedcom.NodeDiff{
+				Left:  nil,
+				Right: parse("0 INDI @P1@")[0],
+				Children: []*gedcom.NodeDiff{
+					{
+						Right: parse("0 DEAT")[0],
+					},
+				},
+			},
+		},
+
+		// Different root nodes.
+		{
+			left:  parse("0 INDI @P1@")[0],
+			right: parse("0 INDI @P2@")[0],
+			expected: &gedcom.NodeDiff{
+				Left:  parse("0 INDI @P1@")[0],
+				Right: parse("0 INDI @P2@")[0],
+			},
+		},
+		{
+			left:  parse("0 INDI @P1@")[0],
+			right: parse("0 INDI @P2@", "1 DEAT")[0],
+			expected: &gedcom.NodeDiff{
+				Left:  parse("0 INDI @P1@")[0],
+				Right: parse("0 INDI @P2@")[0],
+				Children: []*gedcom.NodeDiff{
+					{
+						Right: parse("0 DEAT")[0],
+					},
+				},
+			},
+		},
+		{
+			left:  parse("0 INDI @P1@", "1 BIRT")[0],
+			right: parse("0 INDI @P2@", "1 DEAT")[0],
+			expected: &gedcom.NodeDiff{
+				Left:  parse("0 INDI @P1@")[0],
+				Right: parse("0 INDI @P2@")[0],
+				Children: []*gedcom.NodeDiff{
+					{
+						Left: parse("0 BIRT")[0],
+					},
+					{
+						Right: parse("0 DEAT")[0],
+					},
+				},
+			},
+		},
+		{
+			left:  parse("0 INDI @P1@", "1 BIRT")[0],
+			right: parse("0 INDI @P2@", "1 BIRT")[0],
+			expected: &gedcom.NodeDiff{
+				Left:  parse("0 INDI @P1@")[0],
+				Right: parse("0 INDI @P2@")[0],
+				Children: []*gedcom.NodeDiff{
+					{
+						Left:  parse("0 BIRT")[0],
+						Right: parse("0 BIRT")[0],
+					},
+				},
+			},
+		},
+
+		// Example from the docs.
+		{
+			left: parse(
+				"0 INDI @P3@",
+				"1 NAME John /Smith/",
+				"1 BIRT",
+				"2 DATE 3 SEP 1943",
+				"1 DEAT",
+				"2 PLAC England",
+				"1 BIRT",
+				"2 DATE Abt. Oct 1943",
+			)[0],
+			right: parse(
+				"0 INDI @P4@",
+				"1 NAME J. /Smith/",
+				"1 BIRT",
+				"2 DATE Abt. Sep 1943",
+				"1 DEAT",
+				"2 DATE Aft. 2001",
+				"1 BIRT",
+				"2 DATE 3 SEP 1943",
+				"2 PLAC Surry, England",
+			)[0],
+			expected: &gedcom.NodeDiff{
+				Left:  parse("0 INDI @P3@")[0],
+				Right: parse("0 INDI @P4@")[0],
+				Children: []*gedcom.NodeDiff{
+					{
+						Left:     parse("0 NAME John /Smith/")[0],
+						Right:    nil,
+						Children: nil,
+					},
+					{
+						Left:  parse("0 BIRT")[0],
+						Right: parse("0 BIRT")[0],
+						Children: []*gedcom.NodeDiff{
+							{
+								Left:  parse("0 DATE 3 SEP 1943")[0],
+								Right: parse("0 DATE 3 SEP 1943")[0],
+							},
+							{
+								Left:  parse("0 DATE Abt. Oct 1943")[0],
+								Right: nil,
+							},
+							{
+								Left:  nil,
+								Right: parse("0 DATE Abt. Sep 1943")[0],
+							},
+							{
+								Left:  nil,
+								Right: parse("0 PLAC Surry, England")[0],
+							},
+						},
+					},
+					{
+						Left:  parse("0 DEAT")[0],
+						Right: parse("0 DEAT")[0],
+						Children: []*gedcom.NodeDiff{
+							{
+								Left:  parse("0 PLAC England")[0],
+								Right: nil,
+							},
+							{
+								Left:  nil,
+								Right: parse("0 DATE Aft. 2001")[0],
+							},
+						},
+					},
+					{
+						Left:     nil,
+						Right:    parse("0 NAME J. /Smith/")[0],
+						Children: nil,
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run("", func(t *testing.T) {
+			actual := gedcom.CompareNodes(test.left, test.right)
+			assert.Equal(t, test.expected.String(), actual.String())
+		})
+	}
+}

--- a/simple_node.go
+++ b/simple_node.go
@@ -1,10 +1,5 @@
 package gedcom
 
-import (
-	"bytes"
-	"fmt"
-)
-
 // SimpleNode is used as the default node type when there is no more appropriate
 // or specific type to use.
 type SimpleNode struct {
@@ -41,6 +36,25 @@ func (node *SimpleNode) Document() *Document {
 	return node.document
 }
 
+// Equals compares two nodes for value equality.
+//
+// 1. If either or both nodes are nil then false is always returned.
+// 2. Nodes are compared only by their root value (shallow) meaning any value
+// for the child nodes is ignored.
+// 3. The document the node belongs to is not taken into consideration to be
+// able to compare nodes by value across different documents.
+// 4. A node is considered to have the same value (and therefore be equal) is
+// both nodes share the all of the same tag, value and pointer.
+func (node *SimpleNode) Equals(node2 Node) bool {
+	if node == nil || IsNil(node2) {
+		return false
+	}
+
+	return node.tag == node2.Tag() &&
+		node.value == node2.Value() &&
+		node.pointer == node2.Pointer()
+}
+
 func (node *SimpleNode) SetDocument(document *Document) {
 	node.document = document
 
@@ -62,22 +76,5 @@ func (node *SimpleNode) AddNode(n Node) {
 }
 
 func (node *SimpleNode) String() string {
-	return node.gedcomLine()
-}
-
-func (node *SimpleNode) gedcomLine() string {
-	buf := bytes.NewBufferString("")
-
-	if node.pointer != "" {
-		buf.WriteString(fmt.Sprintf("@%s@ ", node.pointer))
-	}
-
-	buf.WriteString(node.tag.Tag())
-
-	if node.value != "" {
-		buf.WriteByte(' ')
-		buf.WriteString(node.value)
-	}
-
-	return buf.String()
+	return GedcomLine(0, node)
 }

--- a/simple_node_test.go
+++ b/simple_node_test.go
@@ -2,6 +2,7 @@ package gedcom_test
 
 import (
 	"github.com/elliotchance/gedcom"
+	"github.com/elliotchance/tf"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -13,4 +14,53 @@ func TestSimpleNode_ChildNodes(t *testing.T) {
 		assert.NotNil(t, node.Nodes())
 		assert.Len(t, node.Nodes(), 0)
 	})
+}
+
+func TestIsNil(t *testing.T) {
+	IsNil := tf.Function(t, gedcom.IsNil)
+
+	IsNil((*gedcom.SimpleNode)(nil)).Returns(true)
+	IsNil(gedcom.NewSimpleNode(nil, gedcom.TagBirth, "", "", nil)).Returns(false)
+	IsNil((*gedcom.NameNode)(nil)).Returns(true)
+	IsNil(gedcom.NewNameNode(nil, "", "", nil)).Returns(false)
+
+	// Untyped nil is a special case that cannot be tested above.
+	assert.True(t, gedcom.IsNil(nil))
+}
+
+func TestSimpleNode_Equals(t *testing.T) {
+	Equals := tf.Function(t, (*gedcom.SimpleNode).Equals)
+
+	s0 := (*gedcom.SimpleNode)(nil)
+
+	// These are the same.
+	s1 := gedcom.NewSimpleNode(nil, gedcom.TagName, "", "", nil)
+	s2 := gedcom.NewNameNode(nil, "", "", nil)
+
+	// These are different in some way from each other.
+	s3 := gedcom.NewSimpleNode(nil, gedcom.TagName, "", "a", nil)
+	s4 := gedcom.NewNameNode(nil, "a", "", nil)
+	s5 := gedcom.NewNameNode(nil, "", "b", nil)
+	s6 := gedcom.NewSimpleNode(nil, gedcom.TagVersion, "", "a", nil)
+
+	// Nils
+	Equals(s0, s0).Returns(false)
+	Equals(s0, s1).Returns(false)
+	Equals(s1, s0).Returns(false)
+
+	Equals(s1, s1).Returns(true)
+	Equals(s1, s2).Returns(true)
+
+	Equals(s1, s3).Returns(false)
+	Equals(s1, s4).Returns(false)
+	Equals(s1, s5).Returns(false)
+
+	Equals(s3, s3).Returns(true)
+	Equals(s3, s4).Returns(false)
+	Equals(s3, s5).Returns(false)
+	Equals(s3, s6).Returns(false)
+	Equals(s6, s3).Returns(false)
+	Equals(s6, s4).Returns(false)
+	Equals(s6, s5).Returns(false)
+	Equals(s6, s6).Returns(true)
 }


### PR DESCRIPTION
- Added CompareNodes() to recrsively compare nodes and return a nested NodeDiff. The NodeDiff comes with a string renderer.
- Improved the decoder to return an error and line number if a line cannot be parsed.
- Added NewDocumentFromString() to make it easier to handle strings containing GEDCOM data.
- Added GedcomLine() as the canonical way to render and compare node values. The encoder has been changed to use this as well.
- Added Node.Equals() to compare nodes by value.
- Added IsNil() as a safer alternative for testing if a Node interface is nil.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/gedcom/69)
<!-- Reviewable:end -->
