### PR TITLE
Added Filter(). Fixes #73

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ exporting and diffing GEDCOM files.
       * [Nodes](#nodes)
    * [Nodes](#nodes-1)
       * [Dates](#dates)
+      * [Filtering](#filtering)
    * [Rendering as HTML](#rendering-as-html)
    * [Converting to JSON](#converting-to-json)
    * [Converting to Text](#converting-to-text)
@@ -165,6 +166,33 @@ date range into a number for easier distance and comparison measurements.
 4. Algorithms for calculating the similarity of dates on a configurable
 parabola.
 
+Filtering
+---------
+
+The [`Filter`][4] function recursively removes or manipulates nodes with a
+[`FilterFunction`][5]:
+
+```go
+newNodes := gedcom.Filter(node, func (node gedcom.Node) (gedcom.Node, bool) {
+    if node.Tag().Is(gedcom.TagIndividual) {
+        // false means it will not traverse children, since an
+        // individual can never be inside of another individual.
+        return node, false
+    }
+
+    return nil, false
+})
+
+// Remove all tags that are not official.
+newNodes := gedcom.Filter(node, gedcom.OfficialTagFilter())
+```
+
+Filter functions:
+
+1. [`WhitelistTagFilter`][6]
+2. [`BlacklistTagFilter`][7]
+3. [`OfficialTagFilter`][8]
+
 Rendering as HTML
 =================
 
@@ -254,3 +282,8 @@ You can (and probably should) also use
 [1]: https://godoc.org/github.com/elliotchance/gedcom#CompareNodes
 [2]: https://godoc.org/github.com/elliotchance/gedcom#NodeDiff
 [3]: https://godoc.org/github.com/elliotchance/gedcom#NodeDiff.String
+[4]: https://godoc.org/github.com/elliotchance/gedcom#Filter
+[5]: https://godoc.org/github.com/elliotchance/gedcom#FilterFunction
+[6]: https://godoc.org/github.com/elliotchance/gedcom#WhitelistTagFilter
+[7]: https://godoc.org/github.com/elliotchance/gedcom#BlacklistTagFilter
+[8]: https://godoc.org/github.com/elliotchance/gedcom#OfficialTagFilter

--- a/decoder.go
+++ b/decoder.go
@@ -149,26 +149,34 @@ func parseLine(document *Document, line string) (Node, int, error) {
 	// Value (optional).
 	value := parts[4]
 
-	// Check for more specific type.
+	return NewNode(document, tag, value, pointer), indent, nil
+}
+
+// NewNode creates a node with no children. It is also the correct way to
+// create a shallow copy of a node.
+//
+// If the node tag is recognised as a more specific type, such as *DateNode then
+// that will be returned. Otherwise a *SimpleNode will be used.
+func NewNode(document *Document, tag Tag, value, pointer string) Node {
 	switch tag {
 	case TagDate:
-		return NewDateNode(document, value, pointer, []Node{}), indent, nil
+		return NewDateNode(document, value, pointer, nil)
 
 	case TagFamily:
-		return NewFamilyNode(document, pointer, []Node{}), indent, nil
+		return NewFamilyNode(document, pointer, nil)
 
 	case TagIndividual:
-		return NewIndividualNode(document, value, pointer, []Node{}), indent, nil
+		return NewIndividualNode(document, value, pointer, nil)
 
 	case TagName:
-		return NewNameNode(document, value, pointer, []Node{}), indent, nil
+		return NewNameNode(document, value, pointer, nil)
 
 	case TagPlace:
-		return NewPlaceNode(document, value, pointer, []Node{}), indent, nil
+		return NewPlaceNode(document, value, pointer, nil)
 
 	case TagSource:
-		return NewSourceNode(document, value, pointer, []Node{}), indent, nil
+		return NewSourceNode(document, value, pointer, nil)
 	}
 
-	return NewSimpleNode(document, tag, value, pointer, []Node{}), indent, nil
+	return NewSimpleNode(document, tag, value, pointer, nil)
 }

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -1,10 +1,11 @@
 package gedcom_test
 
 import (
-	"github.com/elliotchance/gedcom"
-	"github.com/stretchr/testify/assert"
 	"strings"
 	"testing"
+
+	"github.com/elliotchance/gedcom"
+	"github.com/stretchr/testify/assert"
 )
 
 var tests = map[string]*gedcom.Document{
@@ -16,50 +17,50 @@ var tests = map[string]*gedcom.Document{
 	},
 	"0 HEAD": {
 		Nodes: []gedcom.Node{
-			gedcom.NewSimpleNode(nil, gedcom.TagHeader, "", "", []gedcom.Node{}),
+			gedcom.NewSimpleNode(nil, gedcom.TagHeader, "", "", nil),
 		},
 	},
 	"0 HEAD\n1 CHAR UTF-8": {
 		Nodes: []gedcom.Node{
 			gedcom.NewSimpleNode(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagCharacterSet, "UTF-8", "", []gedcom.Node{}),
+				gedcom.NewSimpleNode(nil, gedcom.TagCharacterSet, "UTF-8", "", nil),
 			}),
 		},
 	},
 	"0 HEAD\n\n1 CHAR UTF-8\n": {
 		Nodes: []gedcom.Node{
 			gedcom.NewSimpleNode(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagCharacterSet, "UTF-8", "", []gedcom.Node{}),
+				gedcom.NewSimpleNode(nil, gedcom.TagCharacterSet, "UTF-8", "", nil),
 			}),
 		},
 	},
 	"0 HEAD\n1 CHAR UTF-8\n1 SOUR Ancestry.com Family Trees": {
 		Nodes: []gedcom.Node{
 			gedcom.NewSimpleNode(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagCharacterSet, "UTF-8", "", []gedcom.Node{}),
-				gedcom.NewSourceNode(nil, "Ancestry.com Family Trees", "", []gedcom.Node{}),
+				gedcom.NewSimpleNode(nil, gedcom.TagCharacterSet, "UTF-8", "", nil),
+				gedcom.NewSourceNode(nil, "Ancestry.com Family Trees", "", nil),
 			}),
 		},
 	},
 	"0 HEAD\n1 CHAR UTF-8\n1 CHAR UTF-8": {
 		Nodes: []gedcom.Node{
 			gedcom.NewSimpleNode(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagCharacterSet, "UTF-8", "", []gedcom.Node{}),
-				gedcom.NewSimpleNode(nil, gedcom.TagCharacterSet, "UTF-8", "", []gedcom.Node{}),
+				gedcom.NewSimpleNode(nil, gedcom.TagCharacterSet, "UTF-8", "", nil),
+				gedcom.NewSimpleNode(nil, gedcom.TagCharacterSet, "UTF-8", "", nil),
 			}),
 		},
 	},
 	"0 HEAD\n1 SOUR Ancestry.com Family Trees": {
 		Nodes: []gedcom.Node{
 			gedcom.NewSimpleNode(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-				gedcom.NewSourceNode(nil, "Ancestry.com Family Trees", "", []gedcom.Node{}),
+				gedcom.NewSourceNode(nil, "Ancestry.com Family Trees", "", nil),
 			}),
 		},
 	},
 	"0 HEAD\n1 BIRT": {
 		Nodes: []gedcom.Node{
 			gedcom.NewSimpleNode(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagBirth, "", "", []gedcom.Node{}),
+				gedcom.NewSimpleNode(nil, gedcom.TagBirth, "", "", nil),
 			}),
 		},
 	},
@@ -67,7 +68,7 @@ var tests = map[string]*gedcom.Document{
 		Nodes: []gedcom.Node{
 			gedcom.NewSimpleNode(nil, gedcom.TagHeader, "", "", []gedcom.Node{
 				gedcom.NewSimpleNode(nil, gedcom.TagGedcomInformation, "", "", []gedcom.Node{
-					gedcom.NewSimpleNode(nil, gedcom.TagVersion, "(2010.3)", "", []gedcom.Node{}),
+					gedcom.NewSimpleNode(nil, gedcom.TagVersion, "(2010.3)", "", nil),
 				}),
 			}),
 		},
@@ -76,7 +77,7 @@ var tests = map[string]*gedcom.Document{
 		Nodes: []gedcom.Node{
 			gedcom.NewSimpleNode(nil, gedcom.TagHeader, "", "", []gedcom.Node{
 				gedcom.NewSimpleNode(nil, gedcom.TagGedcomInformation, "", "", []gedcom.Node{
-					gedcom.NewSimpleNode(nil, gedcom.TagVersion, "5.5", "", []gedcom.Node{}),
+					gedcom.NewSimpleNode(nil, gedcom.TagVersion, "5.5", "", nil),
 				}),
 			}),
 		},
@@ -85,7 +86,7 @@ var tests = map[string]*gedcom.Document{
 		Nodes: []gedcom.Node{
 			gedcom.NewSimpleNode(nil, gedcom.TagHeader, "", "", []gedcom.Node{
 				gedcom.NewSimpleNode(nil, gedcom.TagGedcomInformation, "", "", []gedcom.Node{
-					gedcom.NewSimpleNode(nil, gedcom.TagFormat, "LINEAGE-LINKED", "", []gedcom.Node{}),
+					gedcom.NewSimpleNode(nil, gedcom.TagFormat, "LINEAGE-LINKED", "", nil),
 				}),
 			}),
 		},
@@ -94,7 +95,7 @@ var tests = map[string]*gedcom.Document{
 		Nodes: []gedcom.Node{
 			gedcom.NewSimpleNode(nil, gedcom.TagHeader, "", "", []gedcom.Node{
 				gedcom.NewSimpleNode(nil, gedcom.TagBirth, "", "", []gedcom.Node{
-					gedcom.NewPlaceNode(nil, "Camperdown, Nsw, Australia", "", []gedcom.Node{}),
+					gedcom.NewPlaceNode(nil, "Camperdown, Nsw, Australia", "", nil),
 				}),
 			}),
 		},
@@ -102,28 +103,28 @@ var tests = map[string]*gedcom.Document{
 	"0 HEAD\n1 NAME Elliot Rupert de Peyster /Chance/": {
 		Nodes: []gedcom.Node{
 			gedcom.NewSimpleNode(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-				gedcom.NewNameNode(nil, "Elliot Rupert de Peyster /Chance/", "", []gedcom.Node{}),
+				gedcom.NewNameNode(nil, "Elliot Rupert de Peyster /Chance/", "", nil),
 			}),
 		},
 	},
 	"0 HEAD\n0 @P1@ INDI": {
 		Nodes: []gedcom.Node{
-			gedcom.NewSimpleNode(nil, gedcom.TagHeader, "", "", []gedcom.Node{}),
-			gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{}),
+			gedcom.NewSimpleNode(nil, gedcom.TagHeader, "", "", nil),
+			gedcom.NewIndividualNode(nil, "", "P1", nil),
 		},
 	},
 	"0 HEAD\n1 SEX M\n0 @P1@ INDI": {
 		Nodes: []gedcom.Node{
 			gedcom.NewSimpleNode(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagSex, "M", "", []gedcom.Node{}),
+				gedcom.NewSimpleNode(nil, gedcom.TagSex, "M", "", nil),
 			}),
-			gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{}),
+			gedcom.NewIndividualNode(nil, "", "P1", nil),
 		},
 	},
 	"0 HEAD\n1 SEX M": {
 		Nodes: []gedcom.Node{
 			gedcom.NewSimpleNode(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagSex, "M", "", []gedcom.Node{}),
+				gedcom.NewSimpleNode(nil, gedcom.TagSex, "M", "", nil),
 			}),
 		},
 	},
@@ -131,17 +132,17 @@ var tests = map[string]*gedcom.Document{
 		Nodes: []gedcom.Node{
 			gedcom.NewSimpleNode(nil, gedcom.TagHeader, "", "", []gedcom.Node{
 				gedcom.NewSimpleNode(nil, gedcom.TagBirth, "", "", []gedcom.Node{
-					gedcom.NewPlaceNode(nil, "Camperdown, Nsw, Australia", "", []gedcom.Node{}),
+					gedcom.NewPlaceNode(nil, "Camperdown, Nsw, Australia", "", nil),
 				}),
-				gedcom.NewSimpleNode(nil, gedcom.TagSex, "M", "", []gedcom.Node{}),
+				gedcom.NewSimpleNode(nil, gedcom.TagSex, "M", "", nil),
 			}),
 		},
 	},
 	"0 HEAD\n0 @P1@ INDI\n1 BIRT": {
 		Nodes: []gedcom.Node{
-			gedcom.NewSimpleNode(nil, gedcom.TagHeader, "", "", []gedcom.Node{}),
+			gedcom.NewSimpleNode(nil, gedcom.TagHeader, "", "", nil),
 			gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagBirth, "", "", []gedcom.Node{}),
+				gedcom.NewSimpleNode(nil, gedcom.TagBirth, "", "", nil),
 			}),
 		},
 	},
@@ -149,10 +150,10 @@ var tests = map[string]*gedcom.Document{
 		Nodes: []gedcom.Node{
 			gedcom.NewSimpleNode(nil, gedcom.TagHeader, "", "", []gedcom.Node{
 				gedcom.NewSimpleNode(nil, gedcom.TagGedcomInformation, "", "", []gedcom.Node{
-					gedcom.NewSimpleNode(nil, gedcom.TagFormat, "LINEAGE-LINKED", "", []gedcom.Node{}),
+					gedcom.NewSimpleNode(nil, gedcom.TagFormat, "LINEAGE-LINKED", "", nil),
 				}),
 			}),
-			gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{}),
+			gedcom.NewIndividualNode(nil, "", "P1", nil),
 		},
 	},
 	"0 HEAD0\n1 HEAD1\n2 HEAD2\n3 HEAD3\n0 HEAD00": {
@@ -160,11 +161,11 @@ var tests = map[string]*gedcom.Document{
 			gedcom.NewSimpleNode(nil, gedcom.TagFromString("HEAD0"), "", "", []gedcom.Node{
 				gedcom.NewSimpleNode(nil, gedcom.TagFromString("HEAD1"), "", "", []gedcom.Node{
 					gedcom.NewSimpleNode(nil, gedcom.TagFromString("HEAD2"), "", "", []gedcom.Node{
-						gedcom.NewSimpleNode(nil, gedcom.TagFromString("HEAD3"), "", "", []gedcom.Node{}),
+						gedcom.NewSimpleNode(nil, gedcom.TagFromString("HEAD3"), "", "", nil),
 					}),
 				}),
 			}),
-			gedcom.NewSimpleNode(nil, gedcom.TagFromString("HEAD00"), "", "", []gedcom.Node{}),
+			gedcom.NewSimpleNode(nil, gedcom.TagFromString("HEAD00"), "", "", nil),
 		},
 	},
 	"0 HEAD0\n1 HEAD1\n2 HEAD2\n3 HEAD3\n1 HEAD10": {
@@ -172,33 +173,33 @@ var tests = map[string]*gedcom.Document{
 			gedcom.NewSimpleNode(nil, gedcom.TagFromString("HEAD0"), "", "", []gedcom.Node{
 				gedcom.NewSimpleNode(nil, gedcom.TagFromString("HEAD1"), "", "", []gedcom.Node{
 					gedcom.NewSimpleNode(nil, gedcom.TagFromString("HEAD2"), "", "", []gedcom.Node{
-						gedcom.NewSimpleNode(nil, gedcom.TagFromString("HEAD3"), "", "", []gedcom.Node{}),
+						gedcom.NewSimpleNode(nil, gedcom.TagFromString("HEAD3"), "", "", nil),
 					}),
 				}),
-				gedcom.NewSimpleNode(nil, gedcom.TagFromString("HEAD10"), "", "", []gedcom.Node{}),
+				gedcom.NewSimpleNode(nil, gedcom.TagFromString("HEAD10"), "", "", nil),
 			}),
 		},
 	},
 	"0 HEAD0\r1 HEAD1": {
 		Nodes: []gedcom.Node{
 			gedcom.NewSimpleNode(nil, gedcom.TagFromString("HEAD0"), "", "", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagFromString("HEAD1"), "", "", []gedcom.Node{}),
+				gedcom.NewSimpleNode(nil, gedcom.TagFromString("HEAD1"), "", "", nil),
 			}),
 		},
 	},
 	"0 HEAD0\r\n1 HEAD1": {
 		Nodes: []gedcom.Node{
 			gedcom.NewSimpleNode(nil, gedcom.TagFromString("HEAD0"), "", "", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagFromString("HEAD1"), "", "", []gedcom.Node{}),
+				gedcom.NewSimpleNode(nil, gedcom.TagFromString("HEAD1"), "", "", nil),
 			}),
 		},
 	},
 	"0 HEAD0\n1 HEAD1\n1 HEAD10\n2 HEAD2": {
 		Nodes: []gedcom.Node{
 			gedcom.NewSimpleNode(nil, gedcom.TagFromString("HEAD0"), "", "", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagFromString("HEAD1"), "", "", []gedcom.Node{}),
+				gedcom.NewSimpleNode(nil, gedcom.TagFromString("HEAD1"), "", "", nil),
 				gedcom.NewSimpleNode(nil, gedcom.TagFromString("HEAD10"), "", "", []gedcom.Node{
-					gedcom.NewSimpleNode(nil, gedcom.TagFromString("HEAD2"), "", "", []gedcom.Node{}),
+					gedcom.NewSimpleNode(nil, gedcom.TagFromString("HEAD2"), "", "", nil),
 				}),
 			}),
 		},
@@ -206,7 +207,7 @@ var tests = map[string]*gedcom.Document{
 	"0 HEAD\n1 BIRT ": {
 		Nodes: []gedcom.Node{
 			gedcom.NewSimpleNode(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagBirth, "", "", []gedcom.Node{}),
+				gedcom.NewSimpleNode(nil, gedcom.TagBirth, "", "", nil),
 			}),
 		},
 	},
@@ -214,10 +215,10 @@ var tests = map[string]*gedcom.Document{
 		Nodes: []gedcom.Node{
 			gedcom.NewIndividualNode(nil, "", "P221", []gedcom.Node{
 				gedcom.NewSimpleNode(nil, gedcom.TagBirth, "", "", []gedcom.Node{
-					gedcom.NewDateNode(nil, "1851", "", []gedcom.Node{}),
+					gedcom.NewDateNode(nil, "1851", "", nil),
 				}),
 				gedcom.NewSimpleNode(nil, gedcom.TagDeath, "", "", []gedcom.Node{
-					gedcom.NewDateNode(nil, "1856", "", []gedcom.Node{}),
+					gedcom.NewDateNode(nil, "1856", "", nil),
 				}),
 			}),
 		},
@@ -225,14 +226,14 @@ var tests = map[string]*gedcom.Document{
 	"0 @F1@ FAM\n1 HUSB @P2@\n1 WIFE @P3@": {
 		Nodes: []gedcom.Node{
 			gedcom.NewFamilyNode(nil, "F1", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagHusband, "@P2@", "", []gedcom.Node{}),
-				gedcom.NewSimpleNode(nil, gedcom.TagWife, "@P3@", "", []gedcom.Node{}),
+				gedcom.NewSimpleNode(nil, gedcom.TagHusband, "@P2@", "", nil),
+				gedcom.NewSimpleNode(nil, gedcom.TagWife, "@P3@", "", nil),
 			}),
 		},
 	},
 	"0 DATE 1856": {
 		Nodes: []gedcom.Node{
-			gedcom.NewDateNode(nil, "1856", "", []gedcom.Node{}),
+			gedcom.NewDateNode(nil, "1856", "", nil),
 		},
 	},
 }
@@ -266,6 +267,28 @@ func TestDocument_String(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			newGed := actual.String()
 			assert.Equal(t, trimSpaces(expected), trimSpaces(newGed), expected)
+		})
+	}
+}
+
+func TestNewNode(t *testing.T) {
+	const p = "pointer"
+	const v = "value"
+
+	for _, test := range []struct {
+		tag      gedcom.Tag
+		expected gedcom.Node
+	}{
+		{gedcom.TagDate, gedcom.NewDateNode(nil, v, p, nil)},
+		{gedcom.TagFamily, gedcom.NewFamilyNode(nil, p, nil)},
+		{gedcom.TagIndividual, gedcom.NewIndividualNode(nil, v, p, nil)},
+		{gedcom.TagName, gedcom.NewNameNode(nil, v, p, nil)},
+		{gedcom.TagPlace, gedcom.NewPlaceNode(nil, v, p, nil)},
+		{gedcom.TagSource, gedcom.NewSourceNode(nil, v, p, nil)},
+		{gedcom.TagVersion, gedcom.NewSimpleNode(nil, gedcom.TagVersion, v, p, nil)},
+	} {
+		t.Run(test.tag.String(), func(t *testing.T) {
+			assert.Equal(t, test.expected, gedcom.NewNode(nil, test.tag, v, p))
 		})
 	}
 }

--- a/filter.go
+++ b/filter.go
@@ -1,0 +1,92 @@
+package gedcom
+
+// FilterFunction is used with the Filter function.
+//
+// The node (as passed in through the parameter) will be replaced with newNode.
+// You should return the same node argument if you do not want the node to be
+// changed.
+//
+// The traverseChildren argument decides if the traversal should continue
+// through the children of node. If the traversal continues (traverseChildren is
+// true) the FilterFunction will always receive the children of the node, and
+// not the children (if any) of newNode.
+//
+// If the newNode is nil then it will be removed and the children will not be
+// traversed, regardless of the traverseChildren value.
+type FilterFunction func(node Node) (newNode Node, traverseChildren bool)
+
+// Filter returns a new nest node structure by recursively filtering all
+// children based on a callback FilterFunction.
+//
+// See FilterFunction for the implementation details of fn.
+//
+// There are several other functions that can be used as filters including;
+// WhitelistTagFilter, BlacklistTagFilter and OfficialTagFilter.
+func Filter(root Node, fn FilterFunction) Node {
+	newRoot, keepTraversing := fn(root)
+	if newRoot == nil {
+		return nil
+	}
+
+	// Shallow copy the node.
+	// https://github.com/elliotchance/gedcom/issues/74
+	result := NewNode(newRoot.Document(), newRoot.Tag(), newRoot.Value(),
+		newRoot.Pointer())
+
+	if keepTraversing {
+		for _, child := range root.Nodes() {
+			newNode := Filter(child, fn)
+			if newNode != nil {
+				result.AddNode(newNode)
+			}
+		}
+	}
+
+	return result
+}
+
+// WhitelistTagFilter returns any node that is one of the provided tags.
+//
+// This is the opposite of BlacklistTagFilter.
+//
+// See the Filter() function.
+func WhitelistTagFilter(tags ...Tag) FilterFunction {
+	return func(node Node) (Node, bool) {
+		for _, tag := range tags {
+			if tag.Is(node.Tag()) {
+				return node, true
+			}
+		}
+
+		return nil, false
+	}
+}
+
+// BlacklistTagFilter returns any node that is not one of the provided tags.
+//
+// This is the opposite of WhitelistTagFilter.
+//
+// See the Filter function.
+func BlacklistTagFilter(tags ...Tag) FilterFunction {
+	return func(node Node) (Node, bool) {
+		for _, tag := range tags {
+			if tag.Is(node.Tag()) {
+				return nil, false
+			}
+		}
+
+		return node, true
+	}
+}
+
+// OfficialTagFilter returns any node that is official tag. See Tag.IsOfficial
+// for more information.
+//
+// See the Filter function.
+func OfficialTagFilter() FilterFunction {
+	return func(node Node) (Node, bool) {
+		isOfficial := node.Tag().IsOfficial()
+
+		return NodeCondition(isOfficial, node, nil), isOfficial
+	}
+}

--- a/filter_test.go
+++ b/filter_test.go
@@ -1,0 +1,241 @@
+package gedcom_test
+
+import (
+	"testing"
+
+	"github.com/elliotchance/gedcom"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFilter(t *testing.T) {
+	root := gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
+		gedcom.NewNameNode(nil, "Elliot /Chance/", "", nil),
+		gedcom.NewSimpleNode(nil, gedcom.TagBirth, "", "", []gedcom.Node{
+			gedcom.NewDateNode(nil, "6 MAY 1989", "", nil),
+		}),
+	})
+
+	for _, test := range []struct {
+		filter   gedcom.FilterFunction
+		expected string
+	}{
+		{
+			filter: func(node gedcom.Node) (gedcom.Node, bool) {
+				return nil, false
+			},
+			expected: "",
+		},
+		{
+			filter: func(node gedcom.Node) (gedcom.Node, bool) {
+				return node, true
+			},
+			expected: `0 @P1@ INDI
+1 NAME Elliot /Chance/
+1 BIRT
+2 DATE 6 MAY 1989
+`,
+		},
+		{
+			filter: func(node gedcom.Node) (gedcom.Node, bool) {
+				return node, false
+			},
+			expected: `0 @P1@ INDI
+`,
+		},
+		{
+			filter: func(node gedcom.Node) (gedcom.Node, bool) {
+				if node.Tag().Is(gedcom.TagIndividual) {
+					// false means it will not traverse children, since an
+					// individual can never be inside of another individual.
+					return node, false
+				}
+
+				return nil, false
+			},
+			expected: `0 @P1@ INDI
+`,
+		},
+		{
+			filter: func(node gedcom.Node) (gedcom.Node, bool) {
+				t := node.Tag()
+				return gedcom.NodeCondition(
+					t.Is(gedcom.TagIndividual) || t.Is(gedcom.TagName),
+					node,
+					nil,
+				), true
+			},
+			expected: `0 @P1@ INDI
+1 NAME Elliot /Chance/
+`,
+		},
+		{
+			filter: func(node gedcom.Node) (gedcom.Node, bool) {
+				t := node.Tag()
+				return gedcom.NodeCondition(
+					t.Is(gedcom.TagIndividual) || t.Is(gedcom.TagDate),
+					node,
+					nil,
+				), true
+			},
+			expected: `0 @P1@ INDI
+`,
+		},
+		{
+			filter: func(node gedcom.Node) (gedcom.Node, bool) {
+				t := node.Tag()
+				return gedcom.NodeCondition(
+					t.Is(gedcom.TagIndividual) || t.Is(gedcom.TagBirth),
+					node,
+					nil,
+				), true
+			},
+			expected: `0 @P1@ INDI
+1 BIRT
+`,
+		},
+		{
+			filter: func(node gedcom.Node) (gedcom.Node, bool) {
+				t := node.Tag()
+				return gedcom.NodeCondition(
+					t.Is(gedcom.TagIndividual) || t.Is(gedcom.TagBirth) || t.Is(gedcom.TagDate),
+					node,
+					nil,
+				), true
+			},
+			expected: `0 @P1@ INDI
+1 BIRT
+2 DATE 6 MAY 1989
+`,
+		},
+		{
+			filter: func(node gedcom.Node) (gedcom.Node, bool) {
+				if node.Tag().Is(gedcom.TagName) {
+					return gedcom.NewDateNode(nil, "1 APR 1943", "", nil), true
+				}
+
+				return node, true
+			},
+			expected: `0 @P1@ INDI
+1 DATE 1 APR 1943
+1 BIRT
+2 DATE 6 MAY 1989
+`,
+		},
+	} {
+		t.Run("", func(t *testing.T) {
+			result := gedcom.NodeGedcom(gedcom.Filter(root, test.filter))
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}
+
+func TestWhitelistTagFilter(t *testing.T) {
+	root := gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
+		gedcom.NewNameNode(nil, "Elliot /Chance/", "", nil),
+		gedcom.NewSimpleNode(nil, gedcom.TagBirth, "", "", []gedcom.Node{
+			gedcom.NewDateNode(nil, "6 MAY 1989", "", nil),
+		}),
+	})
+
+	for _, test := range []struct {
+		tags     []gedcom.Tag
+		expected string
+	}{
+		{
+			tags:     []gedcom.Tag{},
+			expected: ``,
+		},
+		{
+			tags: []gedcom.Tag{gedcom.TagIndividual},
+			expected: `0 @P1@ INDI
+`,
+		},
+		{
+			tags:     []gedcom.Tag{gedcom.TagBirth},
+			expected: ``,
+		},
+		{
+			tags: []gedcom.Tag{gedcom.TagBirth, gedcom.TagIndividual},
+			expected: `0 @P1@ INDI
+1 BIRT
+`,
+		},
+	} {
+		t.Run("", func(t *testing.T) {
+			filter := gedcom.WhitelistTagFilter(test.tags...)
+			result := gedcom.NodeGedcom(gedcom.Filter(root, filter))
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}
+
+func TestBlacklistTagFilter(t *testing.T) {
+	root := gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
+		gedcom.NewNameNode(nil, "Elliot /Chance/", "", nil),
+		gedcom.NewSimpleNode(nil, gedcom.TagBirth, "", "", []gedcom.Node{
+			gedcom.NewDateNode(nil, "6 MAY 1989", "", nil),
+		}),
+	})
+
+	for _, test := range []struct {
+		tags     []gedcom.Tag
+		expected string
+	}{
+		{
+			tags: []gedcom.Tag{},
+			expected: `0 @P1@ INDI
+1 NAME Elliot /Chance/
+1 BIRT
+2 DATE 6 MAY 1989
+`,
+		},
+		{
+			tags:     []gedcom.Tag{gedcom.TagIndividual},
+			expected: ``,
+		},
+		{
+			tags: []gedcom.Tag{gedcom.TagBirth},
+			expected: `0 @P1@ INDI
+1 NAME Elliot /Chance/
+`,
+		},
+		{
+			tags:     []gedcom.Tag{gedcom.TagBirth, gedcom.TagIndividual},
+			expected: ``,
+		},
+	} {
+		t.Run("", func(t *testing.T) {
+			filter := gedcom.BlacklistTagFilter(test.tags...)
+			result := gedcom.NodeGedcom(gedcom.Filter(root, filter))
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}
+
+func TestOfficialTagFilter(t *testing.T) {
+	root := gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
+		gedcom.NewSimpleNode(nil, gedcom.UnofficialTagCreated, "Elliot /Chance/", "", []gedcom.Node{
+			gedcom.NewDateNode(nil, "3 Mar 2007", "", nil),
+		}),
+		gedcom.NewSimpleNode(nil, gedcom.TagBirth, "", "", []gedcom.Node{
+			gedcom.NewDateNode(nil, "6 MAY 1989", "", nil),
+		}),
+	})
+
+	for _, test := range []struct {
+		expected string
+	}{
+		{
+			expected: `0 @P1@ INDI
+1 BIRT
+2 DATE 6 MAY 1989
+`,
+		},
+	} {
+		t.Run("", func(t *testing.T) {
+			filter := gedcom.OfficialTagFilter()
+			result := gedcom.NodeGedcom(gedcom.Filter(root, filter))
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}

--- a/node.go
+++ b/node.go
@@ -33,3 +33,27 @@ type Node interface {
 func IsNil(node Node) bool {
 	return node == nil || reflect.ValueOf(node).IsNil()
 }
+
+// NodeGedcom is the recursive version of GedcomLine. It will render a node and
+// all of its children (if any) as a multi-line GEDCOM data.
+//
+// Unlike rendering a Document, the root node will have a depth of 0 (like the
+// root nodes of a Document) which means that you will almost certainly not be
+// able to use the returned GEDCOM data as a whole of part of GEDCOM file.
+//
+// That being said, you should be able to parse this data as a Document and
+// retain the same nested node structure originally encoded.
+//
+// This function is mostly useful for debugging and displaying complex nodes in
+// the understandable and consistent form of GEDCOM data.
+func NodeGedcom(node Node) string {
+	if IsNil(node) {
+		return ""
+	}
+
+	document := &Document{
+		Nodes: []Node{node},
+	}
+
+	return document.String()
+}

--- a/node_diff.go
+++ b/node_diff.go
@@ -148,7 +148,7 @@ func CompareNodes(left, right Node) *NodeDiff {
 	//
 	// The extra conditional check is to make sure that a nil left does not
 	// break the right only traversing.
-	prefix := []string{GedcomLine(-1, nodeCondition(IsNil(left), right, left))}
+	prefix := []string{GedcomLine(-1, NodeCondition(IsNil(left), right, left))}
 	flatLeft := flattenNode(left, prefix)
 	flatRight := flattenNode(right, prefix)
 
@@ -161,15 +161,6 @@ func CompareNodes(left, right Node) *NodeDiff {
 	result.Right = right
 
 	return result
-}
-
-// nodeCondition is a convenience method for inline conditionals.
-func nodeCondition(condition bool, node1, node2 Node) Node {
-	if condition {
-		return node1
-	}
-
-	return node2
 }
 
 func (nd *NodeDiff) unflatten(flatNodes [][]string, assignRight bool) {
@@ -188,8 +179,8 @@ func (nd *NodeDiff) unflattenSingle(flatNode []string, assignRight bool) {
 		case nd.Left == nil && nd.Right == nil:
 			// This is the first (root) node.
 
-			nd.Left = nodeCondition(!assignRight, parsedLine, nd.Left)
-			nd.Right = nodeCondition(assignRight, parsedLine, nd.Right)
+			nd.Left = NodeCondition(!assignRight, parsedLine, nd.Left)
+			nd.Right = NodeCondition(assignRight, parsedLine, nd.Right)
 			i = nd
 
 		case GedcomLine(-1, i.Left) == line || GedcomLine(-1, i.Right) == line:
@@ -206,8 +197,8 @@ func (nd *NodeDiff) unflattenSingle(flatNode []string, assignRight bool) {
 			// is a match, otherwise add it to the end.
 
 			child := &NodeDiff{
-				Left:  nodeCondition(!assignRight, parsedLine, nil),
-				Right: nodeCondition(assignRight, parsedLine, nil),
+				Left:  NodeCondition(!assignRight, parsedLine, nil),
+				Right: NodeCondition(assignRight, parsedLine, nil),
 			}
 
 			found := false

--- a/node_test.go
+++ b/node_test.go
@@ -1,0 +1,25 @@
+package gedcom_test
+
+import (
+	"github.com/elliotchance/gedcom"
+	"github.com/elliotchance/tf"
+	"testing"
+)
+
+func TestNodeGedcom(t *testing.T) {
+	NodeGedcom := tf.Function(t, gedcom.NodeGedcom)
+
+	root := gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
+		gedcom.NewNameNode(nil, "Elliot /Chance/", "", nil),
+		gedcom.NewSimpleNode(nil, gedcom.TagBirth, "", "", []gedcom.Node{
+			gedcom.NewDateNode(nil, "6 MAY 1989", "", nil),
+		}),
+	})
+
+	NodeGedcom((*gedcom.SimpleNode)(nil)).Returns("")
+	NodeGedcom(root).Returns(`0 @P1@ INDI
+1 NAME Elliot /Chance/
+1 BIRT
+2 DATE 6 MAY 1989
+`)
+}

--- a/simple_node.go
+++ b/simple_node.go
@@ -10,6 +10,11 @@ type SimpleNode struct {
 	children []Node
 }
 
+// NewSimpleNode creates a non-specific node.
+//
+// Note: You should not use this constructor for general use. Instead use
+// NewNode which will return a *SimpleNode if a more appropriate node type
+// exists for the tag.
 func NewSimpleNode(document *Document, tag Tag, value, pointer string, children []Node) *SimpleNode {
 	return &SimpleNode{
 		document: document,
@@ -64,10 +69,6 @@ func (node *SimpleNode) SetDocument(document *Document) {
 }
 
 func (node *SimpleNode) Nodes() []Node {
-	if node.children == nil {
-		return []Node{}
-	}
-
 	return node.children
 }
 

--- a/simple_node_test.go
+++ b/simple_node_test.go
@@ -8,12 +8,9 @@ import (
 )
 
 func TestSimpleNode_ChildNodes(t *testing.T) {
-	t.Run("NilReturnsArray", func(t *testing.T) {
-		node := gedcom.NewSimpleNode(nil, gedcom.TagText, "", "", nil)
+	node := gedcom.NewSimpleNode(nil, gedcom.TagText, "", "", nil)
 
-		assert.NotNil(t, node.Nodes())
-		assert.Len(t, node.Nodes(), 0)
-	})
+	assert.Len(t, node.Nodes(), 0)
 }
 
 func TestIsNil(t *testing.T) {

--- a/util.go
+++ b/util.go
@@ -130,3 +130,12 @@ func Compound(nodes ...interface{}) []Node {
 
 	return result
 }
+
+// NodeCondition is a convenience method for inline conditionals.
+func NodeCondition(condition bool, node1, node2 Node) Node {
+	if condition {
+		return node1
+	}
+
+	return node2
+}

--- a/util_test.go
+++ b/util_test.go
@@ -1,9 +1,11 @@
 package gedcom_test
 
 import (
-	"github.com/elliotchance/gedcom"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/elliotchance/gedcom"
+	"github.com/elliotchance/tf"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAtoi(t *testing.T) {
@@ -126,4 +128,14 @@ func TestCompound(t *testing.T) {
 			assert.Equal(t, test.want, gedcom.Compound(test.inputs...))
 		})
 	}
+}
+
+func TestNodeCondition(t *testing.T) {
+	NodeCondition := tf.Function(t, gedcom.NodeCondition)
+
+	bob := gedcom.NewNameNode(nil, "Bob", "", nil)
+	sally := gedcom.NewNameNode(nil, "Sally", "", nil)
+
+	NodeCondition(true, bob, sally).Returns(bob)
+	NodeCondition(false, bob, sally).Returns(sally)
 }


### PR DESCRIPTION
- Filter() returns a new nest node structure by recursively filtering all children based on a callback FilterFunction.
- Added three built in filters; WhitelistTagFilter, BlacklistTagFilter and OfficialTagFilter.
- Added NewNode() to create a node of a specific type. It is better to use this than NewSimpleNode().
- Added NodeCondition() to make inline if statements with nodes easier. This was previously part of the private API.
- Added NodeGedcom() to make it easier to render complex nodes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/gedcom/75)
<!-- Reviewable:end -->
