### PR TITLE
Greatly improved CompareNodes. Fixes #76

### DIFF
--- a/birth_node.go
+++ b/birth_node.go
@@ -1,0 +1,49 @@
+package gedcom
+
+// BirthNode is the event of entering into life.
+type BirthNode struct {
+	*SimpleNode
+}
+
+// NewBirthNode creates a new BIRT node.
+func NewBirthNode(document *Document, value, pointer string, children []Node) *BirthNode {
+	return &BirthNode{
+		NewSimpleNode(document, TagBirth, value, pointer, children),
+	}
+}
+
+// Dates returns zero or more dates associated with the Birth.
+//
+// When more than one date is returned you should not assume that the order has
+// any significance for the importance of the dates.
+func (node *BirthNode) Dates() (result []*DateNode) {
+	for _, n := range NodesWithTag(node, TagDate) {
+		result = append(result, n.(*DateNode))
+	}
+
+	return
+}
+
+// Equal will always return true if both nodes are not nil.
+//
+// If either node is nil (including both) or if the right side is not a
+// BirthNode then false is always returned. Otherwise Equals will always return
+// true.
+//
+// The reason Equals always returns true is because Equals is a shallow test and
+// an individual can only ever have one birth event. Therefore it is safe to
+// assume that birth events themselves are equal, even if the children they
+// contain are not.
+//
+// This logic is especially important for CompareNodes.
+func (node *BirthNode) Equals(node2 Node) bool {
+	if IsNil(node) || IsNil(node2) {
+		return false
+	}
+
+	if _, ok := node2.(*BirthNode); !ok {
+		return false
+	}
+
+	return true
+}

--- a/birth_node_test.go
+++ b/birth_node_test.go
@@ -1,0 +1,63 @@
+package gedcom_test
+
+import (
+	"testing"
+
+	"github.com/elliotchance/gedcom"
+	"github.com/elliotchance/tf"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewBirthNode(t *testing.T) {
+	doc := gedcom.NewDocument()
+	child := gedcom.NewNameNode(doc, "", "", nil)
+	node := gedcom.NewBirthNode(doc, "foo", "bar", []gedcom.Node{child})
+
+	assert.Equal(t, gedcom.TagBirth, node.Tag())
+	assert.Equal(t, []gedcom.Node{child}, node.Nodes())
+	assert.Equal(t, doc, node.Document())
+	assert.Equal(t, "foo", node.Value())
+	assert.Equal(t, "bar", node.Pointer())
+}
+
+func TestBirthNode_Dates(t *testing.T) {
+	Dates := tf.Function(t, (*gedcom.BirthNode).Dates)
+
+	Dates(gedcom.NewBirthNode(nil, "", "", nil)).Returns([]*gedcom.DateNode(nil))
+
+	Dates(gedcom.NewBirthNode(nil, "", "", []gedcom.Node{})).
+		Returns([]*gedcom.DateNode(nil))
+
+	Dates(gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
+		gedcom.NewDateNode(nil, "3 Sep 2001", "", nil),
+	})).Returns([]*gedcom.DateNode{
+		gedcom.NewDateNode(nil, "3 Sep 2001", "", nil),
+	})
+
+	Dates(gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
+		gedcom.NewDateNode(nil, "7 Jan 2001", "", nil),
+		gedcom.NewDateNode(nil, "3 Sep 2001", "", nil),
+	})).Returns([]*gedcom.DateNode{
+		gedcom.NewDateNode(nil, "7 Jan 2001", "", nil),
+		gedcom.NewDateNode(nil, "3 Sep 2001", "", nil),
+	})
+}
+
+func TestBirthNode_Equals(t *testing.T) {
+	Equals := tf.Function(t, (*gedcom.BirthNode).Equals)
+
+	n1 := gedcom.NewBirthNode(nil, "foo", "", nil)
+	n2 := gedcom.NewBirthNode(nil, "bar", "", nil)
+
+	// nils
+	Equals((*gedcom.BirthNode)(nil), (*gedcom.BirthNode)(nil)).Returns(false)
+	Equals(n1, (*gedcom.BirthNode)(nil)).Returns(false)
+	Equals((*gedcom.BirthNode)(nil), n1).Returns(false)
+
+	// Wrong node type.
+	Equals(n1, gedcom.NewNameNode(nil, "foo", "", nil)).Returns(false)
+
+	// All other cases are success.
+	Equals(n1, n1).Returns(true)
+	Equals(n1, n2).Returns(true)
+}

--- a/decoder.go
+++ b/decoder.go
@@ -159,6 +159,9 @@ func parseLine(document *Document, line string) (Node, int, error) {
 // that will be returned. Otherwise a *SimpleNode will be used.
 func NewNode(document *Document, tag Tag, value, pointer string) Node {
 	switch tag {
+	case TagBirth:
+		return NewBirthNode(document, value, pointer, nil)
+
 	case TagDate:
 		return NewDateNode(document, value, pointer, nil)
 
@@ -173,6 +176,9 @@ func NewNode(document *Document, tag Tag, value, pointer string) Node {
 
 	case TagPlace:
 		return NewPlaceNode(document, value, pointer, nil)
+
+	case TagResidence:
+		return NewResidenceNode(document, value, pointer, nil)
 
 	case TagSource:
 		return NewSourceNode(document, value, pointer, nil)

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -60,7 +60,7 @@ var tests = map[string]*gedcom.Document{
 	"0 HEAD\n1 BIRT": {
 		Nodes: []gedcom.Node{
 			gedcom.NewSimpleNode(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagBirth, "", "", nil),
+				gedcom.NewBirthNode(nil, "", "", nil),
 			}),
 		},
 	},
@@ -94,7 +94,7 @@ var tests = map[string]*gedcom.Document{
 	"0 HEAD\n1 BIRT\n2 PLAC Camperdown, Nsw, Australia": {
 		Nodes: []gedcom.Node{
 			gedcom.NewSimpleNode(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagBirth, "", "", []gedcom.Node{
+				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
 					gedcom.NewPlaceNode(nil, "Camperdown, Nsw, Australia", "", nil),
 				}),
 			}),
@@ -131,7 +131,7 @@ var tests = map[string]*gedcom.Document{
 	"0 HEAD\n1 BIRT\n2 PLAC Camperdown, Nsw, Australia\n1 SEX M": {
 		Nodes: []gedcom.Node{
 			gedcom.NewSimpleNode(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagBirth, "", "", []gedcom.Node{
+				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
 					gedcom.NewPlaceNode(nil, "Camperdown, Nsw, Australia", "", nil),
 				}),
 				gedcom.NewSimpleNode(nil, gedcom.TagSex, "M", "", nil),
@@ -142,7 +142,7 @@ var tests = map[string]*gedcom.Document{
 		Nodes: []gedcom.Node{
 			gedcom.NewSimpleNode(nil, gedcom.TagHeader, "", "", nil),
 			gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagBirth, "", "", nil),
+				gedcom.NewBirthNode(nil, "", "", nil),
 			}),
 		},
 	},
@@ -207,14 +207,14 @@ var tests = map[string]*gedcom.Document{
 	"0 HEAD\n1 BIRT ": {
 		Nodes: []gedcom.Node{
 			gedcom.NewSimpleNode(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagBirth, "", "", nil),
+				gedcom.NewBirthNode(nil, "", "", nil),
 			}),
 		},
 	},
 	"0 @P221@ INDI\n1 BIRT\n2 DATE 1851\n1 DEAT\n2 DATE 1856": {
 		Nodes: []gedcom.Node{
 			gedcom.NewIndividualNode(nil, "", "P221", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagBirth, "", "", []gedcom.Node{
+				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
 					gedcom.NewDateNode(nil, "1851", "", nil),
 				}),
 				gedcom.NewSimpleNode(nil, gedcom.TagDeath, "", "", []gedcom.Node{
@@ -279,11 +279,13 @@ func TestNewNode(t *testing.T) {
 		tag      gedcom.Tag
 		expected gedcom.Node
 	}{
+		{gedcom.TagBirth, gedcom.NewBirthNode(nil, v, p, nil)},
 		{gedcom.TagDate, gedcom.NewDateNode(nil, v, p, nil)},
 		{gedcom.TagFamily, gedcom.NewFamilyNode(nil, p, nil)},
 		{gedcom.TagIndividual, gedcom.NewIndividualNode(nil, v, p, nil)},
 		{gedcom.TagName, gedcom.NewNameNode(nil, v, p, nil)},
 		{gedcom.TagPlace, gedcom.NewPlaceNode(nil, v, p, nil)},
+		{gedcom.TagResidence, gedcom.NewResidenceNode(nil, v, p, nil)},
 		{gedcom.TagSource, gedcom.NewSourceNode(nil, v, p, nil)},
 		{gedcom.TagVersion, gedcom.NewSimpleNode(nil, gedcom.TagVersion, v, p, nil)},
 	} {

--- a/document.go
+++ b/document.go
@@ -134,3 +134,8 @@ func NewDocumentFromString(gedcom string) (*Document, error) {
 
 	return decoder.Decode()
 }
+
+// NewDocument returns an empty document.
+func NewDocument() *Document {
+	return &Document{}
+}

--- a/document_test.go
+++ b/document_test.go
@@ -1,10 +1,10 @@
 package gedcom_test
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
-	"errors"
 	"github.com/elliotchance/gedcom"
 	"github.com/stretchr/testify/assert"
 )
@@ -160,4 +160,10 @@ func TestNewDocumentFromString(t *testing.T) {
 			assert.Equal(t, test.expected, result)
 		})
 	}
+}
+
+func TestNewDocument(t *testing.T) {
+	doc := gedcom.NewDocument()
+
+	assert.Len(t, doc.Nodes, 0)
 }

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -11,7 +11,7 @@ func TestGedcomLine(t *testing.T) {
 
 	GedcomLine(0, (*gedcom.SimpleNode)(nil)).Returns("")
 
-	GedcomLine(0, gedcom.NewSimpleNode(nil, gedcom.TagBirth, "foo", "72", nil)).
+	GedcomLine(0, gedcom.NewBirthNode(nil, "foo", "72", nil)).
 		Returns("0 @72@ BIRT foo")
 
 	GedcomLine(3, gedcom.NewSimpleNode(nil, gedcom.TagDeath, "bar", "baz", nil)).
@@ -20,6 +20,6 @@ func TestGedcomLine(t *testing.T) {
 	GedcomLine(2, gedcom.NewDateNode(nil, "3 SEP 1945", "", nil)).
 		Returns("2 DATE 3 SEP 1945")
 
-	GedcomLine(-1, gedcom.NewSimpleNode(nil, gedcom.TagBirth, "foo", "72", nil)).
+	GedcomLine(-1, gedcom.NewBirthNode(nil, "foo", "72", nil)).
 		Returns("@72@ BIRT foo")
 }

--- a/filter_test.go
+++ b/filter_test.go
@@ -10,7 +10,7 @@ import (
 func TestFilter(t *testing.T) {
 	root := gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
 		gedcom.NewNameNode(nil, "Elliot /Chance/", "", nil),
-		gedcom.NewSimpleNode(nil, gedcom.TagBirth, "", "", []gedcom.Node{
+		gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
 			gedcom.NewDateNode(nil, "6 MAY 1989", "", nil),
 		}),
 	})
@@ -132,7 +132,7 @@ func TestFilter(t *testing.T) {
 func TestWhitelistTagFilter(t *testing.T) {
 	root := gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
 		gedcom.NewNameNode(nil, "Elliot /Chance/", "", nil),
-		gedcom.NewSimpleNode(nil, gedcom.TagBirth, "", "", []gedcom.Node{
+		gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
 			gedcom.NewDateNode(nil, "6 MAY 1989", "", nil),
 		}),
 	})
@@ -172,7 +172,7 @@ func TestWhitelistTagFilter(t *testing.T) {
 func TestBlacklistTagFilter(t *testing.T) {
 	root := gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
 		gedcom.NewNameNode(nil, "Elliot /Chance/", "", nil),
-		gedcom.NewSimpleNode(nil, gedcom.TagBirth, "", "", []gedcom.Node{
+		gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
 			gedcom.NewDateNode(nil, "6 MAY 1989", "", nil),
 		}),
 	})
@@ -217,7 +217,7 @@ func TestOfficialTagFilter(t *testing.T) {
 		gedcom.NewSimpleNode(nil, gedcom.UnofficialTagCreated, "Elliot /Chance/", "", []gedcom.Node{
 			gedcom.NewDateNode(nil, "3 Mar 2007", "", nil),
 		}),
-		gedcom.NewSimpleNode(nil, gedcom.TagBirth, "", "", []gedcom.Node{
+		gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
 			gedcom.NewDateNode(nil, "6 MAY 1989", "", nil),
 		}),
 	})

--- a/individual_node.go
+++ b/individual_node.go
@@ -151,8 +151,12 @@ func (node *IndividualNode) IsLiving() bool {
 }
 
 // Births returns zero or more birth events for the individual.
-func (node *IndividualNode) Births() []Node {
-	return NodesWithTag(node, TagBirth)
+func (node *IndividualNode) Births() (nodes []*BirthNode) {
+	for _, n := range NodesWithTag(node, TagBirth) {
+		nodes = append(nodes, n.(*BirthNode))
+	}
+
+	return
 }
 
 // Baptisms returns zero or more baptism events for the individual. The baptisms

--- a/individual_node_test.go
+++ b/individual_node_test.go
@@ -80,42 +80,42 @@ func TestIndividualNode_Sex(t *testing.T) {
 func TestIndividualNode_Births(t *testing.T) {
 	var tests = []struct {
 		node   *gedcom.IndividualNode
-		births []gedcom.Node
+		births []*gedcom.BirthNode
 	}{
 		{
 			node:   individual("P1", "", "", ""),
-			births: []gedcom.Node{},
+			births: nil,
 		},
 		{
 			node:   gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{}),
-			births: []gedcom.Node{},
+			births: nil,
 		},
 		{
 			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagBirth, "", "", []gedcom.Node{}),
+				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{}),
 			}),
-			births: []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagBirth, "", "", []gedcom.Node{}),
+			births: []*gedcom.BirthNode{
+				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{}),
 			},
 		},
 		{
 			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagBirth, "", "", []gedcom.Node{}),
+				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{}),
 				gedcom.NewSimpleNode(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
 			}),
-			births: []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagBirth, "", "", []gedcom.Node{}),
+			births: []*gedcom.BirthNode{
+				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{}),
 			},
 		},
 		{
 			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagBirth, "foo", "", []gedcom.Node{}),
+				gedcom.NewBirthNode(nil, "foo", "", []gedcom.Node{}),
 				gedcom.NewSimpleNode(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
-				gedcom.NewSimpleNode(nil, gedcom.TagBirth, "bar", "", []gedcom.Node{}),
+				gedcom.NewBirthNode(nil, "bar", "", []gedcom.Node{}),
 			}),
-			births: []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagBirth, "foo", "", []gedcom.Node{}),
-				gedcom.NewSimpleNode(nil, gedcom.TagBirth, "bar", "", []gedcom.Node{}),
+			births: []*gedcom.BirthNode{
+				gedcom.NewBirthNode(nil, "foo", "", []gedcom.Node{}),
+				gedcom.NewBirthNode(nil, "bar", "", []gedcom.Node{}),
 			},
 		},
 	}
@@ -207,7 +207,7 @@ func TestIndividualNode_Deaths(t *testing.T) {
 		{
 			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
 				gedcom.NewSimpleNode(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
-				gedcom.NewSimpleNode(nil, gedcom.TagBirth, "", "", []gedcom.Node{}),
+				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{}),
 			}),
 			deaths: []gedcom.Node{
 				gedcom.NewSimpleNode(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
@@ -257,7 +257,7 @@ func TestIndividualNode_Burials(t *testing.T) {
 		{
 			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
 				gedcom.NewSimpleNode(nil, gedcom.TagBurial, "", "", []gedcom.Node{}),
-				gedcom.NewSimpleNode(nil, gedcom.TagBirth, "", "", []gedcom.Node{}),
+				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{}),
 			}),
 			burials: []gedcom.Node{
 				gedcom.NewSimpleNode(nil, gedcom.TagBurial, "", "", []gedcom.Node{}),
@@ -551,7 +551,7 @@ func TestIndividualNode_EstimatedBirthDate(t *testing.T) {
 		// A single date.
 		{
 			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagBirth, "", "", []gedcom.Node{
+				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
 					gedcom.NewDateNode(nil, "1 Aug 1980", "", nil),
 				}),
 			}),
@@ -577,7 +577,7 @@ func TestIndividualNode_EstimatedBirthDate(t *testing.T) {
 		// Multiple dates and other cases.
 		{
 			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagBirth, "", "", []gedcom.Node{
+				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
 					gedcom.NewDateNode(nil, "1 Aug 1980", "", nil),
 				}),
 				gedcom.NewSimpleNode(nil, gedcom.TagBaptism, "", "", []gedcom.Node{
@@ -588,7 +588,7 @@ func TestIndividualNode_EstimatedBirthDate(t *testing.T) {
 		},
 		{
 			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagBirth, "", "", []gedcom.Node{
+				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
 					gedcom.NewDateNode(nil, "1 Aug 1980", "", nil),
 					gedcom.NewDateNode(nil, "23 Mar 1979", "", nil),
 				}),
@@ -597,7 +597,7 @@ func TestIndividualNode_EstimatedBirthDate(t *testing.T) {
 		},
 		{
 			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagBirth, "", "", []gedcom.Node{
+				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
 					gedcom.NewDateNode(nil, "1 Aug 1980", "", nil),
 				}),
 				gedcom.NewSimpleNode(nil, gedcom.TagLDSBaptism, "", "", []gedcom.Node{
@@ -608,14 +608,14 @@ func TestIndividualNode_EstimatedBirthDate(t *testing.T) {
 		},
 		{
 			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagBirth, "", "", []gedcom.Node{}),
+				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{}),
 				gedcom.NewSimpleNode(nil, gedcom.TagLDSBaptism, "", "", []gedcom.Node{}),
 			}),
 			expected: nil,
 		},
 		{
 			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagBirth, "", "", []gedcom.Node{}),
+				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{}),
 				gedcom.NewSimpleNode(nil, gedcom.TagLDSBaptism, "", "", []gedcom.Node{
 					gedcom.NewDateNode(nil, "1 Aug 1980", "", nil),
 				}),
@@ -731,8 +731,8 @@ func TestIndividualNode_EstimatedDeathDate(t *testing.T) {
 	}
 }
 
-func born(value string) gedcom.Node {
-	return gedcom.NewSimpleNode(nil, gedcom.TagBirth, "", "", []gedcom.Node{
+func born(value string) *gedcom.BirthNode {
+	return gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
 		gedcom.NewDateNode(nil, value, "", []gedcom.Node{}),
 	})
 }

--- a/node_diff.go
+++ b/node_diff.go
@@ -20,33 +20,29 @@ import (
 // that a birth event that appears before another birth event is no more
 // important than any other tag, including other birth events.
 //
-// Child nodes belonging to two parent nodes that are considered equal can be
-// merged. For example, all of the following examples are considered to be equal
-// because they share the same parent value:
+// Child nodes belonging to two parent nodes that are considered equal (by using
+// Equals) can be merged. For example, all of the following examples are
+// considered to be equal because the BirthNode.Equals regards all BirthNodes as
+// equal (see specific documentation for a complete explanation):
 //
 //   BIRT               |  BIRT               |  BIRT
 //     DATE 3 SEP 1943  |    DATE 3 SEP 1943  |    PLAC England
 //   BIRT               |    PLAC England     |    DATE 3 SEP 1943
 //     PLAC England     |                     |  BIRT
 //
-// Finally, and perhaps the most important take away is that nodes are absolute
-// in value. They can only be absolutely equal or they must be considered
-// independent. No matter how similar the events or values they are never placed
-// against each other to describe a "difference".
-//
-// For example, two individuals that have a different birth dates would not
-// return a single DiffNode with the left and right side different values,
-// instead two NodeDiffs would be returned that describe each side having an
-// event that is not present in the other. Only when the nodes are absolutely
-// equal are they said to be the same.
+// However, the semantics of Equals is quite different for other types of nodes.
+// For example ResidenceNodes are considered equal only if they have the same
+// date, as it wouldn't make sense (or just be plain wrong) to merge children
+// from separate Residence events.
 type NodeDiff struct {
-	// Left or Right may be nil, but never both. Only in the case of the root
-	// node may the Left and Right represent nodes of different values.
-	// Otherwise nodes with different values will be added as separate children.
+	// Left or Right may be nil, but never both.
 	//
-	// Since nodes may be compared from different documents it's important to
-	// retain the left and right nodes when they are both equal so they stay
-	// connected to their original document.
+	// Since nodes may be compared from different documents and have different
+	// raw values it's important to retain the left and right nodes. Make sure
+	// when displaying or traversing your data you are showing the correct side.
+	//
+	// The Left and Right retain their original children as well so you an still
+	// perform all the same operations on the nodes inside a NodeDiff.
 	Left, Right Node
 
 	// Children represents each of the compared child nodes from both sides. See
@@ -59,18 +55,29 @@ type NodeDiff struct {
 // NodeDiff before you continue reading.
 //
 // The returned NodeDiff will have root node assigned to the Left and Right,
-// even if they different values. This is the only case where this is possible.
-// It was decided to do it this way to allow comparing of nodes that often have
-// a different root node value (like individuals with different pointers).
+// even if they are non-equal values. This is the only case where this is
+// possible. It was decided to do it this way to allow comparing of nodes that
+// often have a different root node value (like individuals with different
+// pointers), and also keep the output from CompareNodes consistent.
 //
-// If you need to be sure the root node are the same or different you can check
-// before-hand, or afterwards with (this is also nil safe):
+// If you need to be sure the root node are the equal after the comparison, you
+// can use (this is also nil safe):
 //
-//   GedcomLine(-1, d.Left) == GedcomLine(-1, d.Right)
+//   d.Left.Equals(d.Right)
 //
-// The process of comparison is easiest to explain by following an example. Keep
-// in mind that if any of the rules seem confusing you should refer to the
-// documentation of NodeDiff.
+// The algorithm to perform the diff is actually very simple:
+//
+// 1. It creates an empty NodeDiff instance.
+//
+// 2. It traverses down the left creating all the respective child nodes as it
+// goes. Before it adds a child node at any level it will always check
+// previously created nodes at the same level for equality. If it finds a match
+// it will redirect the traversal through this parent rather than creating a new
+// child.
+//
+// 3. It traverses the right side with the same rules. The only real difference
+// is that it will assign the node to the right side on a match/new child
+// instead of the left.
 //
 // Here are two individuals that have slightly different data:
 //
@@ -88,156 +95,65 @@ type NodeDiff struct {
 // pointer values). The returned left and right will have the respective root
 // nodes.
 //
-// The first step is to flatten the nodes. Each node is represented as an slice
-// containing all of its parent elements:
+// Here is the output, rendered with NodeDiff.String():
 //
-//   -- Left
-//   ["INDI @P3@"]
-//   ["INDI @P3@", "NAME John /Smith/"]
-//   ["INDI @P3@", "BIRT"]
-//   ["INDI @P3@", "BIRT", "DATE 3 SEP 1943"]
-//   ["INDI @P3@", "DEAT"]
-//   ["INDI @P3@", "DEAT", "PLAC England"]
-//   ["INDI @P3@", "BIRT"]
-//   ["INDI @P3@", "BIRT", "DATE Abt. Oct 1943"]
-//
-//   -- Right
-//   ["INDI @P4@"]
-//   ["INDI @P4@", "NAME J. /Smith/"]
-//   ["INDI @P4@", "BIRT"]
-//   ["INDI @P4@", "BIRT", "DATE Abt. Sep 1943"]
-//   ["INDI @P4@", "BIRT"]
-//   ["INDI @P4@", "BIRT", "DATE 3 SEP 1943"]
-//   ["INDI @P4@", "DEAT"]
-//   ["INDI @P4@", "DEAT", "DATE Aft. 2001"]
-//   ["INDI @P4@", "DEAT", "PLAC Surry, England"]
-//
-// Now we begin unflattening the data back into the nested structure. The "L"
-// and "R" represent which side is not nil in the DiffNode.
-//
-// Beginning with the Left items:
-//
-//   L  0 INDI @P3@
+//   LR 0 INDI @P3@
 //   L  1 NAME John /Smith/
-//   L  1 BIRT
+//   LR 1 BIRT
 //   L  2 DATE Abt. Oct 1943
-//   L  2 DATE 3 SEP 1943
-//   L  1 DEAT
+//   LR 2 DATE 3 SEP 1943
+//    R 2 DATE Abt. Sep 1943
+//   LR 1 DEAT
 //   L  2 PLAC England
+//    R 2 DATE Aft. 2001
+//    R 2 PLAC Surry, England
+//    R 1 NAME J. /Smith/
 //
-// Then the Right items and applied on top. Equal nodes will be converted from
-// "L" -> "LR" (assign right):
-//
-//   LR 0 INDI @P3@            | = Assign right (notice the @P4@ is not shown)
-//   L  1 NAME John /Smith/    |
-//   LR 1 BIRT                 | = Assign right
-//   L  2 DATE Abt. Oct 1943   |
-//   LR 2 DATE 3 SEP 1943      | = Assign right
-//    R 2 DATE Abt. Sep 1943   | + Added
-//   LR 1 DEAT                 | = Assign right
-//   L  2 PLAC England         |
-//    R 2 DATE Aft. 2001       | + Added
-//    R 2 PLAC Surry, England  | + Added
-//    R 1 NAME J. /Smith/      | + Added
-//
-// The output format is the same as NodeDiff.String().
 func CompareNodes(left, right Node) *NodeDiff {
-	// Flatten the nodes. We use the left prefix when flattening the right nodes
-	// as to not interfere with the a root node on the right that may be
-	// different. At the end we will assign the right root node.
-	//
-	// The extra conditional check is to make sure that a nil left does not
-	// break the right only traversing.
-	prefix := []string{GedcomLine(-1, NodeCondition(IsNil(left), right, left))}
-	flatLeft := flattenNode(left, prefix)
-	flatRight := flattenNode(right, prefix)
-
-	// Unflatten the nodes back to the diff.
 	result := &NodeDiff{}
-	result.unflatten(flatLeft, false)
-	result.unflatten(flatRight, true)
 
-	// Fix up the right root node.
-	result.Right = right
+	result.traverse(left, true)
+	result.traverse(right, false)
 
 	return result
 }
 
-func (nd *NodeDiff) unflatten(flatNodes [][]string, assignRight bool) {
-	for _, item := range flatNodes {
-		nd.unflattenSingle(item, assignRight)
+func (nd *NodeDiff) traverse(n Node, isLeft bool) {
+	if n == nil {
+		return
 	}
-}
 
-func (nd *NodeDiff) unflattenSingle(flatNode []string, assignRight bool) {
-	i := nd
-	for _, line := range flatNode {
-		// We can ignore the error here because we encoded the lines.
-		parsedLine, _, _ := parseLine(nil, "0 "+line)
+	if isLeft && nd.Left == nil {
+		nd.Left = n
+	}
 
-		switch {
-		case nd.Left == nil && nd.Right == nil:
-			// This is the first (root) node.
+	if !isLeft && nd.Right == nil {
+		nd.Right = n
+	}
 
-			nd.Left = NodeCondition(!assignRight, parsedLine, nd.Left)
-			nd.Right = NodeCondition(assignRight, parsedLine, nd.Right)
-			i = nd
-
-		case GedcomLine(-1, i.Left) == line || GedcomLine(-1, i.Right) == line:
-			// We have found a match with an existing line, traverse down. This
-			// is not the same situation below were each of the children are
-			// checked.
-
-			if assignRight {
-				i.Right = parsedLine
+	for _, child := range n.Nodes() {
+		found := false
+		for _, diffChild := range nd.Children {
+			if diffChild.Left != nil && diffChild.Left.Equals(child) {
+				diffChild.traverse(child, isLeft)
+				found = true
+				break
 			}
 
-		default:
-			// We will be adding a new node. Search the children to see if there
-			// is a match, otherwise add it to the end.
-
-			child := &NodeDiff{
-				Left:  NodeCondition(!assignRight, parsedLine, nil),
-				Right: NodeCondition(assignRight, parsedLine, nil),
-			}
-
-			found := false
-			for _, n := range i.Children {
-				if GedcomLine(-1, n.Left) == line || GedcomLine(-1, n.Right) == line {
-					if assignRight {
-						n.Right = parsedLine
-					}
-					i = n
-					found = true
-					break
-				}
-			}
-
-			if !found {
-				i.Children = append(i.Children, child)
-				i = child
+			if diffChild.Right != nil && diffChild.Right.Equals(child) {
+				diffChild.traverse(child, isLeft)
+				found = true
+				break
 			}
 		}
-	}
-}
 
-func flattenNode(node Node, prefix []string) [][]string {
-	if IsNil(node) {
-		return [][]string{}
-	}
+		if !found {
+			newNd := &NodeDiff{}
+			newNd.traverse(child, isLeft)
 
-	children := node.Nodes()
-	if len(children) == 0 {
-		return [][]string{prefix}
+			nd.Children = append(nd.Children, newNd)
+		}
 	}
-
-	r := [][]string{prefix}
-	for _, child := range children {
-		line := GedcomLine(-1, child)
-		r = append(r, flattenNode(child, append(prefix, line))...)
-	}
-
-	return r
 }
 
 func (nd *NodeDiff) lrLine(indent int) string {

--- a/node_diff_test.go
+++ b/node_diff_test.go
@@ -121,6 +121,67 @@ func TestCompareNodes(t *testing.T) {
 			},
 		},
 
+		// Do not merge Residence (based on Equals).
+		{
+			left: parse(
+				"0 INDI @P3@",
+				"1 NAME John /Smith/",
+				"1 RESI",
+				"2 PLAC England",
+				"1 RESI",
+				"2 DATE Abt. Oct 1943",
+			)[0],
+			right: parse(
+				"0 INDI @P3@",
+				"1 NAME John /Smith/",
+				"1 RESI",
+				"2 DATE About Oct 1943",
+				"1 RESI",
+				"2 PLAC Yorkshire, England",
+			)[0],
+			expected: &gedcom.NodeDiff{
+				Left:  parse("0 INDI @P3@")[0],
+				Right: parse("0 INDI @P3@")[0],
+				Children: []*gedcom.NodeDiff{
+					{
+						Left:     parse("0 NAME John /Smith/")[0],
+						Right:    parse("0 NAME John /Smith/")[0],
+						Children: nil,
+					},
+					{
+						Left:  parse("0 RESI")[0],
+						Right: nil,
+						Children: []*gedcom.NodeDiff{
+							{
+								Left:  parse("0 PLAC England")[0],
+								Right: nil,
+							},
+						},
+					},
+					{
+						Left:  parse("0 RESI")[0],
+						Right: parse("0 RESI")[0],
+						Children: []*gedcom.NodeDiff{
+							{
+								Left:  parse("0 DATE Abt. Oct 1943")[0],
+								Right: parse("0 DATE About Oct 1943")[0],
+							},
+						},
+					},
+					{
+						Left:  nil,
+						Right: parse("0 RESI")[0],
+						Children: []*gedcom.NodeDiff{
+							{
+								Left:  nil,
+								Right: parse("0 PLAC Yorkshire, England")[0],
+							},
+						},
+					},
+				},
+			},
+		},
+
 		// Example from the docs.
 		{
 			left: parse(
@@ -134,7 +195,7 @@ func TestCompareNodes(t *testing.T) {
 				"2 DATE Abt. Oct 1943",
 			)[0],
 			right: parse(
-				"0 INDI @P4@",
+				"0 INDI @P3@",
 				"1 NAME J. /Smith/",
 				"1 BIRT",
 				"2 DATE Abt. Sep 1943",
@@ -146,7 +207,7 @@ func TestCompareNodes(t *testing.T) {
 			)[0],
 			expected: &gedcom.NodeDiff{
 				Left:  parse("0 INDI @P3@")[0],
-				Right: parse("0 INDI @P4@")[0],
+				Right: parse("0 INDI @P3@")[0],
 				Children: []*gedcom.NodeDiff{
 					{
 						Left:     parse("0 NAME John /Smith/")[0],

--- a/node_test.go
+++ b/node_test.go
@@ -11,7 +11,7 @@ func TestNodeGedcom(t *testing.T) {
 
 	root := gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
 		gedcom.NewNameNode(nil, "Elliot /Chance/", "", nil),
-		gedcom.NewSimpleNode(nil, gedcom.TagBirth, "", "", []gedcom.Node{
+		gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
 			gedcom.NewDateNode(nil, "6 MAY 1989", "", nil),
 		}),
 	})

--- a/residence_node.go
+++ b/residence_node.go
@@ -1,0 +1,54 @@
+package gedcom
+
+// ResidenceNode is the act of dwelling at an address for a period of time.
+type ResidenceNode struct {
+	*SimpleNode
+}
+
+// NewResidenceNode creates a new RESI node.
+func NewResidenceNode(document *Document, value, pointer string, children []Node) *ResidenceNode {
+	return &ResidenceNode{
+		NewSimpleNode(document, TagResidence, value, pointer, children),
+	}
+}
+
+// Dates returns zero or more dates associated with the residence.
+//
+// When more than one date is returned you should not assume that the order has
+// any significance for the importance of the dates.
+func (node *ResidenceNode) Dates() (result []*DateNode) {
+	for _, n := range NodesWithTag(node, TagDate) {
+		result = append(result, n.(*DateNode))
+	}
+
+	return
+}
+
+// Equal tests if two residence events are the same.
+//
+// Two residence events are considered equal if they both contain the same date.
+// If either or both contain more than one date only a single date in must match
+// both sides.
+//
+// If either node is nil (including both) or if the right side is not a
+// ResidenceNode then false is always returned.
+func (node *ResidenceNode) Equals(node2 Node) bool {
+	if IsNil(node) || IsNil(node2) {
+		return false
+	}
+
+	if n2, ok := node2.(*ResidenceNode); ok {
+		leftDates := node.Dates()
+		rightDates := n2.Dates()
+
+		for _, left := range leftDates {
+			for _, right := range rightDates {
+				if left.Equals(right) {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}

--- a/residence_node_test.go
+++ b/residence_node_test.go
@@ -1,0 +1,72 @@
+package gedcom_test
+
+import (
+	"testing"
+
+	"github.com/elliotchance/gedcom"
+	"github.com/elliotchance/tf"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewResidenceNode(t *testing.T) {
+	doc := gedcom.NewDocument()
+	child := gedcom.NewNameNode(doc, "", "", nil)
+	node := gedcom.NewResidenceNode(doc, "foo", "bar", []gedcom.Node{child})
+
+	assert.Equal(t, gedcom.TagResidence, node.Tag())
+	assert.Equal(t, []gedcom.Node{child}, node.Nodes())
+	assert.Equal(t, doc, node.Document())
+	assert.Equal(t, "foo", node.Value())
+	assert.Equal(t, "bar", node.Pointer())
+}
+
+func TestResidenceNode_Dates(t *testing.T) {
+	Dates := tf.Function(t, (*gedcom.ResidenceNode).Dates)
+
+	Dates(gedcom.NewResidenceNode(nil, "", "", nil)).Returns([]*gedcom.DateNode(nil))
+
+	Dates(gedcom.NewResidenceNode(nil, "", "", []gedcom.Node{})).
+		Returns([]*gedcom.DateNode(nil))
+
+	Dates(gedcom.NewResidenceNode(nil, "", "", []gedcom.Node{
+		gedcom.NewDateNode(nil, "3 Sep 2001", "", nil),
+	})).Returns([]*gedcom.DateNode{
+		gedcom.NewDateNode(nil, "3 Sep 2001", "", nil),
+	})
+
+	Dates(gedcom.NewResidenceNode(nil, "", "", []gedcom.Node{
+		gedcom.NewDateNode(nil, "7 Jan 2001", "", nil),
+		gedcom.NewDateNode(nil, "3 Sep 2001", "", nil),
+	})).Returns([]*gedcom.DateNode{
+		gedcom.NewDateNode(nil, "7 Jan 2001", "", nil),
+		gedcom.NewDateNode(nil, "3 Sep 2001", "", nil),
+	})
+}
+
+func TestResidenceNode_Equals(t *testing.T) {
+	Equals := tf.Function(t, (*gedcom.ResidenceNode).Equals)
+
+	n1 := gedcom.NewResidenceNode(nil, "foo", "", nil)
+	n2 := gedcom.NewResidenceNode(nil, "bar", "", nil)
+	n3 := gedcom.NewResidenceNode(nil, "bar", "", []gedcom.Node{
+		gedcom.NewDateNode(nil, "3 Sep 1943", "", nil),
+		gedcom.NewDateNode(nil, "Oct 1943", "", nil),
+	})
+	n4 := gedcom.NewResidenceNode(nil, "bar", "", []gedcom.Node{
+		gedcom.NewDateNode(nil, "Oct 1943", "", nil),
+	})
+
+	// nils
+	Equals((*gedcom.ResidenceNode)(nil), (*gedcom.ResidenceNode)(nil)).Returns(false)
+	Equals(n1, (*gedcom.ResidenceNode)(nil)).Returns(false)
+	Equals((*gedcom.ResidenceNode)(nil), n1).Returns(false)
+
+	// Wrong node type.
+	Equals(n1, gedcom.NewNameNode(nil, "foo", "", nil)).Returns(false)
+
+	// General cases.
+	Equals(n1, n1).Returns(false)
+	Equals(n1, n2).Returns(false)
+	Equals(n1, n3).Returns(false)
+	Equals(n3, n4).Returns(true)
+}

--- a/simple_node_test.go
+++ b/simple_node_test.go
@@ -17,7 +17,7 @@ func TestIsNil(t *testing.T) {
 	IsNil := tf.Function(t, gedcom.IsNil)
 
 	IsNil((*gedcom.SimpleNode)(nil)).Returns(true)
-	IsNil(gedcom.NewSimpleNode(nil, gedcom.TagBirth, "", "", nil)).Returns(false)
+	IsNil(gedcom.NewBirthNode(nil, "", "", nil)).Returns(false)
 	IsNil((*gedcom.NameNode)(nil)).Returns(true)
 	IsNil(gedcom.NewNameNode(nil, "", "", nil)).Returns(false)
 

--- a/tag.go
+++ b/tag.go
@@ -2,6 +2,17 @@ package gedcom
 
 import "fmt"
 
+const (
+	// A constant that means none of the below flags are enabled.
+	tagOptionNone = 0
+
+	// tagOptionEvent describes is this tag is a type of event, such as a birth
+	// (BIRT) for an individual or a marriage for a family (MARR). Generally
+	// speaking all events have an optional date (DATE) and place (PLAC) as
+	// child nodes.
+	tagOptionEvent = 1 << iota
+)
+
 // knownTags is a private cache used to quickly and easily convert strings to
 // tags. It is initialised by newTag.
 var knownTags map[string]Tag
@@ -9,10 +20,10 @@ var knownTags map[string]Tag
 // Tag is the type of node. You should not initialise a Tag instance manually,
 // but rather use TagFromString.
 type Tag struct {
-	// known will be true when using one of the Tag constants. You should use
+	// isKnown will be true when using one of the Tag constants. You should use
 	// this if you have loaded a Tag from a string and you to check if all of
 	// the other fields are loaded.
-	known bool
+	isKnown bool
 
 	// tag is the raw tag as it is represented in the GEDCOM file, like "INDI"
 	// for an individual. Generally speaking non-standard (unofficial) tags
@@ -30,10 +41,8 @@ type Tag struct {
 	// same as Tag.
 	name string
 
-	// isEvent describes is this tag is a type of event, such as a birth (BIRT)
-	// for an individual or a marriage for a family (MARR). Generally speaking
-	// all events have an optional date (DATE) and place (PLAC) as child nodes.
-	isEvent bool
+	// A combination of flags from the tagOption constants.
+	options int
 }
 
 // http://wiki-en.genealogy.net/GEDCOM-Tags
@@ -51,124 +60,124 @@ type Tag struct {
 // begin with an underscore _ .
 var (
 	// A short name of a title, description, or name.
-	TagAbbreviation = newTag("ABBR", "Abbreviation", false)
+	TagAbbreviation = newTag("ABBR", "Abbreviation", tagOptionNone)
 
 	// The contemporary place, usually required for postal purposes, of an
 	// individual, a submitter of information, a repository, a business, a
 	// school, or a company.
-	TagAddress = newTag("ADDR", "Address", false)
+	TagAddress = newTag("ADDR", "Address", tagOptionNone)
 
 	// The first line of an address.
-	TagAddress1 = newTag("ADR1", "Address Line 1", false)
+	TagAddress1 = newTag("ADR1", "Address Line 1", tagOptionNone)
 
 	// The second line of an address.
-	TagAddress2 = newTag("ADR2", "Address Line 2", false)
+	TagAddress2 = newTag("ADR2", "Address Line 2", tagOptionNone)
 
 	// Pertaining to creation of a child-parent relationship that does not exist
 	// biologically.
-	TagAdoption = newTag("ADOP", "Adoption", true)
+	TagAdoption = newTag("ADOP", "Adoption", tagOptionEvent)
 
 	// Ancestral File Number, a unique permanent record file number of an
 	// individual record stored in Ancestral File.
-	TagAncestralFileNumber = newTag("AFN", "Ancestral File Number", false)
+	TagAncestralFileNumber = newTag("AFN", "Ancestral File Number", tagOptionNone)
 
 	// The age of the individual at the time an event occurred, or the age
 	// listed in the document.
-	TagAge = newTag("AGE", "Age", false)
+	TagAge = newTag("AGE", "Age", tagOptionNone)
 
 	// The institution or individual having authority and/or responsibility to
 	// manage or govern.
-	TagAgency = newTag("AGNC", "Agency", false)
+	TagAgency = newTag("AGNC", "Agency", tagOptionNone)
 
 	// An indicator to link different record descriptions of a person who may be
 	// the same person.
-	TagAlias = newTag("ALIA", "Alias", false)
+	TagAlias = newTag("ALIA", "Alias", tagOptionNone)
 
 	// Pertaining to forbearers of an individual.
-	TagAncestors = newTag("ANCE", "Ancestors", false)
+	TagAncestors = newTag("ANCE", "Ancestors", tagOptionNone)
 
 	// Indicates an interest in additional research for ancestors of this
 	// individual. (See also DESI)
-	TagAncestorsInterest = newTag("ANCI", "Ancestors Interest", false)
+	TagAncestorsInterest = newTag("ANCI", "Ancestors Interest", tagOptionNone)
 
 	// Declaring a marriage void from the beginning (never existed).
-	TagAnnulment = newTag("ANUL", "Annulment", true)
+	TagAnnulment = newTag("ANUL", "Annulment", tagOptionEvent)
 
 	// An indicator to link friends, neighbors, relatives, or associates of an
 	// individual.
-	TagAssociates = newTag("ASSO", "Associates", false)
+	TagAssociates = newTag("ASSO", "Associates", tagOptionNone)
 
 	// The name of the individual who created or compiled information.
-	TagAuthor = newTag("AUTH", "Author", false)
+	TagAuthor = newTag("AUTH", "Author", tagOptionNone)
 
 	// The event of baptism performed at age eight or later by priesthood
 	// authority of the LDS Church. (See also BAPM)
-	TagLDSBaptism = newTag("BAPL", "LDS Baptism", true)
+	TagLDSBaptism = newTag("BAPL", "LDS Baptism", tagOptionEvent)
 
 	// The event of baptism (not LDS), performed in infancy or later. (See also
 	// BAPL and CHR)
-	TagBaptism = newTag("BAPM", "Baptism", true)
+	TagBaptism = newTag("BAPM", "Baptism", tagOptionEvent)
 
 	// The ceremonial event held when a Jewish boy reaches age 13.
-	TagBarMitzvah = newTag("BARM", "Bar Mitzvah", true)
+	TagBarMitzvah = newTag("BARM", "Bar Mitzvah", tagOptionEvent)
 
 	// The ceremonial event held when a Jewish girl reaches age 13, also known
 	// as "Bat Mitzvah."
-	TagBasMitzvah = newTag("BASM", "Bas Mitzvah", true)
+	TagBasMitzvah = newTag("BASM", "Bas Mitzvah", tagOptionEvent)
 
-	// The event of entering into life.
-	TagBirth = newTag("BIRT", "Birth", true)
+	// See BirthNode.
+	TagBirth = newTag("BIRT", "Birth", tagOptionEvent)
 
 	// A religious event of bestowing divine care or intercession. Sometimes
 	// given in connection with a naming ceremony.
-	TagBlessing = newTag("BLES", "Blessing", true)
+	TagBlessing = newTag("BLES", "Blessing", tagOptionEvent)
 
 	// A grouping of data used as input to a multimedia system that processes
 	// binary data to represent images, sound, and video. Deleted in Gedcom
 	// 5.5.1
-	TagBinaryObject = newTag("BLOB", "Binary Object", false)
+	TagBinaryObject = newTag("BLOB", "Binary Object", tagOptionNone)
 
 	// The event of the proper disposing of the mortal remains of a deceased
 	// person.
-	TagBurial = newTag("BURI", "Burial", true)
+	TagBurial = newTag("BURI", "Burial", tagOptionEvent)
 
 	// The number used by a repository to identify the specific items in its
 	// collections.
-	TagCallNumber = newTag("CALN", "Call Number", false)
+	TagCallNumber = newTag("CALN", "Call Number", tagOptionNone)
 
 	// The name of an individual's rank or status in society, based on racial or
 	// religious differences, or differences in wealth, inherited rank,
 	// profession, occupation, etc.
-	TagCaste = newTag("CAST", "Caste", false)
+	TagCaste = newTag("CAST", "Caste", tagOptionNone)
 
 	// A description of the cause of the associated event or fact, such as the
 	// cause of death.
-	TagCause = newTag("CAUS", "Cause", false)
+	TagCause = newTag("CAUS", "Cause", tagOptionNone)
 
 	// The event of the periodic count of the population for a designated
 	// locality, such as a national or state Census.
-	TagCensus = newTag("CENS", "Census", true)
+	TagCensus = newTag("CENS", "Census", tagOptionEvent)
 
 	// Indicates a change, correction, or modification. Typically used in
 	// connection with a DATE to specify when a change in information occurred.
-	TagChange = newTag("CHAN", "Change", false)
+	TagChange = newTag("CHAN", "Change", tagOptionNone)
 
 	// An indicator of the character set used in writing this automated
 	// information.
-	TagCharacterSet = newTag("CHAR", "Character Set", false)
+	TagCharacterSet = newTag("CHAR", "Character Set", tagOptionNone)
 
 	// The natural, adopted, or sealed (LDS) child of a father and a mother.
-	TagChild = newTag("CHIL", "Child", false)
+	TagChild = newTag("CHIL", "Child", tagOptionNone)
 
 	// The religious event (not LDS) of baptizing and/or naming a child.
-	TagChristening = newTag("CHR", "Christening", true)
+	TagChristening = newTag("CHR", "Christening", tagOptionEvent)
 
 	// The religious event (not LDS) of baptizing and/or naming an adult person.
-	TagAdultChristening = newTag("CHRA", "Adult Christening", true)
+	TagAdultChristening = newTag("CHRA", "Adult Christening", tagOptionEvent)
 
 	// A lower level jurisdictional unit. Normally an incorporated municipal
 	// unit.
-	TagCity = newTag("CITY", "City", false)
+	TagCity = newTag("CITY", "City", tagOptionNone)
 
 	// An indicator that additional data belongs to the superior value. The
 	// information from the CONC value is to be connected to the value of the
@@ -179,15 +188,15 @@ var (
 	// treatment that spaces get as a GEDCOM delimiter, many GEDCOM values are
 	// trimmed of trailing spaces and some systems look for the first non-space
 	// starting after the tag to determine the beginning of the value.
-	TagConcatenation = newTag("CONC", "Concatenation", false)
+	TagConcatenation = newTag("CONC", "Concatenation", tagOptionNone)
 
 	// The religious event (not LDS) of conferring the gift of the Holy Ghost
 	// and, among protestants, full church membership.
-	TagConfirmation = newTag("CONF", "Confirmation", true)
+	TagConfirmation = newTag("CONF", "Confirmation", tagOptionEvent)
 
 	// The religious event by which a person receives membership in the LDS
 	// Church.
-	TagLDSConfirmation = newTag("CONL", "LDS Confirmation", true)
+	TagLDSConfirmation = newTag("CONL", "LDS Confirmation", tagOptionEvent)
 
 	//  An indicator that additional data belongs to the superior value. The
 	// information from the CONT value is to be connected to the value of the
@@ -196,367 +205,367 @@ var (
 	// text. When importing values from CONT lines the reader should assume only
 	// one delimiter character following the CONT tag. Assume that the rest of
 	// the leading spaces are to be a part of the value.
-	TagContinued = newTag("CONT", "Continued", false)
+	TagContinued = newTag("CONT", "Continued", tagOptionNone)
 
 	// A statement that accompanies data to protect it from unlawful duplication
 	// and distribution.
-	TagCopyright = newTag("COPR", "Copyright", false)
+	TagCopyright = newTag("COPR", "Copyright", tagOptionNone)
 
 	// A name of an institution, agency, corporation, or company.
-	TagCorporate = newTag("CORP", "Corporate", false)
+	TagCorporate = newTag("CORP", "Corporate", tagOptionNone)
 
 	// Disposal of the remains of a person's body by fire.
-	TagCremation = newTag("CREM", "Cremation", true)
+	TagCremation = newTag("CREM", "Cremation", tagOptionEvent)
 
 	// The name or code of the country.
-	TagCountry = newTag("CTRY", "Country", false)
+	TagCountry = newTag("CTRY", "Country", tagOptionNone)
 
 	// Pertaining to stored automated information.
-	TagData = newTag("DATA", "Data", false)
+	TagData = newTag("DATA", "Data", tagOptionNone)
 
 	// The time of an event in a calendar format.
-	TagDate = newTag("DATE", "Date", false)
+	TagDate = newTag("DATE", "Date", tagOptionNone)
 
 	// The event when mortal life terminates.
-	TagDeath = newTag("DEAT", "Death", true)
+	TagDeath = newTag("DEAT", "Death", tagOptionEvent)
 
 	// Pertaining to offspring of an individual.
-	TagDescendants = newTag("DESC", "Descendants", false)
+	TagDescendants = newTag("DESC", "Descendants", tagOptionNone)
 
 	// Indicates an interest in research to identify additional descendants of
 	// this individual. (See also ANCI)
-	TagDescendantsInterest = newTag("DESI", "Descendants Interest", false)
+	TagDescendantsInterest = newTag("DESI", "Descendants Interest", tagOptionNone)
 
 	// A system receiving data.
-	TagDestination = newTag("DEST", "Destination", false)
+	TagDestination = newTag("DEST", "Destination", tagOptionNone)
 
 	// An event of dissolving a marriage through civil action.
-	TagDivorce = newTag("DIV", "Divorce", true)
+	TagDivorce = newTag("DIV", "Divorce", tagOptionEvent)
 
 	// An event of filing for a divorce by a spouse.
-	TagDivorceFiled = newTag("DIVF", "Divorce Filed", true)
+	TagDivorceFiled = newTag("DIVF", "Divorce Filed", tagOptionEvent)
 
 	// The physical characteristics of a person, place, or thing.
-	TagPhysicalDescription = newTag("DSCR", "Physical Description", false)
+	TagPhysicalDescription = newTag("DSCR", "Physical Description", tagOptionNone)
 
 	// Indicator of a level of education attained.
-	TagEducation = newTag("EDUC", "Education", false)
+	TagEducation = newTag("EDUC", "Education", tagOptionNone)
 
 	// An electronic address that can be used for contact such as an email
 	// address. New in Gedcom 5.5.1.
-	TagEmail = newTag("EMAIL", "Email", false)
+	TagEmail = newTag("EMAIL", "Email", tagOptionNone)
 
 	// An event of leaving one's homeland with the intent of residing elsewhere.
-	TagEmigration = newTag("EMIG", "Emigration", true)
+	TagEmigration = newTag("EMIG", "Emigration", tagOptionEvent)
 
 	// A religious event where an endowment ordinance for an individual was
 	// performed by priesthood authority in an LDS temple.
-	TagEndowment = newTag("ENDL", "Endowment", true)
+	TagEndowment = newTag("ENDL", "Endowment", tagOptionEvent)
 
 	// An event of recording or announcing an agreement between two people to
 	// become married.
-	TagEngagement = newTag("ENGA", "Engagement", true)
+	TagEngagement = newTag("ENGA", "Engagement", tagOptionEvent)
 
 	// A noteworthy happening related to an individual, a group, or an
 	// organization.
-	TagEvent = newTag("EVEN", "Event", true)
+	TagEvent = newTag("EVEN", "Event", tagOptionEvent)
 
 	// Pertaining to a noteworthy attribute or fact concerning an individual, a
 	// group, or an organization. A structure is usually qualified or classified
 	// by a subordinate use of the TYPE tag. New in Gedcom 5.5.1.
-	TagFact = newTag("FACT", "Fact", false)
+	TagFact = newTag("FACT", "Fact", tagOptionNone)
 
 	// Identifies a legal, common law, or other customary relationship of man
 	// and woman and their children, if any, or a family created by virtue of
 	// the birth of a child to its biological father and mother.
-	TagFamily = newTag("FAM", "Family", false)
+	TagFamily = newTag("FAM", "Family", tagOptionNone)
 
 	// Identifies the family in which an individual appears as a child.
-	TagFamilyChild = newTag("FAMC", "Family Child", false)
+	TagFamilyChild = newTag("FAMC", "Family Child", tagOptionNone)
 
 	// Pertaining to, or the name of, a family file. Names stored in a file that
 	// are assigned to a family for doing temple ordinance work.
-	TagFamilyFile = newTag("FAMF", "Family File", false)
+	TagFamilyFile = newTag("FAMF", "Family File", tagOptionNone)
 
 	// Identifies the family in which an individual appears as a spouse.
-	TagFamilySpouse = newTag("FAMS", "Family Spouse", false)
+	TagFamilySpouse = newTag("FAMS", "Family Spouse", tagOptionNone)
 
 	// A FAX telephone number appropriate for sending data facsimiles. New in
 	// Gedcom 5.5.1.
-	TagFax = newTag("FAX", "Fax", false)
+	TagFax = newTag("FAX", "Fax", tagOptionNone)
 
 	// A religious rite, the first act of sharing in the Lord's supper as part
 	// of church worship.
-	TagFirstCommunion = newTag("FCOM", "First Communion", true)
+	TagFirstCommunion = newTag("FCOM", "First Communion", tagOptionEvent)
 
 	// An information storage place that is ordered and arranged for
 	// preservation and reference.
-	TagFile = newTag("FILE", "File", false)
+	TagFile = newTag("FILE", "File", tagOptionNone)
 
 	// A phonetic variation of a superior text string. New in Gedcom 5.5.1
-	TagPhonetic = newTag("FONE", "Phonetic", false)
+	TagPhonetic = newTag("FONE", "Phonetic", tagOptionNone)
 
 	// An assigned name given to a consistent format in which information can be
 	// conveyed.
-	TagFormat = newTag("FORM", "Format", false)
+	TagFormat = newTag("FORM", "Format", tagOptionNone)
 
 	// Information about the use of GEDCOM in a transmission.
-	TagGedcomInformation = newTag("GEDC", "GEDCOM Information", false)
+	TagGedcomInformation = newTag("GEDC", "GEDCOM Information", tagOptionNone)
 
 	// A given or earned name used for official identification of a person. It
 	// is also commonly known as the "first name".
 	//
 	// The NameNode provides a GivenName() function.
-	TagGivenName = newTag("GIVN", "Given Name", false)
+	TagGivenName = newTag("GIVN", "Given Name", tagOptionNone)
 
 	// An event of awarding educational diplomas or degrees to individuals.
-	TagGraduation = newTag("GRAD", "Graduation", true)
+	TagGraduation = newTag("GRAD", "Graduation", tagOptionEvent)
 
 	// Identifies information pertaining to an entire GEDCOM transmission.
-	TagHeader = newTag("HEAD", "Header", false)
+	TagHeader = newTag("HEAD", "Header", tagOptionNone)
 
 	// An individual in the family role of a married man or father.
-	TagHusband = newTag("HUSB", "Husband", false)
+	TagHusband = newTag("HUSB", "Husband", tagOptionNone)
 
 	// A number assigned to identify a person within some significant external
 	// system.
-	TagIdentityNumber = newTag("IDNO", "Identity Number", false)
+	TagIdentityNumber = newTag("IDNO", "Identity Number", tagOptionNone)
 
 	// An event of entering into a new locality with the intent of residing
 	// there.
-	TagImmigration = newTag("IMMI", "Immigration", true)
+	TagImmigration = newTag("IMMI", "Immigration", tagOptionEvent)
 
 	// A person.
-	TagIndividual = newTag("INDI", "Individual", false)
+	TagIndividual = newTag("INDI", "Individual", tagOptionNone)
 
 	// The name of the language used in a communication or transmission of
 	// information.
-	TagLanguage = newTag("LANG", "Language", false)
+	TagLanguage = newTag("LANG", "Language", tagOptionNone)
 
 	// A value indicating a coordinate position on a line, plane, or space. New
 	// in Gedcom 5.5.1.
-	TagLatitude = newTag("LATI", "Latitude", false)
+	TagLatitude = newTag("LATI", "Latitude", tagOptionNone)
 
 	// A role of an individual acting as a person receiving a bequest or legal
 	// devise.
-	TagLegatee = newTag("LEGA", "Legatee", false)
+	TagLegatee = newTag("LEGA", "Legatee", tagOptionNone)
 
 	// A value indicating a coordinate position on a line, plane, or space. New
 	// in Gedcom 5.5.1.
-	TagLongitude = newTag("LONG", "Longitude", false)
+	TagLongitude = newTag("LONG", "Longitude", tagOptionNone)
 
 	// Pertains to a representation of measurements usually presented in a
 	// graphical form. New in Gedcom 5.5.1
-	TagMap = newTag("MAP", "Map", false)
+	TagMap = newTag("MAP", "Map", tagOptionNone)
 
 	// An event of an official public notice given that two people intend to
 	// marry.
-	TagMarriageBann = newTag("MARB", "Marriage Bann", true)
+	TagMarriageBann = newTag("MARB", "Marriage Bann", tagOptionEvent)
 
 	// An event of recording a formal agreement of marriage, including the
 	// prenuptial agreement in which marriage partners reach agreement about the
 	// property rights of one or both, securing property to their children.
-	TagMarriageContract = newTag("MARC", "Marriage Contract", true)
+	TagMarriageContract = newTag("MARC", "Marriage Contract", tagOptionEvent)
 
 	// An event of obtaining a legal license to marry.
-	TagMarriageLicence = newTag("MARL", "Marriage Licence", true)
+	TagMarriageLicence = newTag("MARL", "Marriage Licence", tagOptionEvent)
 
 	// A legal, common-law, or customary event of creating a family unit of a
 	// man and a woman as husband and wife.
-	TagMarriage = newTag("MARR", "Marriage", true)
+	TagMarriage = newTag("MARR", "Marriage", tagOptionEvent)
 
 	// An event of creating an agreement between two people contemplating
 	// marriage, at which time they agree to release or modify property rights
 	// that would otherwise arise from the marriage.
-	TagMarriageSettlement = newTag("MARS", "Marriage Settlement", true)
+	TagMarriageSettlement = newTag("MARS", "Marriage Settlement", tagOptionEvent)
 
 	// Identifies information about the media or having to do with the medium in
 	// which information is stored.
-	TagMedia = newTag("MEDI", "Media", false)
+	TagMedia = newTag("MEDI", "Media", tagOptionNone)
 
 	// A word or combination of words used to help identify an individual,
 	// title, or other item. More than one NAME line should be used for people
 	// who were known by multiple names.
 	//
 	// NAME tags will be interpreted with the NameNode type.
-	TagName = newTag("NAME", "Name", false)
+	TagName = newTag("NAME", "Name", tagOptionNone)
 
 	// The national heritage of an individual.
-	TagNationality = newTag("NATI", "Nationality", false)
+	TagNationality = newTag("NATI", "Nationality", tagOptionNone)
 
 	// The event of obtaining citizenship.
-	TagNaturalization = newTag("NATU", "Naturalization", true)
+	TagNaturalization = newTag("NATU", "Naturalization", tagOptionEvent)
 
 	// The number of children that this person is known to be the parent of (all
 	// marriages) when subordinate to an individual, or that belong to this
 	// family when subordinate to a FAM_RECORD.
-	TagChildrenCount = newTag("NCHI", "Children Count", false)
+	TagChildrenCount = newTag("NCHI", "Children Count", tagOptionNone)
 
 	// A descriptive or familiar that is used instead of, or in addition to,
 	// one's proper name.
-	TagNickname = newTag("NICK", "Nickname", false)
+	TagNickname = newTag("NICK", "Nickname", tagOptionNone)
 
 	// The number of times this person has participated in a family as a spouse
 	// or parent.
-	TagMarriageCount = newTag("NMR", "Marriage Count", false)
+	TagMarriageCount = newTag("NMR", "Marriage Count", tagOptionNone)
 
 	// Additional information provided by the submitter for understanding the
 	// enclosing data.
-	TagNote = newTag("NOTE", "Note", false)
+	TagNote = newTag("NOTE", "Note", tagOptionNone)
 
 	// Text which appears on a name line before the given and surname parts of a
 	// name. i.e. ( Lt. Cmndr. ) Joseph /Allen/ jr. In this example Lt. Cmndr.
 	// is considered as the name prefix portion.
 	//
 	// The NameNode provides a Prefix() function.
-	TagNamePrefix = newTag("NPFX", "Name Prefix", false)
+	TagNamePrefix = newTag("NPFX", "Name Prefix", tagOptionNone)
 
 	// Text which appears on a name line after or behind the given and surname
 	// parts of a name. i.e. Lt. Cmndr. Joseph /Allen/ ( jr. ) In this example
 	// jr. is considered as the name suffix portion.
 	//
 	// The NameNode provides a Suffix() function.
-	TagNameSuffix = newTag("NSFX", "Name Suffix", false)
+	TagNameSuffix = newTag("NSFX", "Name Suffix", tagOptionNone)
 
 	// Pertaining to a grouping of attributes used in describing something.
 	// Usually referring to the data required to represent a multimedia object,
 	// such an audio recording, a photograph of a person, or an image of a
 	// document.
-	TagObject = newTag("OBJE", "Object", false)
+	TagObject = newTag("OBJE", "Object", tagOptionNone)
 
 	// The type of work or profession of an individual.
-	TagOccupation = newTag("OCCU", "Occupation", false)
+	TagOccupation = newTag("OCCU", "Occupation", tagOptionNone)
 
 	// Pertaining to a religious ordinance in general.
-	TagOrdinance = newTag("ORDI", "Ordinance", false)
+	TagOrdinance = newTag("ORDI", "Ordinance", tagOptionNone)
 
 	// A religious event of receiving authority to act in religious matters.
-	TagOrdination = newTag("ORDN", "Ordination", true)
+	TagOrdination = newTag("ORDN", "Ordination", tagOptionEvent)
 
 	// A number or description to identify where information can be found in a
 	// referenced work.
-	TagPage = newTag("PAGE", "Page", false)
+	TagPage = newTag("PAGE", "Page", tagOptionNone)
 
 	// Information pertaining to an individual to parent lineage chart.
-	TagPedigree = newTag("PEDI", "Pedigree", false)
+	TagPedigree = newTag("PEDI", "Pedigree", tagOptionNone)
 
 	// A unique number assigned to access a specific telephone.
-	TagPhone = newTag("PHON", "Phone", false)
+	TagPhone = newTag("PHON", "Phone", tagOptionNone)
 
 	// A jurisdictional name to identify the place or location of an event.
-	TagPlace = newTag("PLAC", "Place", false)
+	TagPlace = newTag("PLAC", "Place", tagOptionNone)
 
 	// A code used by a postal service to identify an area to facilitate mail
 	// handling.
-	TagPostalCode = newTag("POST", "Postal Code", false)
+	TagPostalCode = newTag("POST", "Postal Code", tagOptionNone)
 
 	// An event of judicial determination of the validity of a will. May
 	// indicate several related court activities over several dates.
-	TagProbate = newTag("PROB", "Probate", true)
+	TagProbate = newTag("PROB", "Probate", tagOptionEvent)
 
 	// Pertaining to possessions such as real estate or other property of
 	// interest.
-	TagProperty = newTag("PROP", "Property", false)
+	TagProperty = newTag("PROP", "Property", tagOptionNone)
 
 	// Refers to when and/or were a work was published or created.
-	TagPublication = newTag("PUBL", "Publication", false)
+	TagPublication = newTag("PUBL", "Publication", tagOptionNone)
 
 	// An assessment of the certainty of the evidence to support the conclusion
 	// drawn from evidence.
-	TagQualityOfData = newTag("QUAY", "Quality Of Data", false)
+	TagQualityOfData = newTag("QUAY", "Quality Of Data", tagOptionNone)
 
 	// A description or number used to identify an item for filing, storage, or
 	// other reference purposes.
-	TagReference = newTag("REFN", "Reference", false)
+	TagReference = newTag("REFN", "Reference", tagOptionNone)
 
 	// A relationship value between the indicated contexts.
-	TagRelationship = newTag("RELA", "Relationship", false)
+	TagRelationship = newTag("RELA", "Relationship", tagOptionNone)
 
 	// A religious denomination to which a person is affiliated or for which a
 	// record applies.
-	TagReligion = newTag("RELI", "Religion", false)
+	TagReligion = newTag("RELI", "Religion", tagOptionNone)
 
 	// An institution or person that has the specified item as part of their
 	// collection(s).
-	TagRepository = newTag("REPO", "Repository", false)
+	TagRepository = newTag("REPO", "Repository", tagOptionNone)
 
-	// The act of dwelling at an address for a period of time.
-	TagResidence = newTag("RESI", "Residence", true)
+	// See ResidenceNode.
+	TagResidence = newTag("RESI", "Residence", tagOptionEvent)
 
 	// A processing indicator signifying access to information has been denied
 	// or otherwise restricted.
-	TagRestriction = newTag("RESN", "Restriction", false)
+	TagRestriction = newTag("RESN", "Restriction", tagOptionNone)
 
 	// An event of exiting an occupational relationship with an employer after a
 	// qualifying time period.
-	TagRetirement = newTag("RETI", "Retirement", true)
+	TagRetirement = newTag("RETI", "Retirement", tagOptionEvent)
 
 	// A permanent number assigned to a record that uniquely identifies it
 	// within a known file.
-	TagRecordFileNumber = newTag("RFN", "Record File Number", false)
+	TagRecordFileNumber = newTag("RFN", "Record File Number", tagOptionNone)
 
 	// A number assigned to a record by an originating automated system that can
 	// be used by a receiving system to report results pertaining to that
 	// record.
-	TagRecordIDNumber = newTag("RIN", "Record ID Number", false)
+	TagRecordIDNumber = newTag("RIN", "Record ID Number", tagOptionNone)
 
 	// A name given to a role played by an individual in connection with an
 	// event.
-	TagRole = newTag("ROLE", "Role", false)
+	TagRole = newTag("ROLE", "Role", tagOptionNone)
 
 	// A romanized variation of a superior text string. New in Gedcom 5.5.1.
-	TagRomanized = newTag("ROMN", "Romanized", false)
+	TagRomanized = newTag("ROMN", "Romanized", tagOptionNone)
 
 	// Indicates the sex of an individual--male or female.
-	TagSex = newTag("SEX", "Sex", false)
+	TagSex = newTag("SEX", "Sex", tagOptionNone)
 
 	// A religious event pertaining to the sealing of a child to his or her
 	// parents in an LDS temple ceremony.
-	TagSealingChild = newTag("SLGC", "Sealing Child", true)
+	TagSealingChild = newTag("SLGC", "Sealing Child", tagOptionEvent)
 
 	// A religious event pertaining to the sealing of a husband and wife in an
 	// LDS temple ceremony.
-	TagSealingSpouse = newTag("SLGS", "Sealing Spouse", true)
+	TagSealingSpouse = newTag("SLGS", "Sealing Spouse", tagOptionEvent)
 
 	// The initial or original material from which information was obtained.
-	TagSource = newTag("SOUR", "Source", false)
+	TagSource = newTag("SOUR", "Source", tagOptionNone)
 
 	// A name piece used as a non-indexing pre-part of a surname.
-	TagSurnamePrefix = newTag("SPFX", "Surname Prefix", false)
+	TagSurnamePrefix = newTag("SPFX", "Surname Prefix", tagOptionNone)
 
 	// A number assigned by the United States Social Security Administration.
 	// Used for tax identification purposes.
-	TagSocialSecurityNumber = newTag("SSN", "Social Security Number", false)
+	TagSocialSecurityNumber = newTag("SSN", "Social Security Number", tagOptionNone)
 
 	// A geographical division of a larger jurisdictional area, such as a State
 	// within the United States of America.
-	TagState = newTag("STAE", "State", false)
+	TagState = newTag("STAE", "State", tagOptionNone)
 
 	// An assessment of the state or condition of something.
-	TagStatus = newTag("STAT", "Status", false)
+	TagStatus = newTag("STAT", "Status", tagOptionNone)
 
 	// An individual or organization who contributes genealogical data to a file
 	// or transfers it to someone else.
-	TagSubmitter = newTag("SUBM", "Submitter", false)
+	TagSubmitter = newTag("SUBM", "Submitter", tagOptionNone)
 
 	// Pertains to a collection of data issued for processing.
-	TagSubmission = newTag("SUBN", "Submission", false)
+	TagSubmission = newTag("SUBN", "Submission", tagOptionNone)
 
 	// A family name passed on or used by members of a family.
 	//
 	// The NameNode provides a Surname() function.
-	TagSurname = newTag("SURN", "Surname", false)
+	TagSurname = newTag("SURN", "Surname", tagOptionNone)
 
 	// The name or code that represents the name a temple of the LDS Church.
-	TagTemple = newTag("TEMP", "Temple", false)
+	TagTemple = newTag("TEMP", "Temple", tagOptionNone)
 
 	// The exact wording found in an original source document.
-	TagText = newTag("TEXT", "Text", false)
+	TagText = newTag("TEXT", "Text", tagOptionNone)
 
 	// A time value in a 24-hour clock format, including hours, minutes, and
 	// optional seconds, separated by a colon (:). Fractions of seconds are
 	// shown in decimal notation.
-	TagTime = newTag("TIME", "Time", false)
+	TagTime = newTag("TIME", "Time", tagOptionNone)
 
 	// A description of a specific writing or other work, such as the title of a
 	// book when used in a source context, or a formal designation used by an
@@ -564,73 +573,73 @@ var (
 	// status, such as Grand Duke.
 	//
 	// The NameNode provides a Title() function.
-	TagTitle = newTag("TITL", "Title", false)
+	TagTitle = newTag("TITL", "Title", tagOptionNone)
 
 	// At level 0, specifies the end of a GEDCOM transmission.
-	TagTrailer = newTag("TRLR", "Trailer", false)
+	TagTrailer = newTag("TRLR", "Trailer", tagOptionNone)
 
 	// A further qualification to the meaning of the associated superior tag.
 	// The value does not have any computer processing reliability. It is more
 	// in the form of a short one or two word note that should be displayed any
 	// time the associated data is displayed.
-	TagType = newTag("TYPE", "Type", false)
+	TagType = newTag("TYPE", "Type", tagOptionNone)
 
 	// Indicates which version of a product, item, or publication is being used
 	// or referenced.
-	TagVersion = newTag("VERS", "Version", false)
+	TagVersion = newTag("VERS", "Version", tagOptionNone)
 
 	// An individual in the role as a mother and/or married woman.
-	TagWife = newTag("WIFE", "Wife", false)
+	TagWife = newTag("WIFE", "Wife", tagOptionNone)
 
 	// World Wide Web home page. New in Gedcom 5.5.1.
-	TagWWW = newTag("WWW", "WWW", false)
+	TagWWW = newTag("WWW", "WWW", tagOptionNone)
 
 	// A legal document treated as an event, by which a person disposes of his
 	// or her estate, to take effect after death. The event date is the date the
 	// will was signed while the person was alive. (See also PROBate)
-	TagWill = newTag("WILL", "Will", true)
+	TagWill = newTag("WILL", "Will", tagOptionEvent)
 )
 
 var (
 	// Unofficial. The unique identifier for the person on FamilySearch.org.
 	// This has been seen exported from MacFamilyFree.
-	UnofficialTagFamilySearchID = newTag("_FID", "FamilySearch ID", false)
+	UnofficialTagFamilySearchID = newTag("_FID", "FamilySearch ID", tagOptionNone)
 
 	// Unofficial. Latitude degrees. This has been seen exported from
 	// MacFamilyFree.
-	UnofficialTagLatitudeDegrees = newTag("_LAD", "Latitude Degrees", false)
+	UnofficialTagLatitudeDegrees = newTag("_LAD", "Latitude Degrees", tagOptionNone)
 
 	// Unofficial. Latitude minutes. This has been seen exported from
 	// MacFamilyFree.
-	UnofficialTagLatitudeMinutes = newTag("_LAM", "Latitude Minutes", false)
+	UnofficialTagLatitudeMinutes = newTag("_LAM", "Latitude Minutes", tagOptionNone)
 
 	// Unofficial. Latitude seconds. This has been seen exported from
 	// MacFamilyFree.
-	UnofficialTagLatitudeSeconds = newTag("_LAS", "Latitude Seconds", false)
+	UnofficialTagLatitudeSeconds = newTag("_LAS", "Latitude Seconds", tagOptionNone)
 
 	// Unofficial. Longitude degrees. This has been seen exported from
 	// MacFamilyFree.
-	UnofficialTagLongitudeDegress = newTag("_LOD", "Longitude Degress", false)
+	UnofficialTagLongitudeDegress = newTag("_LOD", "Longitude Degress", tagOptionNone)
 
 	// Unofficial. Longitude minutes. This has been seen exported from
 	// MacFamilyFree.
-	UnofficialTagLongitudeMinutes = newTag("_LOM", "Longitude Minutes", false)
+	UnofficialTagLongitudeMinutes = newTag("_LOM", "Longitude Minutes", tagOptionNone)
 
 	// Unofficial. Longitude north? This has been seen exported from
 	// MacFamilyFree.
-	UnofficialTagLongitudeNorth = newTag("_LON", "Longitude North", false)
+	UnofficialTagLongitudeNorth = newTag("_LON", "Longitude North", tagOptionNone)
 
 	// Unofficial. Longitude seconds. This has been seen exported from
 	// MacFamilyFree.
-	UnofficialTagLongitudeSeconds = newTag("_LOS", "Longitude Seconds", false)
+	UnofficialTagLongitudeSeconds = newTag("_LOS", "Longitude Seconds", tagOptionNone)
 
 	// Unofficial. Used to group the _LA* and _LO* tags for latitude and
 	// longitude. This has been seen exported from MacFamilyFree.
-	UnofficialTagCoordinates = newTag("_COR", "Coordinates", false)
+	UnofficialTagCoordinates = newTag("_COR", "Coordinates", tagOptionNone)
 
 	// Unofficial. The created date and/or time. This has been seen exported
 	// from Ancestry.com.
-	UnofficialTagCreated = newTag("_CRE", "Created", false)
+	UnofficialTagCreated = newTag("_CRE", "Created", tagOptionNone)
 )
 
 // TagFromString returns known tag constant like TagHeader from it's raw string
@@ -647,10 +656,8 @@ func TagFromString(tag string) Tag {
 	}
 
 	return Tag{
-		known:   false,
-		tag:     tag,
-		name:    tag,
-		isEvent: false,
+		tag:  tag,
+		name: tag,
 	}
 }
 
@@ -724,7 +731,7 @@ func (tag Tag) IsOfficial() bool {
 // It is important to note that tags thar are not seen as events can still have
 // dates and place attached to them.
 func (tag Tag) IsEvent() bool {
-	return tag.isEvent
+	return tag.options&tagOptionEvent != 0
 }
 
 // Tag returns the raw GEDCOM name for the tag, like "MARR".
@@ -732,17 +739,17 @@ func (tag Tag) Tag() string {
 	return tag.tag
 }
 
-// Known returns true if the tag can provide extra information like IsEvent,
+// IsKnown returns true if the tag can provide extra information like IsEvent,
 // IsOfficial, etc. If you are using the Tag or UnofficialTag variables provided
 // by this will always return true.
-func (tag Tag) Known() bool {
-	return tag.known
+func (tag Tag) IsKnown() bool {
+	return tag.isKnown
 }
 
 // newTag is used to create and register a tag. It is for internal use only and
 // should only be used for tags that are known, otherwise initialise the tag
 // manually with Tag{}.
-func newTag(tag, name string, isEvent bool) Tag {
+func newTag(tag, name string, options int) Tag {
 	if knownTags == nil {
 		knownTags = map[string]Tag{}
 	}
@@ -754,10 +761,10 @@ func newTag(tag, name string, isEvent bool) Tag {
 	}
 
 	knownTags[tag] = Tag{
-		known:   true,
+		isKnown: true,
 		tag:     tag,
 		name:    name,
-		isEvent: isEvent,
+		options: options,
 	}
 
 	return knownTags[tag]

--- a/tag_test.go
+++ b/tag_test.go
@@ -219,7 +219,7 @@ func TestTags(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.tag, func(t *testing.T) {
-			if test.expected.Known() {
+			if test.expected.IsKnown() {
 				assert.Contains(t, gedcom.Tags(), test.expected)
 			} else {
 				assert.NotContains(t, gedcom.Tags(), test.expected)
@@ -268,7 +268,7 @@ func TestTag_Known(t *testing.T) {
 	for _, tag := range gedcom.Tags() {
 		t.Run(tag.String(), func(t *testing.T) {
 			expected := tagTests[tag.Tag()]
-			assert.Equal(t, expected.isKnown, tag.Known())
+			assert.Equal(t, expected.isKnown, tag.IsKnown())
 		})
 	}
 }

--- a/util.go
+++ b/util.go
@@ -108,23 +108,21 @@ func Compound(nodes ...interface{}) []Node {
 	result := []Node{}
 
 	for _, n := range nodes {
-		switch i := n.(type) {
-		case nil:
+		v := reflect.ValueOf(n)
+
+		switch v.Kind() {
+		case reflect.Invalid:
 			// Ignore
 
-		case Node:
-			result = append(result, i)
-
-		case []Node:
-			// Should this be replaced with a function that removes nil items?
-			for _, item := range i {
-				if item != nil {
-					result = append(result, item)
+		case reflect.Slice:
+			for i := 0; i < v.Len(); i++ {
+				if j := v.Index(i).Interface(); j != nil {
+					result = append(result, j.(Node))
 				}
 			}
 
 		default:
-			panic("cannot compound type: " + reflect.TypeOf(i).Name())
+			result = append(result, v.Interface().(Node))
 		}
 	}
 


### PR DESCRIPTION
- Greatly improved CompareNodes to use Equals instead of the previous node flattening technique that wasn't able to handle many scenarios. This required a lot of thought into how Equals works and is implemented for some nodes that already exist, but that also need to be created.
- Added BirthNode for BIRT tag.
- Added ResidenceNode for RESI tag.
- Added NewDocument() to easily create an empty document.
- Fixed a bug in Compound() where slices of non-Node caused a panic.
- Refactored the way options can be set on tags internally. This will make it a lot easier in the future to add more binary attributes to Tag constants.
- Changed Tag.Known to Tag.IsKnown which is more consistenly named with other boolean functions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/gedcom/80)
<!-- Reviewable:end -->
