### PR TITLE
Added NodeDiff.IsDeepEqual. Fixes #86

### DIFF
--- a/node_diff_test.go
+++ b/node_diff_test.go
@@ -1,10 +1,11 @@
 package gedcom_test
 
 import (
-	"github.com/elliotchance/gedcom"
-	"github.com/stretchr/testify/assert"
 	"strings"
 	"testing"
+
+	"github.com/elliotchance/gedcom"
+	"github.com/stretchr/testify/assert"
 )
 
 func parse(s ...string) []gedcom.Node {
@@ -264,6 +265,87 @@ func TestCompareNodes(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			actual := gedcom.CompareNodes(test.left, test.right)
 			assert.Equal(t, test.expected.String(), actual.String())
+		})
+	}
+}
+
+func TestNodeDiff_IsDeepEqual(t *testing.T) {
+	d := &gedcom.NodeDiff{
+		Left:  parse("0 INDI @P3@")[0],
+		Right: parse("0 INDI @P3@")[0],
+		Children: []*gedcom.NodeDiff{
+			{
+				Left:  parse("0 NAME John /Smith/")[0],
+				Right: parse("0 NAME John /Smith/")[0],
+			},
+			{
+				Left:  parse("0 BIRT")[0],
+				Right: parse("0 BIRT")[0],
+				Children: []*gedcom.NodeDiff{
+					{
+						Left: parse("0 DATE Abt. Oct 1943")[0],
+					},
+					{
+						Left:  parse("0 DATE 3 SEP 1943")[0],
+						Right: parse("0 DATE 3 SEP 1943")[0],
+					},
+					{
+						Right: parse("0 DATE Abt. Sep 1943")[0],
+					},
+				},
+			},
+			{
+				Left:  parse("0 DEAT")[0],
+				Right: parse("0 DEAT")[0],
+				Children: []*gedcom.NodeDiff{
+					{
+						Left:  parse("0 PLAC England")[0],
+						Right: parse("0 PLAC England")[0],
+					},
+				},
+			},
+			{
+				Right: parse("0 NAME J. /Smith/")[0],
+			},
+		},
+	}
+
+	assert.Equal(t, strings.TrimSpace(`
+LR 0 INDI @P3@
+LR 1 NAME John /Smith/
+LR 1 BIRT
+L  2 DATE Abt. Oct 1943
+LR 2 DATE 3 SEP 1943
+ R 2 DATE Abt. Sep 1943
+LR 1 DEAT
+LR 2 PLAC England
+ R 1 NAME J. /Smith/`),
+		d.String())
+
+	tests := []struct {
+		line     string
+		nd       *gedcom.NodeDiff
+		expected bool
+	}{
+		{"LR 0 INDI @P3@", d, false},
+		{"LR 0 NAME John /Smith/", d.Children[0], true},
+
+		{"LR 0 BIRT", d.Children[1], false},
+		{"L  0 DATE Abt. Oct 1943", d.Children[1].Children[0], false},
+		{"LR 0 DATE 3 SEP 1943", d.Children[1].Children[1], true},
+		{" R 0 DATE Abt. Sep 1943", d.Children[1].Children[2], false},
+
+		{"LR 0 DEAT", d.Children[2], true},
+		{"LR 0 PLAC England", d.Children[2].Children[0], true},
+
+		{" R 0 NAME J. /Smith/", d.Children[3], false},
+	}
+
+	for _, test := range tests {
+		t.Run("", func(t *testing.T) {
+			firstLine := strings.Split(test.nd.String(), "\n")[0]
+			assert.Equal(t, test.line, firstLine)
+			assert.Equal(t, test.expected, test.nd.IsDeepEqual())
 		})
 	}
 }


### PR DESCRIPTION
IsDeepEqual returns true if the current NodeDiff and all of its children have been assigned to the left and right.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/gedcom/88)
<!-- Reviewable:end -->
