### PR TITLE
Add SimpleNameFilter(). Fixes #81

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -90,3 +90,21 @@ func OfficialTagFilter() FilterFunction {
 		return NodeCondition(isOfficial, node, nil), isOfficial
 	}
 }
+
+// SimpleNameFilter flattens NAME nodes.
+//
+// This is useful for comparing names when the components of the name (title,
+// suffix, etc) are less important than the name itself.
+//
+// The new name nodes will have a value constructed with NameNode.GedcomName.
+func SimpleNameFilter() FilterFunction {
+	return func(node Node) (Node, bool) {
+		if name, ok := node.(*NameNode); ok {
+			newNode := NewNameNode(name.Document(), name.GedcomName(), name.Pointer(), nil)
+
+			return newNode, false
+		}
+
+		return node, true
+	}
+}

--- a/filter_test.go
+++ b/filter_test.go
@@ -239,3 +239,61 @@ func TestOfficialTagFilter(t *testing.T) {
 		})
 	}
 }
+
+func TestSimpleNameFilter(t *testing.T) {
+	for _, test := range []struct {
+		root     gedcom.Node
+		expected string
+	}{
+		{
+			root: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
+				gedcom.NewNameNode(nil, "Elliot /Chance/", "", nil),
+				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
+					gedcom.NewDateNode(nil, "6 MAY 1989", "", nil),
+				}),
+			}),
+			expected: `0 @P1@ INDI
+1 NAME Elliot /Chance/
+1 BIRT
+2 DATE 6 MAY 1989
+`,
+		},
+		{
+			root: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
+				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
+					gedcom.NewDateNode(nil, "6 MAY 1989", "", nil),
+				}),
+				gedcom.NewNameNode(nil, "Elliot /Chance/", "", []gedcom.Node{
+					gedcom.NewSimpleNode(nil, gedcom.TagSurname, "Smith", "", nil),
+				}),
+			}),
+			expected: `0 @P1@ INDI
+1 BIRT
+2 DATE 6 MAY 1989
+1 NAME Elliot /Smith/
+`,
+		},
+		{
+			root: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
+				gedcom.NewNameNode(nil, "", "", []gedcom.Node{
+					gedcom.NewSimpleNode(nil, gedcom.TagGivenName, "Bob", "", nil),
+					gedcom.NewSimpleNode(nil, gedcom.TagSurname, "Smith", "", nil),
+				}),
+				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
+					gedcom.NewDateNode(nil, "6 MAY 1989", "", nil),
+				}),
+			}),
+			expected: `0 @P1@ INDI
+1 NAME Bob /Smith/
+1 BIRT
+2 DATE 6 MAY 1989
+`,
+		},
+	} {
+		t.Run("", func(t *testing.T) {
+			filter := gedcom.SimpleNameFilter()
+			result := gedcom.NodeGedcom(gedcom.Filter(test.root, filter))
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}

--- a/name_node.go
+++ b/name_node.go
@@ -24,25 +24,17 @@ func (node *NameNode) parts() []string {
 	return nameRegexp.FindStringSubmatch(node.value)
 }
 
-func (node *NameNode) trimSpaces(s string) string {
-	// Run this twice to make sure we reduce odd numbers of spaces down.
-	s = strings.Replace(s, "  ", " ", -1)
-	s = strings.Replace(s, "  ", " ", -1)
-
-	return strings.TrimSpace(s)
-}
-
 // GivenName is the given or earned name used for official identification of a
 // person. It is also commonly known as the "first name".
 func (node *NameNode) GivenName() string {
 	// GivenName is the proper first name.
 	givenNames := NodesWithTag(node, TagGivenName)
 	if len(givenNames) > 0 {
-		return node.trimSpaces(givenNames[0].Value())
+		return CleanSpace(givenNames[0].Value())
 	}
 
 	// Fall back to trying to extract the first name from NAME tag.
-	return node.trimSpaces(node.parts()[1])
+	return CleanSpace(node.parts()[1])
 }
 
 // Surname is a family name passed on or used by members of a family.
@@ -50,11 +42,11 @@ func (node *NameNode) Surname() string {
 	// Surname is the proper last name.
 	surnames := NodesWithTag(node, TagSurname)
 	if len(surnames) > 0 {
-		return node.trimSpaces(surnames[0].Value())
+		return CleanSpace(surnames[0].Value())
 	}
 
 	// Fallback to trying to extract the surname from the NAME tag.
-	lastName := node.trimSpaces(node.parts()[2])
+	lastName := CleanSpace(node.parts()[2])
 	if lastName == "" {
 		return ""
 	}
@@ -68,7 +60,7 @@ func (node *NameNode) Prefix() string {
 	// prefix should be returned.
 	namePrefixes := NodesWithTag(node, TagNamePrefix)
 	if len(namePrefixes) > 0 {
-		return node.trimSpaces(namePrefixes[0].Value())
+		return CleanSpace(namePrefixes[0].Value())
 	}
 
 	return ""
@@ -78,18 +70,18 @@ func (node *NameNode) Suffix() string {
 	// NameSuffix is the proper name suffix.
 	nameSuffixes := NodesWithTag(node, TagNameSuffix)
 	if len(nameSuffixes) > 0 {
-		return node.trimSpaces(nameSuffixes[0].Value())
+		return CleanSpace(nameSuffixes[0].Value())
 	}
 
 	// Otherwise fallback to trying to extract it from the NAME.
-	return node.trimSpaces(node.parts()[3])
+	return CleanSpace(node.parts()[3])
 }
 
 func (node *NameNode) SurnamePrefix() string {
 	// SurnameSuffix is the proper surname prefix.
 	surnamePrefixes := NodesWithTag(node, TagSurnamePrefix)
 	if len(surnamePrefixes) > 0 {
-		return node.trimSpaces(surnamePrefixes[0].Value())
+		return CleanSpace(surnamePrefixes[0].Value())
 	}
 
 	// Otherwise return nothing.
@@ -100,7 +92,7 @@ func (node *NameNode) Title() string {
 	// Title is the proper individual title.
 	titles := NodesWithTag(node, TagTitle)
 	if len(titles) > 0 {
-		return node.trimSpaces(titles[0].Value())
+		return CleanSpace(titles[0].Value())
 	}
 
 	// Otherwise return nothing.
@@ -108,7 +100,7 @@ func (node *NameNode) Title() string {
 }
 
 func (node *NameNode) String() string {
-	return node.trimSpaces(fmt.Sprintf("%s %s %s %s %s %s", node.Title(),
+	return CleanSpace(fmt.Sprintf("%s %s %s %s %s %s", node.Title(),
 		node.Prefix(), node.GivenName(), node.SurnamePrefix(), node.Surname(),
 		node.Suffix()))
 }
@@ -120,4 +112,20 @@ func (node *NameNode) Type() NameType {
 
 	// Otherwise return nothing.
 	return ""
+}
+
+// GedcomName returns the simplified GEDCOM name often used also as the value
+// for the NAME node.
+//
+// The only difference between this as String() is that the surname is
+// encapsulated inside forward slashes like:
+//
+//   Sir Elliot Rupert /Chance/ Sr
+//
+func (node *NameNode) GedcomName() string {
+	name := fmt.Sprintf("%s %s %s %s /%s/ %s", node.Title(),
+		node.Prefix(), node.GivenName(), node.SurnamePrefix(), node.Surname(),
+		node.Suffix())
+
+	return CleanSpace(strings.Replace(name, "//", "", -1))
 }

--- a/name_node_test.go
+++ b/name_node_test.go
@@ -8,13 +8,14 @@ import (
 
 var nameTests = []struct {
 	node          *gedcom.NameNode
-	title         string
-	prefix        string
-	givenName     string
-	surnamePrefix string
-	surname       string
-	suffix        string
-	str           string
+	title         string // Title()
+	prefix        string // Prefix()
+	givenName     string // GivenName()
+	surnamePrefix string // SurnamePrefix()
+	surname       string // Surname()
+	suffix        string // Suffix()
+	str           string // String()
+	gedcomName    string // GedcomName()
 }{
 	{
 		node:          gedcom.NewNameNode(nil, "", "", nil),
@@ -25,6 +26,7 @@ var nameTests = []struct {
 		surname:       "",
 		suffix:        "",
 		str:           "",
+		gedcomName:    "",
 	},
 	{
 		node:          gedcom.NewNameNode(nil, "/Double  Last/", "", nil),
@@ -35,6 +37,7 @@ var nameTests = []struct {
 		surname:       "Double Last",
 		suffix:        "",
 		str:           "Double Last",
+		gedcomName:    "/Double Last/",
 	},
 	{
 		node:          gedcom.NewNameNode(nil, "//", "", nil),
@@ -45,6 +48,7 @@ var nameTests = []struct {
 		surname:       "",
 		suffix:        "",
 		str:           "",
+		gedcomName:    "",
 	},
 	{
 		// This is an invalid case. I don't mind that the data returned seems
@@ -57,6 +61,7 @@ var nameTests = []struct {
 		surname:       "",
 		suffix:        "/ b",
 		str:           "a / b",
+		gedcomName:    "a / b",
 	},
 	{
 		node:          gedcom.NewNameNode(nil, "Double First", "", nil),
@@ -67,6 +72,7 @@ var nameTests = []struct {
 		surname:       "",
 		suffix:        "",
 		str:           "Double First",
+		gedcomName:    "Double First",
 	},
 	{
 		node:          gedcom.NewNameNode(nil, "First /Last/", "", nil),
@@ -77,6 +83,7 @@ var nameTests = []struct {
 		surname:       "Last",
 		suffix:        "",
 		str:           "First Last",
+		gedcomName:    "First /Last/",
 	},
 	{
 		node:          gedcom.NewNameNode(nil, "First   Middle /Last/", "", nil),
@@ -87,6 +94,7 @@ var nameTests = []struct {
 		surname:       "Last",
 		suffix:        "",
 		str:           "First Middle Last",
+		gedcomName:    "First Middle /Last/",
 	},
 	{
 		node:          gedcom.NewNameNode(nil, "First /Last/  Suffix ", "", nil),
@@ -97,6 +105,7 @@ var nameTests = []struct {
 		surname:       "Last",
 		suffix:        "Suffix",
 		str:           "First Last Suffix",
+		gedcomName:    "First /Last/ Suffix",
 	},
 	{
 		node:          gedcom.NewNameNode(nil, "   /Last/ Suffix", "", nil),
@@ -107,6 +116,7 @@ var nameTests = []struct {
 		surname:       "Last",
 		suffix:        "Suffix",
 		str:           "Last Suffix",
+		gedcomName:    "/Last/ Suffix",
 	},
 	{
 		// The GivenName overrides the givenName name if provided. When multiple
@@ -122,6 +132,7 @@ var nameTests = []struct {
 		surname:       "Last",
 		suffix:        "II",
 		str:           "Other Name Last II",
+		gedcomName:    "Other Name /Last/ II",
 	},
 	{
 		// The Surname overrides the surname name if provided. When multiple
@@ -137,6 +148,7 @@ var nameTests = []struct {
 		surname:       "Other name",
 		suffix:        "II",
 		str:           "First Other name II",
+		gedcomName:    "First /Other name/ II",
 	},
 	{
 		node: gedcom.NewNameNode(nil, "First /Last/ Esq.", "", []gedcom.Node{
@@ -150,6 +162,7 @@ var nameTests = []struct {
 		surname:       "Last",
 		suffix:        "Esq.",
 		str:           "Mr First Last Esq.",
+		gedcomName:    "Mr First /Last/ Esq.",
 	},
 	{
 		// The NameSuffix overrides the suffix in the name if provided.
@@ -167,6 +180,7 @@ var nameTests = []struct {
 		surname:       "Last",
 		suffix:        "Esq.",
 		str:           "Sir First Last Esq.",
+		gedcomName:    "Sir First /Last/ Esq.",
 	},
 	{
 		node: gedcom.NewNameNode(nil, "First /Last/ Esq.", "", []gedcom.Node{
@@ -180,6 +194,7 @@ var nameTests = []struct {
 		surname:       "Last",
 		suffix:        "Esq.",
 		str:           "First Foo Last Esq.",
+		gedcomName:    "First Foo /Last/ Esq.",
 	},
 	{
 		node: gedcom.NewNameNode(nil, "First /Last/ Esq.", "", []gedcom.Node{
@@ -193,6 +208,7 @@ var nameTests = []struct {
 		surname:       "Last",
 		suffix:        "Esq.",
 		str:           "Grand Duke First Last Esq.",
+		gedcomName:    "Grand Duke First /Last/ Esq.",
 	},
 }
 
@@ -248,6 +264,14 @@ func TestNameNode_String(t *testing.T) {
 	for _, test := range nameTests {
 		t.Run("", func(t *testing.T) {
 			assert.Equal(t, test.node.String(), test.str)
+		})
+	}
+}
+
+func TestNameNode_GedcomName(t *testing.T) {
+	for _, test := range nameTests {
+		t.Run("", func(t *testing.T) {
+			assert.Equal(t, test.node.GedcomName(), test.gedcomName)
 		})
 	}
 }


### PR DESCRIPTION
- SimpleNameFilter() flattens NAME nodes.
- Added GedcomName() to return the simplified GEDCOM name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/gedcom/95)
<!-- Reviewable:end -->
