### PR TITLE
Added "-subset". Fixes #105

### DIFF
--- a/gedcomdiff/diff_page.go
+++ b/gedcomdiff/diff_page.go
@@ -41,6 +41,11 @@ func (c *diffPage) String() string {
 	})
 
 	for _, comparison := range c.comparisons {
+		// Same as below.
+		if optionSubset && gedcom.IsNil(comparison.Right) {
+			continue
+		}
+
 		weightedSimilarity := comparison.Similarity.WeightedSimilarity(c.options)
 
 		leftClass := ""
@@ -56,6 +61,9 @@ func (c *diffPage) String() string {
 		case weightedSimilarity < 1:
 			leftClass = "bg-info"
 			rightClass = "bg-info"
+
+		case c.filterFlags.HideEqual:
+			continue
 		}
 
 		rows = append(rows, html.NewTableRow(
@@ -73,6 +81,11 @@ func (c *diffPage) String() string {
 		html.NewTable("", rows...),
 	}
 	for _, comparison := range c.comparisons {
+		// Same as above.
+		if optionSubset && gedcom.IsNil(comparison.Right) {
+			continue
+		}
+
 		components = append(components,
 			newIndividualCompare(comparison, c.filterFlags))
 	}

--- a/gedcomdiff/individual_compare.go
+++ b/gedcomdiff/individual_compare.go
@@ -38,10 +38,10 @@ func (c *individualCompare) String() string {
 
 	name := ""
 	if n := left; n != nil {
-		name = n.Name().String()
+		name = html.NewIndividualNameAndDates(n, true, "").String()
 	}
 	if n := right; name == "" && n != nil {
-		name = n.Name().String()
+		name = html.NewIndividualNameAndDates(n, true, "").String()
 	}
 
 	if !gedcom.IsNil(left) {

--- a/gedcomdiff/main.go
+++ b/gedcomdiff/main.go
@@ -14,6 +14,7 @@ var (
 	optionLeftGedcomFile  string
 	optionRightGedcomFile string
 	optionOutputFile      string
+	optionSubset          bool
 )
 
 var filterFlags = &util.FilterFlags{}
@@ -53,6 +54,10 @@ func parseCLIFlags() {
 	flag.StringVar(&optionLeftGedcomFile, "left-gedcom", "", "Left GEDCOM file.")
 	flag.StringVar(&optionRightGedcomFile, "right-gedcom", "", "Right GEDCOM file.")
 	flag.StringVar(&optionOutputFile, "output", "", "Output file.")
+	flag.BoolVar(&optionSubset, "subset", false, "When -subset is enabled the "+
+		"right side will be considered a smaller part of the larger left "+
+		"side. This means that individuals that entirely exist on the left "+
+		"side will not be included.")
 
 	filterFlags.SetupCLI()
 


### PR DESCRIPTION
- The "-subset" option allows a lerger tree to be compared to a smaller tree by excluding individuals that only exist on the left side.
- Hide individuals that are the same in the gedcomdiff index.
- Show the birth/death dates of individuals for their headings in case all of that vital information does not show below.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/gedcom/109)
<!-- Reviewable:end -->
