### PR TITLE
Close file handles in gedcom2html. Fixes #110

### DIFF
--- a/gedcom2html/main.go
+++ b/gedcom2html/main.go
@@ -78,4 +78,6 @@ func createFile(name string, contents fmt.Stringer) {
 	}
 
 	out.Write([]byte(contents.String()))
+
+	out.Close()
 }


### PR DESCRIPTION
When exporting a large tree (1600 people) it will error with too many files open.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/gedcom/111)
<!-- Reviewable:end -->
