### PR TITLE
Remove extra "," from place names. Fixes #21

### DIFF
--- a/gedcom2html/places.go
+++ b/gedcom2html/places.go
@@ -16,6 +16,7 @@ func prettyPlaceName(s string) string {
 	s = strings.Replace(s, ",,", ",", -1)
 	s = strings.Replace(s, ",,", ",", -1)
 	s = strings.Replace(s, ",", ", ", -1)
+	s = strings.Trim(s, ", ")
 
 	return strings.TrimSpace(s)
 }


### PR DESCRIPTION
In gedcom2html extra commas could appear before or after the place name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/gedcom/112)
<!-- Reviewable:end -->
