### PR TITLE
Using html.Sprintf to catch panics. Fixes #116

### DIFF
--- a/gedcom2html/badge_pill.go
+++ b/gedcom2html/badge_pill.go
@@ -1,6 +1,6 @@
 package main
 
-import "fmt"
+import "github.com/elliotchance/gedcom/html"
 
 // badgePill is a rounded badge that contains a value.
 type badgePill struct {
@@ -16,6 +16,6 @@ func newBadgePill(color, class, value string) *badgePill {
 }
 
 func (c *badgePill) String() string {
-	return fmt.Sprintf(`<span class="badge badge-pill badge-%s %s">%s</span>`,
+	return html.Sprintf(`<span class="badge badge-pill badge-%s %s">%s</span>`,
 		c.color, c.class, c.value)
 }

--- a/gedcom2html/family_in_list.go
+++ b/gedcom2html/family_in_list.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"fmt"
 	"github.com/elliotchance/gedcom"
+	"github.com/elliotchance/gedcom/html"
 )
 
 type familyInList struct {
@@ -23,7 +23,7 @@ func (c *familyInList) String() string {
 		date = n.Value()
 	}
 
-	return fmt.Sprintf(fmt.Sprintf(`
+	return html.Sprintf(`
 		<tr>
 			<td>%s</td>
 			<td nowrap="nowrap" class="text-center">%s</td>
@@ -31,5 +31,5 @@ func (c *familyInList) String() string {
 		</tr>`,
 		newIndividualLink(c.document, c.family.Husband()),
 		date,
-		newIndividualLink(c.document, c.family.Wife())))
+		newIndividualLink(c.document, c.family.Wife()))
 }

--- a/gedcom2html/individual_button.go
+++ b/gedcom2html/individual_button.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"github.com/elliotchance/gedcom"
 	"github.com/elliotchance/gedcom/html"
 )
@@ -26,7 +25,7 @@ func (c *individualButton) String() string {
 
 	onclick := ""
 	if c.individual != nil {
-		onclick = fmt.Sprintf(`onclick="location.href='%s'"`,
+		onclick = html.Sprintf(`onclick="location.href='%s'"`,
 			pageIndividual(c.document, c.individual))
 	}
 
@@ -38,7 +37,7 @@ func (c *individualButton) String() string {
 		onclick = ""
 	}
 
-	return fmt.Sprintf(`
+	return html.Sprintf(`
 		<button type="button" class="btn btn-outline-%s btn-block" %s>
 			<strong>%s</strong><br/>
 			%s&nbsp;

--- a/gedcom2html/individual_event.go
+++ b/gedcom2html/individual_event.go
@@ -1,6 +1,6 @@
 package main
 
-import "fmt"
+import "github.com/elliotchance/gedcom/html"
 
 // individualEvent is a row in the "Events" section of the individuals page.
 type individualEvent struct {
@@ -20,7 +20,7 @@ func newIndividualEvent(kind, date, place, description string) *individualEvent 
 }
 
 func (c *individualEvent) String() string {
-	return fmt.Sprintf(`
+	return html.Sprintf(`
 		<tr>
 			<th>%s</th>
 			<td>%s</td>

--- a/gedcom2html/individual_in_list.go
+++ b/gedcom2html/individual_in_list.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"github.com/elliotchance/gedcom"
 	"github.com/elliotchance/gedcom/html"
 )
@@ -35,7 +34,7 @@ func (c *individualInList) String() string {
 		deathDate = "-"
 	}
 
-	return fmt.Sprintf(fmt.Sprintf(`
+	return html.Sprintf(`
 		<tr>
 			<td nowrap="nowrap">%s</td>
 			<td>%s<br/>%s</td>
@@ -43,5 +42,5 @@ func (c *individualInList) String() string {
 		</tr>`,
 		newIndividualLink(c.document, c.individual),
 		birthDate, newPlaceLink(c.document, birthPlace),
-		deathDate, newPlaceLink(c.document, deathPlace)))
+		deathDate, newPlaceLink(c.document, deathPlace))
 }

--- a/gedcom2html/individual_index_letter.go
+++ b/gedcom2html/individual_index_letter.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"github.com/elliotchance/gedcom/html"
 	"unicode"
 )
 
@@ -23,7 +23,7 @@ func (c *individualIndexLetter) String() string {
 		active = "active"
 	}
 
-	return fmt.Sprintf(`
+	return html.Sprintf(`
 			<li class="nav-item">
     			<a class="nav-link %s" href="%s">%c</a>
   			</li>`,

--- a/gedcom2html/individual_link.go
+++ b/gedcom2html/individual_link.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"github.com/elliotchance/gedcom"
 	"github.com/elliotchance/gedcom/html"
 )
@@ -21,7 +20,7 @@ func newIndividualLink(document *gedcom.Document, individual *gedcom.IndividualN
 }
 
 func (c *individualLink) String() string {
-	return fmt.Sprintf(`
+	return html.Sprintf(`
 		<span class="octicon octicon-primitive-dot" style="color: %s; font-size: 18px"></span>
 		<a href="%s">%s</a>`,
 		colorForIndividual(c.individual),

--- a/gedcom2html/individual_list_page.go
+++ b/gedcom2html/individual_list_page.go
@@ -59,7 +59,7 @@ func (c *individualListPage) String() string {
 	return html.NewPage("Individuals", html.NewComponents(
 		newHeader(c.document, "", selectedIndividualsTab),
 		html.NewRow(
-			html.NewColumn(html.EntireRow, html.NewText(fmt.Sprintf(
+			html.NewColumn(html.EntireRow, html.NewText(html.Sprintf(
 				"%d individuals are hidden because they are living.",
 				livingCount,
 			))),

--- a/gedcom2html/keyed_table_row.go
+++ b/gedcom2html/keyed_table_row.go
@@ -1,6 +1,6 @@
 package main
 
-import "fmt"
+import "github.com/elliotchance/gedcom/html"
 
 // keyedTableRow is a table row consisting of two columns where the left column
 // is a header and a key for the data in the right column. It also allows the
@@ -23,7 +23,7 @@ func (c *keyedTableRow) String() string {
 		return ""
 	}
 
-	return fmt.Sprintf(`
+	return html.Sprintf(`
        <tr>
            <th scope="row">%s</th>
            <td>%s</td>

--- a/gedcom2html/nav_item.go
+++ b/gedcom2html/nav_item.go
@@ -1,8 +1,6 @@
 package main
 
-import (
-	"fmt"
-)
+import "github.com/elliotchance/gedcom/html"
 
 // navItem is a single tab in the tab bar.
 type navItem struct {
@@ -24,7 +22,7 @@ func (c *navItem) String() string {
 		active = "active"
 	}
 
-	return fmt.Sprintf(`
+	return html.Sprintf(`
 		<li class="nav-item">
 			<a class="nav-link %s" href="%s">%s</a>
 		</li>`, active, c.href, c.content)

--- a/gedcom2html/nav_tabs.go
+++ b/gedcom2html/nav_tabs.go
@@ -1,8 +1,6 @@
 package main
 
-import (
-	"fmt"
-)
+import "github.com/elliotchance/gedcom/html"
 
 // navTabs is a group of tabs.
 type navTabs struct {
@@ -21,7 +19,7 @@ func (c *navTabs) String() string {
 		tabs += tab.String()
 	}
 
-	return fmt.Sprintf(`
+	return html.Sprintf(`
     <div class="row">
         <div class="col">
             <ul class="nav nav-tabs">

--- a/gedcom2html/parent_buttons.go
+++ b/gedcom2html/parent_buttons.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"github.com/elliotchance/gedcom"
 	"github.com/elliotchance/gedcom/html"
 )
@@ -21,7 +20,7 @@ func newParentButtons(document *gedcom.Document, family *gedcom.FamilyNode) *par
 }
 
 func (c *parentButtons) String() string {
-	return fmt.Sprintf(`
+	return html.Sprintf(`
 		<div class="row">
 		   <div class="col-5">
 		       %s

--- a/gedcom2html/place_event.go
+++ b/gedcom2html/place_event.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"fmt"
 	"github.com/elliotchance/gedcom"
+	"github.com/elliotchance/gedcom/html"
 )
 
 type placeEvent struct {
@@ -36,10 +36,10 @@ func (c *placeEvent) String() string {
 		}
 	}
 
-	return fmt.Sprintf(fmt.Sprintf(`
+	return html.Sprintf(`
 		<tr>
 			<td nowrap="nowrap">%s</td>
 			<td nowrap="nowrap">%s</td>
 			<td nowrap="nowrap">%s</td>
-		</tr>`, date, description, person))
+		</tr>`, date, description, person)
 }

--- a/gedcom2html/place_in_list.go
+++ b/gedcom2html/place_in_list.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"fmt"
 	"github.com/elliotchance/gedcom"
+	"github.com/elliotchance/gedcom/html"
 )
 
 type placeInList struct {
@@ -18,10 +18,10 @@ func newPlaceInList(document *gedcom.Document, place *place) *placeInList {
 }
 
 func (c *placeInList) String() string {
-	return fmt.Sprintf(fmt.Sprintf(`
+	return html.Sprintf(`
 		<tr>
 			<td nowrap="nowrap">%s %s</td>
 		</tr>`,
 		newPlaceLink(c.document, c.place.prettyName),
-		newCountBadge(len(c.place.nodes))))
+		newCountBadge(len(c.place.nodes)))
 }

--- a/gedcom2html/place_link.go
+++ b/gedcom2html/place_link.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"fmt"
 	"github.com/elliotchance/gedcom"
+	"github.com/elliotchance/gedcom/html"
 )
 
 type placeLink struct {
@@ -18,7 +18,7 @@ func newPlaceLink(document *gedcom.Document, place string) *placeLink {
 }
 
 func (c *placeLink) String() string {
-	return fmt.Sprintf(`
+	return html.Sprintf(`
 		<a href="%s">%s</a>`,
 		pagePlace(c.document, c.place), c.place)
 }

--- a/gedcom2html/plus_svg.go
+++ b/gedcom2html/plus_svg.go
@@ -1,6 +1,6 @@
 package main
 
-import "fmt"
+import "github.com/elliotchance/gedcom/html"
 
 // plusSVG draws a "+" as an SVG with each line of the "+" being optional.
 type plusSVG struct {
@@ -45,7 +45,7 @@ func (c *plusSVG) String() string {
 		vLineY2 = 80
 	}
 
-	return fmt.Sprintf(`
+	return html.Sprintf(`
 		<svg style="width: 100%%; height: 75px">
 			<line x1="%d%%" y1="%d%%" x2="%d%%" y2="%d%%" style="stroke:rgb(0,0,0);stroke-width:3" />
 			<line x1="%d%%" y1="%d%%" x2="%d%%" y2="%d%%" style="stroke:rgb(0,0,0);stroke-width:3" />

--- a/gedcom2html/sex_badge.go
+++ b/gedcom2html/sex_badge.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"fmt"
 	"github.com/elliotchance/gedcom"
+	"github.com/elliotchance/gedcom/html"
 )
 
 // sexBadge shows a coloured "Male", "Female" or "Unknown" badge.
@@ -17,6 +17,6 @@ func newSexBadge(sex gedcom.Sex) *sexBadge {
 }
 
 func (c *sexBadge) String() string {
-	return fmt.Sprintf(`<span class="badge badge-%s">%s</span>`,
+	return html.Sprintf(`<span class="badge badge-%s">%s</span>`,
 		colorClassForSex(c.sex), c.sex)
 }

--- a/gedcom2html/source_in_list.go
+++ b/gedcom2html/source_in_list.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"fmt"
 	"github.com/elliotchance/gedcom"
+	"github.com/elliotchance/gedcom/html"
 )
 
 type sourceInList struct {
@@ -18,8 +18,8 @@ func newSourceInList(document *gedcom.Document, source *gedcom.SourceNode) *sour
 }
 
 func (c *sourceInList) String() string {
-	return fmt.Sprintf(fmt.Sprintf(`
+	return html.Sprintf(`
 		<tr>
 			<td>%s</td>
-		</tr>`, newSourceLink(c.source)))
+		</tr>`, newSourceLink(c.source))
 }

--- a/gedcom2html/source_link.go
+++ b/gedcom2html/source_link.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"fmt"
 	"github.com/elliotchance/gedcom"
+	"github.com/elliotchance/gedcom/html"
 )
 
 type sourceLink struct {
@@ -16,7 +16,7 @@ func newSourceLink(source *gedcom.SourceNode) *sourceLink {
 }
 
 func (c *sourceLink) String() string {
-	return fmt.Sprintf(`
+	return html.Sprintf(`
 		<a href="%s">%s</a>`,
 		pageSource(c.source), c.source.Title())
 }

--- a/gedcom2html/source_property.go
+++ b/gedcom2html/source_property.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"fmt"
 	"github.com/elliotchance/gedcom"
+	"github.com/elliotchance/gedcom/html"
 )
 
 type sourceProperty struct {
@@ -18,7 +18,7 @@ func newSourceProperty(document *gedcom.Document, node gedcom.Node) *sourcePrope
 }
 
 func (c *sourceProperty) String() string {
-	s := fmt.Sprintf(`
+	s := html.Sprintf(`
 		<tr>
 			<th nowrap="nowrap">%s</th>
 			<td>%s</td>

--- a/html/div.go
+++ b/html/div.go
@@ -18,5 +18,5 @@ func NewDiv(class string, body fmt.Stringer) *Div {
 }
 
 func (c *Div) String() string {
-	return fmt.Sprintf(`<div class="%s">%s</div>`, c.class, c.body)
+	return Sprintf(`<div class="%s">%s</div>`, c.class, c.body)
 }

--- a/html/event_date.go
+++ b/html/event_date.go
@@ -1,7 +1,5 @@
 package html
 
-import "fmt"
-
 // EventDate shows a date like "d. 1882" but will not show anything if the date
 // is not provided.
 type EventDate struct {
@@ -21,5 +19,5 @@ func (c *EventDate) String() string {
 		return ""
 	}
 
-	return fmt.Sprintf("<em>%s</em> %s", c.event, c.date)
+	return Sprintf("<em>%s</em> %s", c.event, c.date)
 }

--- a/html/google_analytics.go
+++ b/html/google_analytics.go
@@ -1,9 +1,5 @@
 package html
 
-import (
-	"fmt"
-)
-
 type GoogleAnalytics struct {
 	id string
 }
@@ -19,7 +15,7 @@ func (c *GoogleAnalytics) String() string {
 		return ""
 	}
 
-	return fmt.Sprintf(`<!-- Global site tag (gtag.js) - Google Analytics -->
+	return Sprintf(`<!-- Global site tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=%s"></script>
 <script>
 window.dataLayer = window.dataLayer || [];

--- a/html/heading.go
+++ b/html/heading.go
@@ -1,9 +1,5 @@
 package html
 
-import (
-	"fmt"
-)
-
 // Heading is larger text.
 type Heading struct {
 	text, class string
@@ -19,6 +15,6 @@ func NewHeading(number int, class, text string) *Heading {
 }
 
 func (c *Heading) String() string {
-	return fmt.Sprintf(`<h%d class="%s">%s</h%d>`,
+	return Sprintf(`<h%d class="%s">%s</h%d>`,
 		c.number, c.class, c.text, c.number)
 }

--- a/html/individual_name_and_dates.go
+++ b/html/individual_name_and_dates.go
@@ -1,7 +1,6 @@
 package html
 
 import (
-	"fmt"
 	"github.com/elliotchance/gedcom"
 )
 
@@ -27,5 +26,5 @@ func (c *IndividualNameAndDates) String() string {
 		return name
 	}
 
-	return fmt.Sprintf("%s (%s)", name, dates)
+	return Sprintf("%s (%s)", name, dates)
 }

--- a/html/page.go
+++ b/html/page.go
@@ -22,7 +22,7 @@ func NewPage(title string, body fmt.Stringer, googleAnalyticsID string) *Page {
 }
 
 func (c *Page) String() string {
-	return fmt.Sprintf(`
+	return Sprintf(`
     <html>
 	<head>
 		%s

--- a/html/row.go
+++ b/html/row.go
@@ -1,9 +1,5 @@
 package html
 
-import (
-	"fmt"
-)
-
 const (
 	QuarterRow = 3
 	HalfRow    = 6
@@ -27,7 +23,7 @@ func (c *Row) String() string {
 		columns += column.String()
 	}
 
-	return fmt.Sprintf(`
+	return Sprintf(`
 		<div class="row">
 			%s
 		</div>`, columns)

--- a/html/styled_table_cell.go
+++ b/html/styled_table_cell.go
@@ -17,6 +17,6 @@ func NewStyledTableCell(style, class string, content fmt.Stringer) *StyledTableC
 }
 
 func (c *StyledTableCell) String() string {
-	return fmt.Sprintf(`<td scope="col" class="%s" style="%s">%s</td>`,
+	return Sprintf(`<td scope="col" class="%s" style="%s">%s</td>`,
 		c.class, c.style, c.content)
 }

--- a/html/table.go
+++ b/html/table.go
@@ -16,6 +16,6 @@ func NewTable(tableClass string, content ...fmt.Stringer) *Table {
 }
 
 func (c *Table) String() string {
-	return fmt.Sprintf(`<table class="table %s">%s</table>`,
+	return Sprintf(`<table class="table %s">%s</table>`,
 		c.tableClass, NewComponents(c.content...).String())
 }

--- a/html/table_cell.go
+++ b/html/table_cell.go
@@ -15,5 +15,5 @@ func NewTableCell(class string, content fmt.Stringer) *TableCell {
 }
 
 func (c *TableCell) String() string {
-	return fmt.Sprintf(`<td scope="col" class="%s">%s</td>`, c.class, c.content)
+	return Sprintf(`<td scope="col" class="%s">%s</td>`, c.class, c.content)
 }

--- a/html/table_head.go
+++ b/html/table_head.go
@@ -1,7 +1,5 @@
 package html
 
-import "fmt"
-
 // TableHead is the <thead> section of a table that contains the table heading
 // cells.
 type TableHead struct {
@@ -18,7 +16,7 @@ func (c *TableHead) String() string {
 	s := `<thead><tr>`
 
 	for _, column := range c.columns {
-		s += fmt.Sprintf(`<th scope="col">%s</th>`, column)
+		s += Sprintf(`<th scope="col">%s</th>`, column)
 	}
 
 	return s + `</tr></thead>`

--- a/html/util.go
+++ b/html/util.go
@@ -1,6 +1,9 @@
 package html
 
-import "github.com/elliotchance/gedcom"
+import (
+	"fmt"
+	"github.com/elliotchance/gedcom"
+)
 
 func GetBirth(individual *gedcom.IndividualNode) (birthDate string, birthPlace string) {
 	if individual == nil {
@@ -42,4 +45,17 @@ func GetDeath(individual *gedcom.IndividualNode) (deathDate string, deathPlace s
 	}
 
 	return
+}
+
+func Sprintf(format string, args ...interface{}) string {
+	newArgs := make([]interface{}, len(args))
+	for i, arg := range args {
+		if a, ok := arg.(fmt.Stringer); ok {
+			newArgs[i] = a.String()
+		} else {
+			newArgs[i] = arg
+		}
+	}
+
+	return fmt.Sprintf(format, newArgs...)
 }


### PR DESCRIPTION
When using fmt.Sprintf with HTML components that cause a panic it is supressed and difficult to debug. html.Sprintf will be able to test the String() during the render.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/gedcom/118)
<!-- Reviewable:end -->
