### PR TITLE
Show all event types on statistics page. Fixes #20 and #91

### DIFF
--- a/gedcom2html/event_statistics.go
+++ b/gedcom2html/event_statistics.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"fmt"
 	"github.com/elliotchance/gedcom"
 	"github.com/elliotchance/gedcom/html"
+	"sort"
 	"strconv"
 )
 
@@ -17,36 +19,35 @@ func newEventStatistics(document *gedcom.Document) *eventStatistics {
 }
 
 func (c *eventStatistics) String() string {
-	births := 0
-	christenings := 0
-	deaths := 0
-	burials := 0
+	counts := map[string]int{}
 
 	for _, individual := range c.document.Individuals() {
-		if date, _ := html.GetBirth(individual); date != "" {
-			births += 1
-		}
-
-		if date, _ := html.GetDeath(individual); date != "" {
-			deaths += 1
-		}
-
-		if n := gedcom.First(gedcom.NodesWithTagPath(individual, gedcom.TagChristening)); n != nil {
-			christenings += 1
-		}
-
-		if n := gedcom.First(gedcom.NodesWithTagPath(individual, gedcom.TagBurial)); n != nil {
-			burials += 1
+		for _, event := range individual.AllEvents() {
+			counts[event.Tag().String()] += 1
 		}
 	}
 
-	s := html.NewComponents(
-		newKeyedTableRow("Total", strconv.Itoa(births+christenings+deaths+burials), true),
-		newKeyedTableRow("Births", strconv.Itoa(births), true),
-		newKeyedTableRow("Christenings", strconv.Itoa(christenings), true),
-		newKeyedTableRow("Deaths", strconv.Itoa(deaths), true),
-		newKeyedTableRow("Burials", strconv.Itoa(burials), true),
-	)
+	total := 0
+	for _, count := range counts {
+		total += count
+	}
 
-	return newCard("Events", noBadgeCount, html.NewTable("", s)).String()
+	rows := []fmt.Stringer{
+		newKeyedTableRow("Total", strconv.Itoa(total), true),
+	}
+
+	keys := []string{}
+	for name := range counts {
+		keys = append(keys, name)
+	}
+
+	sort.Strings(keys)
+
+	for _, name := range keys {
+		rows = append(rows,
+			newKeyedTableRow(name, strconv.Itoa(counts[name]), true))
+	}
+
+	return newCard("Events", noBadgeCount,
+		html.NewTable("", html.NewComponents(rows...))).String()
 }

--- a/gedcom2html/individual_events.go
+++ b/gedcom2html/individual_events.go
@@ -23,7 +23,10 @@ func newIndividualEvents(document *gedcom.Document, individual *gedcom.Individua
 func (c *individualEvents) String() string {
 	events := []fmt.Stringer{}
 
-	birthDate, birthPlace := html.GetBirth(c.individual)
+	birth := gedcom.First(c.individual.Births())
+	birthDate := gedcom.String(gedcom.First(gedcom.Dates(birth)))
+	birthPlace := gedcom.String(gedcom.First(gedcom.Places(birth)))
+
 	events = append(events, newIndividualEvent("Birth", birthDate, birthPlace, ""))
 
 	for _, family := range c.individual.Families() {
@@ -67,7 +70,10 @@ func (c *individualEvents) String() string {
 		}
 	}
 
-	deathDate, deathPlace := html.GetDeath(c.individual)
+	death := gedcom.First(c.individual.Deaths())
+	deathDate := gedcom.String(gedcom.First(gedcom.Dates(death)))
+	deathPlace := gedcom.String(gedcom.First(gedcom.Places(death)))
+
 	events = append(events, newIndividualEvent("Death", deathDate, deathPlace, ""))
 
 	s := html.NewTable("text-center",

--- a/gedcom2html/individual_in_list.go
+++ b/gedcom2html/individual_in_list.go
@@ -20,8 +20,13 @@ func newIndividualInList(document *gedcom.Document, individual *gedcom.Individua
 }
 
 func (c *individualInList) String() string {
-	birthDate, birthPlace := html.GetBirth(c.individual)
-	deathDate, deathPlace := html.GetDeath(c.individual)
+	birth := gedcom.First(c.individual.Births())
+	birthDate := gedcom.String(gedcom.First(gedcom.Dates(birth)))
+	birthPlace := gedcom.String(gedcom.First(gedcom.Places(birth)))
+
+	death := gedcom.First(c.individual.Deaths())
+	deathDate := gedcom.String(gedcom.First(gedcom.Dates(death)))
+	deathPlace := gedcom.String(gedcom.First(gedcom.Places(death)))
 
 	birthPlace = prettyPlaceName(birthPlace)
 	deathPlace = prettyPlaceName(deathPlace)

--- a/gedcom2html/statistics_page.go
+++ b/gedcom2html/statistics_page.go
@@ -25,18 +25,16 @@ func (c *statisticsPage) String() string {
 			html.NewBigTitle("Statistics"),
 			html.NewSpace(),
 			html.NewRow(
-				html.NewColumn(html.HalfRow, newIndividualStatistics(c.document)),
+				html.NewColumn(html.HalfRow, html.NewComponents(
+					newIndividualStatistics(c.document),
+					html.NewSpace(),
+					newFamilyStatistics(c.document),
+					html.NewSpace(),
+					newSourceStatistics(c.document),
+					html.NewSpace(),
+					newPlaceStatistics(c.document),
+				)),
 				html.NewColumn(html.HalfRow, newEventStatistics(c.document)),
-			),
-			html.NewSpace(),
-			html.NewRow(
-				html.NewColumn(html.HalfRow, newFamilyStatistics(c.document)),
-				html.NewColumn(html.HalfRow, newSourceStatistics(c.document)),
-			),
-			html.NewSpace(),
-			html.NewRow(
-				html.NewColumn(html.HalfRow, newPlaceStatistics(c.document)),
-				html.NewColumn(html.HalfRow, newEmpty()),
 			),
 		),
 		c.googleAnalyticsID,

--- a/html/individual_dates.go
+++ b/html/individual_dates.go
@@ -17,12 +17,12 @@ func NewIndividualDates(individual *gedcom.IndividualNode, showLiving bool) *Ind
 }
 
 func (c *IndividualDates) String() string {
-	birthDate, _ := GetBirth(c.individual)
-	deathDate, _ := GetDeath(c.individual)
+	birthDate := gedcom.First(c.individual.Births())
+	deathDate := gedcom.Last(c.individual.Deaths())
 
 	eventDates := NewEventDates([]*EventDate{
-		NewEventDate("b.", birthDate),
-		NewEventDate("d.", deathDate),
+		NewEventDate("b.", gedcom.String(birthDate)),
+		NewEventDate("d.", gedcom.String(deathDate)),
 	}).String()
 
 	if c.individual != nil && c.individual.IsLiving() && !c.showLiving {

--- a/html/util.go
+++ b/html/util.go
@@ -2,50 +2,7 @@ package html
 
 import (
 	"fmt"
-	"github.com/elliotchance/gedcom"
 )
-
-func GetBirth(individual *gedcom.IndividualNode) (birthDate string, birthPlace string) {
-	if individual == nil {
-		return
-	}
-
-	birthNode := gedcom.First(gedcom.NodesWithTag(individual, gedcom.TagBirth))
-	if birthNode != nil {
-		birthDateNode := gedcom.First(gedcom.NodesWithTag(birthNode, gedcom.TagDate))
-		if birthDateNode != nil {
-			birthDate = birthDateNode.Value()
-		}
-
-		birthPlaceNode := gedcom.First(gedcom.NodesWithTag(birthNode, gedcom.TagPlace))
-		if birthPlaceNode != nil {
-			birthPlace = birthPlaceNode.Value()
-		}
-	}
-
-	return
-}
-
-func GetDeath(individual *gedcom.IndividualNode) (deathDate string, deathPlace string) {
-	if individual == nil {
-		return
-	}
-
-	deathNode := gedcom.First(gedcom.NodesWithTag(individual, gedcom.TagDeath))
-	if deathNode != nil {
-		deathDateNode := gedcom.First(gedcom.NodesWithTag(deathNode, gedcom.TagDate))
-		if deathDateNode != nil {
-			deathDate = deathDateNode.Value()
-		}
-
-		deathPlaceNode := gedcom.First(gedcom.NodesWithTag(deathNode, gedcom.TagPlace))
-		if deathPlaceNode != nil {
-			deathPlace = deathPlaceNode.Value()
-		}
-	}
-
-	return
-}
 
 func Sprintf(format string, args ...interface{}) string {
 	newArgs := make([]interface{}, len(args))

--- a/individual_node.go
+++ b/individual_node.go
@@ -549,3 +549,16 @@ func (node *IndividualNode) Children() IndividualNodes {
 
 	return children
 }
+
+// AllEvents returns zero or more events of any kind for the individual.
+//
+// This is not to be confused with the EventNode.
+func (node *IndividualNode) AllEvents() (nodes []Node) {
+	for _, n := range node.Nodes() {
+		if n.Tag().IsEvent() {
+			nodes = append(nodes, n)
+		}
+	}
+
+	return
+}

--- a/individual_node_test.go
+++ b/individual_node_test.go
@@ -1298,3 +1298,64 @@ func TestIndividualNode_Children(t *testing.T) {
 
 	Children((*gedcom.IndividualNode)(nil)).Returns(gedcom.IndividualNodes{})
 }
+
+func TestIndividualNode_AllEvents(t *testing.T) {
+	var tests = []struct {
+		node   *gedcom.IndividualNode
+		events []gedcom.Node
+	}{
+		{
+			node:   individual("P1", "", "", ""),
+			events: nil,
+		},
+		{
+			node:   gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{}),
+			events: nil,
+		},
+		{
+			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
+				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{}),
+			}),
+			events: []gedcom.Node{
+				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{}),
+			},
+		},
+		{
+			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
+				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{}),
+				gedcom.NewSimpleNode(nil, gedcom.TagNote, "", "", []gedcom.Node{}),
+			}),
+			events: []gedcom.Node{
+				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{}),
+			},
+		},
+		{
+			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
+				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{}),
+				gedcom.NewSimpleNode(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
+			}),
+			events: []gedcom.Node{
+				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{}),
+				gedcom.NewSimpleNode(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
+			},
+		},
+		{
+			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
+				gedcom.NewBirthNode(nil, "foo", "", []gedcom.Node{}),
+				gedcom.NewSimpleNode(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
+				gedcom.NewBirthNode(nil, "bar", "", []gedcom.Node{}),
+			}),
+			events: []gedcom.Node{
+				gedcom.NewBirthNode(nil, "foo", "", []gedcom.Node{}),
+				gedcom.NewSimpleNode(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
+				gedcom.NewBirthNode(nil, "bar", "", []gedcom.Node{}),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run("", func(t *testing.T) {
+			assert.Equal(t, test.node.AllEvents(), test.events)
+		})
+	}
+}

--- a/simple_node.go
+++ b/simple_node.go
@@ -112,5 +112,5 @@ func (node *SimpleNode) String() string {
 		return ""
 	}
 
-	return GedcomLine(0, node)
+	return node.value
 }

--- a/util.go
+++ b/util.go
@@ -53,34 +53,38 @@ func CleanSpace(s string) string {
 	return s
 }
 
-// First returns the first node of nodes. If the length of nodes is zero then
-// nil is returned. If the first node is nil then nil is also returned.
+// First returns the first non-nil node of nodes. If the length of nodes is zero
+// or a non-nil value is not found then nil is returned.
 //
 // First is useful in combination with other functions like:
 //
 //   birth := First(individual.Births())
 //
-func First(nodes []Node) Node {
-	if len(nodes) == 0 {
+func First(nodes interface{}) Node {
+	n := Compound(nodes)
+	if len(n) == 0 {
 		return nil
 	}
 
-	return nodes[0]
+	return n[0]
 }
 
-// Last returns the last node of nodes. If the length of nodes is zero then
-// nil is returned. If the last node is nil then nil is also returned.
+// Last returns the last non-nil node of nodes. If the length of nodes is zero
+// or a non-nil value is not found then nil is returned.
 //
 // Last is useful in combination with other functions like:
 //
 //   death := Last(individual.Deaths())
 //
-func Last(nodes []Node) Node {
-	if len(nodes) == 0 {
-		return nil
+func Last(nodes interface{}) Node {
+	n := Compound(nodes)
+	for i := len(n) - 1; i >= 0; i-- {
+		if n[i] != nil {
+			return n[i]
+		}
 	}
 
-	return nodes[len(nodes)-1]
+	return nil
 }
 
 // Value is a safe way to fetch the Value() from a node. If the node is nil then
@@ -146,4 +150,36 @@ func Pointer(node Node) string {
 	}
 
 	return node.Pointer()
+}
+
+// String is a safe way to fetch the String() from a node. If the node is nil
+// then an empty string will be returned.
+func String(node Node) string {
+	if node == nil {
+		return ""
+	}
+
+	return node.String()
+}
+
+// Dates returns the shallow DateNodes for each of the provided nodes.
+func Dates(nodes ...Node) (dates []*DateNode) {
+	for _, node := range nodes {
+		for _, n := range NodesWithTag(node, TagDate) {
+			dates = append(dates, n.(*DateNode))
+		}
+	}
+
+	return
+}
+
+// Places returns the shallow PlaceNodes for each of the provided nodes.
+func Places(nodes ...Node) (places []*PlaceNode) {
+	for _, node := range nodes {
+		for _, n := range NodesWithTag(node, TagPlace) {
+			places = append(places, n.(*PlaceNode))
+		}
+	}
+
+	return
 }

--- a/util_test.go
+++ b/util_test.go
@@ -66,8 +66,18 @@ var firtLastTests = []struct {
 	},
 	{
 		[]gedcom.Node{nil, gedcom.NewNameNode(nil, "a", "", nil)},
-		nil,
 		gedcom.NewNameNode(nil, "a", "", nil),
+		gedcom.NewNameNode(nil, "a", "", nil),
+	},
+	{
+		[]gedcom.Node{
+			nil,
+			gedcom.NewNameNode(nil, "a", "", nil),
+			gedcom.NewNameNode(nil, "b", "", nil),
+			nil,
+		},
+		gedcom.NewNameNode(nil, "a", "", nil),
+		gedcom.NewNameNode(nil, "b", "", nil),
 	},
 }
 
@@ -153,6 +163,163 @@ func TestPointer(t *testing.T) {
 	for _, test := range tests {
 		t.Run("", func(t *testing.T) {
 			assert.Equal(t, test.want, gedcom.Pointer(test.node))
+		})
+	}
+}
+
+func TestString(t *testing.T) {
+	tests := []struct {
+		node gedcom.Node
+		want string
+	}{
+		{nil, ""},
+		{gedcom.NewSimpleNode(nil, gedcom.TagVersion, "foo", "", nil), "foo"},
+		{gedcom.NewNameNode(nil, "foo bar", "", nil), "foo bar"},
+	}
+
+	for _, test := range tests {
+		t.Run("", func(t *testing.T) {
+			assert.Equal(t, test.want, gedcom.String(test.node))
+		})
+	}
+}
+
+func TestDates(t *testing.T) {
+	tests := []struct {
+		nodes []gedcom.Node
+		want  []*gedcom.DateNode
+	}{
+		{nil, nil},
+		{
+			[]gedcom.Node{
+				gedcom.NewSimpleNode(nil, gedcom.TagVersion, "foo", "", nil),
+			},
+			nil,
+		},
+		{
+			[]gedcom.Node{
+				gedcom.NewNameNode(nil, "foo bar", "", []gedcom.Node{
+					gedcom.NewDateNode(nil, "2 Sep 1981", "", nil),
+				}),
+			},
+			[]*gedcom.DateNode{
+				gedcom.NewDateNode(nil, "2 Sep 1981", "", nil),
+			},
+		},
+		{
+			[]gedcom.Node{
+				gedcom.NewNameNode(nil, "foo bar", "", []gedcom.Node{
+					gedcom.NewDateNode(nil, "2 Sep 1981", "", nil),
+					gedcom.NewDateNode(nil, "3 Sep 1981", "", nil),
+				}),
+			},
+			[]*gedcom.DateNode{
+				gedcom.NewDateNode(nil, "2 Sep 1981", "", nil),
+				gedcom.NewDateNode(nil, "3 Sep 1981", "", nil),
+			},
+		},
+		{
+			[]gedcom.Node{
+				gedcom.NewNameNode(nil, "foo bar", "", []gedcom.Node{
+					gedcom.NewDateNode(nil, "2 Sep 1981", "", nil),
+					gedcom.NewDateNode(nil, "3 Sep 1981", "", nil),
+				}),
+				gedcom.NewNameNode(nil, "foo bar", "", []gedcom.Node{
+					gedcom.NewDateNode(nil, "4 Sep 1981", "", nil),
+				}),
+			},
+			[]*gedcom.DateNode{
+				gedcom.NewDateNode(nil, "2 Sep 1981", "", nil),
+				gedcom.NewDateNode(nil, "3 Sep 1981", "", nil),
+				gedcom.NewDateNode(nil, "4 Sep 1981", "", nil),
+			},
+		},
+		{
+			[]gedcom.Node{
+				gedcom.NewNameNode(nil, "foo bar", "", nil),
+				gedcom.NewNameNode(nil, "foo bar", "", []gedcom.Node{
+					gedcom.NewDateNode(nil, "4 Sep 1981", "", nil),
+				}),
+			},
+			[]*gedcom.DateNode{
+				gedcom.NewDateNode(nil, "4 Sep 1981", "", nil),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run("", func(t *testing.T) {
+			assert.Equal(t, test.want, gedcom.Dates(test.nodes...))
+		})
+	}
+}
+
+func TestPlaces(t *testing.T) {
+	tests := []struct {
+		nodes []gedcom.Node
+		want  []*gedcom.PlaceNode
+	}{
+		{nil, nil},
+		{
+			[]gedcom.Node{
+				gedcom.NewSimpleNode(nil, gedcom.TagVersion, "foo", "", nil),
+			},
+			nil,
+		},
+		{
+			[]gedcom.Node{
+				gedcom.NewNameNode(nil, "foo bar", "", []gedcom.Node{
+					gedcom.NewPlaceNode(nil, "Australia", "", nil),
+				}),
+			},
+			[]*gedcom.PlaceNode{
+				gedcom.NewPlaceNode(nil, "Australia", "", nil),
+			},
+		},
+		{
+			[]gedcom.Node{
+				gedcom.NewNameNode(nil, "foo bar", "", []gedcom.Node{
+					gedcom.NewPlaceNode(nil, "Australia", "", nil),
+					gedcom.NewPlaceNode(nil, "United States", "", nil),
+				}),
+			},
+			[]*gedcom.PlaceNode{
+				gedcom.NewPlaceNode(nil, "Australia", "", nil),
+				gedcom.NewPlaceNode(nil, "United States", "", nil),
+			},
+		},
+		{
+			[]gedcom.Node{
+				gedcom.NewNameNode(nil, "foo bar", "", []gedcom.Node{
+					gedcom.NewPlaceNode(nil, "Australia", "", nil),
+					gedcom.NewPlaceNode(nil, "United States", "", nil),
+				}),
+				gedcom.NewNameNode(nil, "foo bar", "", []gedcom.Node{
+					gedcom.NewPlaceNode(nil, "England", "", nil),
+				}),
+			},
+			[]*gedcom.PlaceNode{
+				gedcom.NewPlaceNode(nil, "Australia", "", nil),
+				gedcom.NewPlaceNode(nil, "United States", "", nil),
+				gedcom.NewPlaceNode(nil, "England", "", nil),
+			},
+		},
+		{
+			[]gedcom.Node{
+				gedcom.NewNameNode(nil, "foo bar", "", nil),
+				gedcom.NewNameNode(nil, "foo bar", "", []gedcom.Node{
+					gedcom.NewPlaceNode(nil, "Australia", "", nil),
+				}),
+			},
+			[]*gedcom.PlaceNode{
+				gedcom.NewPlaceNode(nil, "Australia", "", nil),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run("", func(t *testing.T) {
+			assert.Equal(t, test.want, gedcom.Places(test.nodes...))
 		})
 	}
 }


### PR DESCRIPTION
- gedcom2html statistics page now shows all event types.
- A minor layout change for the statistic boxes so they fit better into two columns.
- Added IndividualNode.AllEvents() as an easier way to extract all nodes from an individual that have a Tag.IsEvent() of true.
- SimpleNode.String (and by extension most Node.String) now return the Value() rather than the GEDCOM rendered line which is much more approproate as a printing value.
- First() and Last() now accepts a much more flexible interface{} so it can be used with slices of more specific types.
- Added Dates() and Places() which return the shallow DateNodes or PlaceNodes respectively for each of the provided node arguments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/gedcom/120)
<!-- Reviewable:end -->
