### PR TITLE
Set UTF-8 charset for HTML. Fixes #126

### DIFF
--- a/decoder_test.go
+++ b/decoder_test.go
@@ -236,6 +236,11 @@ var tests = map[string]*gedcom.Document{
 			gedcom.NewDateNode(nil, "1856", "", nil),
 		},
 	},
+	"0 NAME κόσμε": {
+		Nodes: []gedcom.Node{
+			gedcom.NewNameNode(nil, "κόσμε", "", nil),
+		},
+	},
 }
 
 func TestDecoder_Decode(t *testing.T) {

--- a/html/page.go
+++ b/html/page.go
@@ -25,6 +25,7 @@ func (c *Page) String() string {
 	return Sprintf(`
     <html>
 	<head>
+		<meta charset="UTF-8">
 		%s
 		<title>%s</title>
 		<link href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.1/css/bootstrap.min.css"

--- a/sex_test.go
+++ b/sex_test.go
@@ -1,0 +1,15 @@
+package gedcom
+
+import (
+	"github.com/elliotchance/tf"
+	"testing"
+)
+
+func TestSex_String(t *testing.T) {
+	String := tf.Function(t, Sex.String)
+
+	String("").Returns("Unknown")
+	String(SexUnknown).Returns("Unknown")
+	String(SexMale).Returns("Male")
+	String(SexFemale).Returns("Female")
+}


### PR DESCRIPTION
- The GEDCOM data was being read correctly by the browser needed to be told that all pages are UTF-8.
- I have also added some tests for Sex.String().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/gedcom/130)
<!-- Reviewable:end -->
