### PR TITLE
Complete spec for PlaceNode. Fixes #11

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -171,11 +171,29 @@ func NewNode(document *Document, tag Tag, value, pointer string) Node {
 	case TagFamily:
 		return NewFamilyNode(document, pointer, nil)
 
+	case TagFormat:
+		return NewFormatNode(document, value, pointer, nil)
+
 	case TagIndividual:
 		return NewIndividualNode(document, value, pointer, nil)
 
+	case TagLatitude:
+		return NewLatitudeNode(document, value, pointer, nil)
+
+	case TagLongitude:
+		return NewLongitudeNode(document, value, pointer, nil)
+
+	case TagMap:
+		return NewMapNode(document, value, pointer, nil)
+
 	case TagName:
 		return NewNameNode(document, value, pointer, nil)
+
+	case TagNote:
+		return NewNoteNode(document, value, pointer, nil)
+
+	case TagPhonetic:
+		return NewPhoneticVariationNode(document, value, pointer, nil)
 
 	case TagPlace:
 		return NewPlaceNode(document, value, pointer, nil)
@@ -183,8 +201,14 @@ func NewNode(document *Document, tag Tag, value, pointer string) Node {
 	case TagResidence:
 		return NewResidenceNode(document, value, pointer, nil)
 
+	case TagRomanized:
+		return NewRomanizedVariationNode(document, value, pointer, nil)
+
 	case TagSource:
 		return NewSourceNode(document, value, pointer, nil)
+
+	case TagType:
+		return NewTypeNode(document, value, pointer, nil)
 	}
 
 	return NewSimpleNode(document, tag, value, pointer, nil)

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -86,7 +86,7 @@ var tests = map[string]*gedcom.Document{
 		Nodes: []gedcom.Node{
 			gedcom.NewSimpleNode(nil, gedcom.TagHeader, "", "", []gedcom.Node{
 				gedcom.NewSimpleNode(nil, gedcom.TagGedcomInformation, "", "", []gedcom.Node{
-					gedcom.NewSimpleNode(nil, gedcom.TagFormat, "LINEAGE-LINKED", "", nil),
+					gedcom.NewFormatNode(nil, "LINEAGE-LINKED", "", nil),
 				}),
 			}),
 		},
@@ -150,7 +150,7 @@ var tests = map[string]*gedcom.Document{
 		Nodes: []gedcom.Node{
 			gedcom.NewSimpleNode(nil, gedcom.TagHeader, "", "", []gedcom.Node{
 				gedcom.NewSimpleNode(nil, gedcom.TagGedcomInformation, "", "", []gedcom.Node{
-					gedcom.NewSimpleNode(nil, gedcom.TagFormat, "LINEAGE-LINKED", "", nil),
+					gedcom.NewFormatNode(nil, "LINEAGE-LINKED", "", nil),
 				}),
 			}),
 			gedcom.NewIndividualNode(nil, "", "P1", nil),
@@ -283,11 +283,19 @@ func TestNewNode(t *testing.T) {
 		{gedcom.TagDate, gedcom.NewDateNode(nil, v, p, nil)},
 		{gedcom.TagEvent, gedcom.NewEventNode(nil, v, p, nil)},
 		{gedcom.TagFamily, gedcom.NewFamilyNode(nil, p, nil)},
+		{gedcom.TagFormat, gedcom.NewFormatNode(nil, v, p, nil)},
 		{gedcom.TagIndividual, gedcom.NewIndividualNode(nil, v, p, nil)},
+		{gedcom.TagLatitude, gedcom.NewLatitudeNode(nil, v, p, nil)},
+		{gedcom.TagLongitude, gedcom.NewLongitudeNode(nil, v, p, nil)},
+		{gedcom.TagMap, gedcom.NewMapNode(nil, v, p, nil)},
 		{gedcom.TagName, gedcom.NewNameNode(nil, v, p, nil)},
+		{gedcom.TagNote, gedcom.NewNoteNode(nil, v, p, nil)},
+		{gedcom.TagPhonetic, gedcom.NewPhoneticVariationNode(nil, v, p, nil)},
 		{gedcom.TagPlace, gedcom.NewPlaceNode(nil, v, p, nil)},
 		{gedcom.TagResidence, gedcom.NewResidenceNode(nil, v, p, nil)},
+		{gedcom.TagRomanized, gedcom.NewRomanizedVariationNode(nil, v, p, nil)},
 		{gedcom.TagSource, gedcom.NewSourceNode(nil, v, p, nil)},
+		{gedcom.TagType, gedcom.NewTypeNode(nil, v, p, nil)},
 		{gedcom.TagVersion, gedcom.NewSimpleNode(nil, gedcom.TagVersion, v, p, nil)},
 	} {
 		t.Run(test.tag.String(), func(t *testing.T) {

--- a/format_node.go
+++ b/format_node.go
@@ -1,0 +1,14 @@
+package gedcom
+
+// FormatNode represents an assigned name given to a consistent format in which
+// information can be conveyed.
+type FormatNode struct {
+	*SimpleNode
+}
+
+// NewFormatNode creates a new FORM node.
+func NewFormatNode(document *Document, value, pointer string, children []Node) *FormatNode {
+	return &FormatNode{
+		NewSimpleNode(document, TagFormat, value, pointer, children),
+	}
+}

--- a/format_node_test.go
+++ b/format_node_test.go
@@ -1,0 +1,22 @@
+package gedcom_test
+
+import (
+	"testing"
+
+	"github.com/elliotchance/gedcom"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewFormatNode(t *testing.T) {
+	doc := gedcom.NewDocument()
+	child := gedcom.NewNameNode(doc, "", "", nil)
+	node := gedcom.NewFormatNode(doc, "foo", "bar", []gedcom.Node{child})
+
+	assert.NotNil(t, node)
+	assert.IsType(t, node, (*gedcom.FormatNode)(nil))
+	assert.Equal(t, gedcom.TagFormat, node.Tag())
+	assert.Equal(t, []gedcom.Node{child}, node.Nodes())
+	assert.Equal(t, doc, node.Document())
+	assert.Equal(t, "foo", node.Value())
+	assert.Equal(t, "bar", node.Pointer())
+}

--- a/latitude_node.go
+++ b/latitude_node.go
@@ -1,0 +1,16 @@
+package gedcom
+
+// LatitudeNode represents a value indicating a coordinate position on a line,
+// plane, or space.
+//
+// New in Gedcom 5.5.1.
+type LatitudeNode struct {
+	*SimpleNode
+}
+
+// NewLatitudeNode creates a new LATI node.
+func NewLatitudeNode(document *Document, value, pointer string, children []Node) *LatitudeNode {
+	return &LatitudeNode{
+		NewSimpleNode(document, TagLatitude, value, pointer, children),
+	}
+}

--- a/latitude_node_test.go
+++ b/latitude_node_test.go
@@ -1,0 +1,21 @@
+package gedcom_test
+
+import (
+	"github.com/elliotchance/gedcom"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestNewLatitudeNode(t *testing.T) {
+	doc := gedcom.NewDocument()
+	child := gedcom.NewNameNode(doc, "", "", nil)
+	node := gedcom.NewLatitudeNode(doc, "foo", "bar", []gedcom.Node{child})
+
+	assert.NotNil(t, node)
+	assert.IsType(t, node, (*gedcom.LatitudeNode)(nil))
+	assert.Equal(t, gedcom.TagLatitude, node.Tag())
+	assert.Equal(t, []gedcom.Node{child}, node.Nodes())
+	assert.Equal(t, doc, node.Document())
+	assert.Equal(t, "foo", node.Value())
+	assert.Equal(t, "bar", node.Pointer())
+}

--- a/longitude_node.go
+++ b/longitude_node.go
@@ -1,0 +1,16 @@
+package gedcom
+
+// LongitudeNode represents a value indicating a coordinate position on a line,
+// plane, or space.
+//
+// New in Gedcom 5.5.1.
+type LongitudeNode struct {
+	*SimpleNode
+}
+
+// NewLongitudeNode creates a new LONG node.
+func NewLongitudeNode(document *Document, value, pointer string, children []Node) *LongitudeNode {
+	return &LongitudeNode{
+		NewSimpleNode(document, TagLongitude, value, pointer, children),
+	}
+}

--- a/longitude_node_test.go
+++ b/longitude_node_test.go
@@ -1,0 +1,21 @@
+package gedcom_test
+
+import (
+	"github.com/elliotchance/gedcom"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestNewLongitudeNode(t *testing.T) {
+	doc := gedcom.NewDocument()
+	child := gedcom.NewNameNode(doc, "", "", nil)
+	node := gedcom.NewLongitudeNode(doc, "foo", "bar", []gedcom.Node{child})
+
+	assert.NotNil(t, node)
+	assert.IsType(t, node, (*gedcom.LongitudeNode)(nil))
+	assert.Equal(t, gedcom.TagLongitude, node.Tag())
+	assert.Equal(t, []gedcom.Node{child}, node.Nodes())
+	assert.Equal(t, doc, node.Document())
+	assert.Equal(t, "foo", node.Value())
+	assert.Equal(t, "bar", node.Pointer())
+}

--- a/map_node.go
+++ b/map_node.go
@@ -1,0 +1,56 @@
+package gedcom
+
+// MapNode pertains to a representation of measurements usually presented in a
+// graphical form.
+//
+// New in Gedcom 5.5.1.
+type MapNode struct {
+	*SimpleNode
+}
+
+// NewMapNode creates a new MAP node.
+func NewMapNode(document *Document, value, pointer string, children []Node) *MapNode {
+	return &MapNode{
+		NewSimpleNode(document, TagMap, value, pointer, children),
+	}
+}
+
+// Latitude is the value specifying the latitudinal coordinate of the place
+// name.
+//
+// The latitude coordinate is the direction North or South from the equator in
+// degrees and fraction of degrees carried out to give the desired accuracy.
+//
+// For example: 18 degrees, 9 minutes, and 3.4 seconds North would be formatted
+// as N18.150944.
+//
+// Minutes and seconds are converted by dividing the minutes value by 60 and the
+// seconds value by 3600 and adding the results together. This sum becomes the
+// fractional part of the degree’s value.
+func (node *MapNode) Latitude() *LatitudeNode {
+	n := First(NodesWithTag(node, TagLatitude))
+
+	if IsNil(n) {
+		return nil
+	}
+
+	return n.(*LatitudeNode)
+}
+
+// Longitude is the value specifying the longitudinal coordinate of the place
+// name.
+//
+// The longitude coordinate is degrees and fraction of degrees east or west of
+// the zero or base meridian coordinate.
+//
+// For example: 168 degrees, 9 minutes, and 3.4 seconds East would be formatted
+// as E168.150944.
+func (node *MapNode) Longitude() *LongitudeNode {
+	n := First(NodesWithTag(node, TagLongitude))
+
+	if IsNil(n) {
+		return nil
+	}
+
+	return n.(*LongitudeNode)
+}

--- a/map_node_test.go
+++ b/map_node_test.go
@@ -1,0 +1,113 @@
+package gedcom_test
+
+import (
+	"github.com/elliotchance/gedcom"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestNewMapNode(t *testing.T) {
+	doc := gedcom.NewDocument()
+	child := gedcom.NewNameNode(doc, "", "", nil)
+	node := gedcom.NewMapNode(doc, "foo", "bar", []gedcom.Node{child})
+
+	assert.NotNil(t, node)
+	assert.IsType(t, node, (*gedcom.MapNode)(nil))
+	assert.Equal(t, gedcom.TagMap, node.Tag())
+	assert.Equal(t, []gedcom.Node{child}, node.Nodes())
+	assert.Equal(t, doc, node.Document())
+	assert.Equal(t, "foo", node.Value())
+	assert.Equal(t, "bar", node.Pointer())
+}
+
+func TestPlaceNode_Latitude(t *testing.T) {
+	var tests = []struct {
+		node     *gedcom.MapNode
+		expected *gedcom.LatitudeNode
+	}{
+		{
+			node:     nil,
+			expected: nil,
+		},
+		{
+			node:     gedcom.NewMapNode(nil, "", "", nil),
+			expected: nil,
+		},
+		{
+			node:     gedcom.NewMapNode(nil, "", "", []gedcom.Node{}),
+			expected: nil,
+		},
+		{
+			node: gedcom.NewMapNode(nil, "", "", []gedcom.Node{
+				gedcom.NewLatitudeNode(nil, "", "", []gedcom.Node{}),
+			}),
+			expected: gedcom.NewLatitudeNode(nil, "", "", []gedcom.Node{}),
+		},
+		{
+			node: gedcom.NewMapNode(nil, "", "", []gedcom.Node{
+				gedcom.NewNameNode(nil, "", "", []gedcom.Node{}),
+			}),
+			expected: nil,
+		},
+		{
+			node: gedcom.NewMapNode(nil, "", "", []gedcom.Node{
+				gedcom.NewNameNode(nil, "", "", []gedcom.Node{}),
+				gedcom.NewLatitudeNode(nil, "1", "", []gedcom.Node{}),
+				gedcom.NewLatitudeNode(nil, "2", "", []gedcom.Node{}),
+			}),
+			expected: gedcom.NewLatitudeNode(nil, "1", "", []gedcom.Node{}),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run("", func(t *testing.T) {
+			assert.Equal(t, test.node.Latitude(), test.expected)
+		})
+	}
+}
+
+func TestPlaceNode_Longitude(t *testing.T) {
+	var tests = []struct {
+		node     *gedcom.MapNode
+		expected *gedcom.LongitudeNode
+	}{
+		{
+			node:     nil,
+			expected: nil,
+		},
+		{
+			node:     gedcom.NewMapNode(nil, "", "", nil),
+			expected: nil,
+		},
+		{
+			node:     gedcom.NewMapNode(nil, "", "", []gedcom.Node{}),
+			expected: nil,
+		},
+		{
+			node: gedcom.NewMapNode(nil, "", "", []gedcom.Node{
+				gedcom.NewLongitudeNode(nil, "", "", []gedcom.Node{}),
+			}),
+			expected: gedcom.NewLongitudeNode(nil, "", "", []gedcom.Node{}),
+		},
+		{
+			node: gedcom.NewMapNode(nil, "", "", []gedcom.Node{
+				gedcom.NewNameNode(nil, "", "", []gedcom.Node{}),
+			}),
+			expected: nil,
+		},
+		{
+			node: gedcom.NewMapNode(nil, "", "", []gedcom.Node{
+				gedcom.NewNameNode(nil, "", "", []gedcom.Node{}),
+				gedcom.NewLongitudeNode(nil, "1", "", []gedcom.Node{}),
+				gedcom.NewLongitudeNode(nil, "2", "", []gedcom.Node{}),
+			}),
+			expected: gedcom.NewLongitudeNode(nil, "1", "", []gedcom.Node{}),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run("", func(t *testing.T) {
+			assert.Equal(t, test.node.Longitude(), test.expected)
+		})
+	}
+}

--- a/nodes.go
+++ b/nodes.go
@@ -1,5 +1,7 @@
 package gedcom
 
+import "reflect"
+
 // nodeCache is used by NodesWithTag. Even though the lookup of child tags are
 // fairly inexpensive it happens a lot and its common for the same paths to be
 // looked up many time. Especially when doing larger task like comparing GEDCOM
@@ -88,4 +90,25 @@ func HasNestedNode(node Node, lookingFor Node) bool {
 	}
 
 	return false
+}
+
+// CastNodes creates a slice of a more specific node type.
+//
+// All Nodes must be the same type and the same as the provided t.
+func CastNodes(nodes []Node, t interface{}) interface{} {
+	size := len(nodes)
+	nodeType := reflect.TypeOf(t)
+	sliceType := reflect.SliceOf(nodeType)
+	slice := reflect.MakeSlice(sliceType, size, size)
+
+	for i, node := range nodes {
+		value := reflect.ValueOf(node)
+		slice.Index(i).Set(value)
+	}
+
+	return slice.Interface()
+}
+
+func castNodesWithTag(node Node, tag Tag, t interface{}) interface{} {
+	return CastNodes(NodesWithTag(node, tag), t)
 }

--- a/nodes_test.go
+++ b/nodes_test.go
@@ -1,9 +1,11 @@
 package gedcom_test
 
 import (
-	"github.com/elliotchance/gedcom"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/elliotchance/gedcom"
+	"github.com/elliotchance/tf"
+	"github.com/stretchr/testify/assert"
 )
 
 var nodesWithTagTests = []struct {
@@ -248,4 +250,18 @@ func TestHasNestedNode(t *testing.T) {
 			assert.Equal(t, test.want, result)
 		})
 	}
+}
+
+func TestCastNodes(t *testing.T) {
+	CastNodes := tf.Function(t, gedcom.CastNodes)
+
+	CastNodes(nil, (*gedcom.NameNode)(nil)).
+		Returns([]*gedcom.NameNode{})
+
+	CastNodes([]gedcom.Node{}, (*gedcom.NameNode)(nil)).
+		Returns([]*gedcom.NameNode{})
+
+	name := gedcom.NewNameNode(nil, "Elliot Rupert de Peyster /Chance/", "", nil)
+	CastNodes([]gedcom.Node{name}, (*gedcom.NameNode)(nil)).
+		Returns([]*gedcom.NameNode{name})
 }

--- a/note_node.go
+++ b/note_node.go
@@ -1,0 +1,14 @@
+package gedcom
+
+// NoteNode represents additional information provided by the submitter for
+// understanding the enclosing data.
+type NoteNode struct {
+	*SimpleNode
+}
+
+// NewNoteNode creates a new NOTE node.
+func NewNoteNode(document *Document, value, pointer string, children []Node) *NoteNode {
+	return &NoteNode{
+		NewSimpleNode(document, TagNote, value, pointer, children),
+	}
+}

--- a/note_node_test.go
+++ b/note_node_test.go
@@ -1,0 +1,21 @@
+package gedcom_test
+
+import (
+	"github.com/elliotchance/gedcom"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestNewNoteNode(t *testing.T) {
+	doc := gedcom.NewDocument()
+	child := gedcom.NewNameNode(doc, "", "", nil)
+	node := gedcom.NewNoteNode(doc, "foo", "bar", []gedcom.Node{child})
+
+	assert.NotNil(t, node)
+	assert.IsType(t, node, (*gedcom.NoteNode)(nil))
+	assert.Equal(t, gedcom.TagNote, node.Tag())
+	assert.Equal(t, []gedcom.Node{child}, node.Nodes())
+	assert.Equal(t, doc, node.Document())
+	assert.Equal(t, "foo", node.Value())
+	assert.Equal(t, "bar", node.Pointer())
+}

--- a/phonetic_variation_node.go
+++ b/phonetic_variation_node.go
@@ -1,0 +1,33 @@
+package gedcom
+
+// Indicates the method used in transforming the text to the phonetic variation.
+//
+// These constants can be used for PhoneticVariationNode.Type.Value. The value
+// is not limited to these constants. Any user defined value is also valid.
+const (
+	// Phonetic method for sounding Korean glifs.
+	PhoneticVariationTypeHangul = "hangul"
+
+	// Hiragana and/or Katakana characters were used in sounding the Kanji
+	// character used by japanese.
+	PhoneticVariationTypeKana = "kana"
+)
+
+// PhoneticVariationNode represents a phonetic variation of a superior text
+// string.
+//
+// New in Gedcom 5.5.1.
+type PhoneticVariationNode struct {
+	*SimpleNode
+}
+
+// NewPhoneticVariationNode creates a new FONE node.
+func NewPhoneticVariationNode(document *Document, value, pointer string, children []Node) *PhoneticVariationNode {
+	return &PhoneticVariationNode{
+		NewSimpleNode(document, TagPhonetic, value, pointer, children),
+	}
+}
+
+func (node *PhoneticVariationNode) Type() *TypeNode {
+	return getType(node)
+}

--- a/phonetic_variation_node_test.go
+++ b/phonetic_variation_node_test.go
@@ -1,0 +1,67 @@
+package gedcom_test
+
+import (
+	"github.com/elliotchance/gedcom"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestNewPhoneticVariationNode(t *testing.T) {
+	doc := gedcom.NewDocument()
+	child := gedcom.NewNameNode(doc, "", "", nil)
+	node := gedcom.NewPhoneticVariationNode(doc, "foo", "bar", []gedcom.Node{child})
+
+	assert.NotNil(t, node)
+	assert.IsType(t, node, (*gedcom.PhoneticVariationNode)(nil))
+	assert.Equal(t, gedcom.TagPhonetic, node.Tag())
+	assert.Equal(t, []gedcom.Node{child}, node.Nodes())
+	assert.Equal(t, doc, node.Document())
+	assert.Equal(t, "foo", node.Value())
+	assert.Equal(t, "bar", node.Pointer())
+}
+
+func TestPhoneticVariationNode_Type(t *testing.T) {
+	var tests = []struct {
+		node     *gedcom.PhoneticVariationNode
+		expected *gedcom.TypeNode
+	}{
+		{
+			node:     nil,
+			expected: nil,
+		},
+		{
+			node:     gedcom.NewPhoneticVariationNode(nil, "", "", nil),
+			expected: nil,
+		},
+		{
+			node:     gedcom.NewPhoneticVariationNode(nil, "", "", []gedcom.Node{}),
+			expected: nil,
+		},
+		{
+			node: gedcom.NewPhoneticVariationNode(nil, "", "", []gedcom.Node{
+				gedcom.NewTypeNode(nil, "", "", []gedcom.Node{}),
+			}),
+			expected: gedcom.NewTypeNode(nil, "", "", []gedcom.Node{}),
+		},
+		{
+			node: gedcom.NewPhoneticVariationNode(nil, "", "", []gedcom.Node{
+				gedcom.NewNameNode(nil, "", "", []gedcom.Node{}),
+			}),
+			expected: nil,
+		},
+		{
+			node: gedcom.NewPhoneticVariationNode(nil, "", "", []gedcom.Node{
+				gedcom.NewNameNode(nil, "", "", []gedcom.Node{}),
+				gedcom.NewTypeNode(nil, "1", "", []gedcom.Node{}),
+				gedcom.NewTypeNode(nil, "2", "", []gedcom.Node{}),
+			}),
+			expected: gedcom.NewTypeNode(nil, "1", "", []gedcom.Node{}),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run("", func(t *testing.T) {
+			assert.Equal(t, test.node.Type(), test.expected)
+		})
+	}
+}

--- a/place_node.go
+++ b/place_node.go
@@ -1,12 +1,178 @@
 package gedcom
 
-// PlaceNode represents a place (location).
+import "strings"
+
+// PlaceNode represents a jurisdictional name to identify the place or location
+// of an event.
+//
+// The original specification was derived from
+// http://wiki-en.genealogy.net/GEDCOM/PLAC-Tag
 type PlaceNode struct {
 	*SimpleNode
 }
 
+// NewPlaceNode creates a new PLAC node.
+//
+// The original specification was derived from
+// http://wiki-en.genealogy.net/GEDCOM/PLAC-Tag
 func NewPlaceNode(document *Document, value, pointer string, children []Node) *PlaceNode {
 	return &PlaceNode{
 		NewSimpleNode(document, TagPlace, value, pointer, children),
 	}
+}
+
+// JurisdictionalName determines the best name to use to identify the
+// jurisdiction entities.
+//
+// If Format() is not empty then this is the best jurisdictional name to use
+// because it should be in the form of "Name,County,State,Country". Otherwise it
+// will have to fallback to using the PlaceNode value.
+//
+// The PlaceNode value does not have to follow any standards but it's common for
+// it to have the same value as the Format would have had.
+//
+// If the jurisdictional name is not exactly in the form of
+// "Name,County,State,Country" (including more or less components) then it
+// cannot be split. In this case the Name component is the entire name and the
+// County, State and Country will be empty.
+func (node *PlaceNode) JurisdictionalName() string {
+	name := Value(node.Format())
+
+	if name == "" {
+		name = Value(node)
+	}
+
+	return name
+}
+
+// Name is the first part of the JurisdictionalName().
+//
+// If the JurisdictionalName is not in the exact form of
+// "Name,County,State,Country" then Name will return the entire jurisdictional
+// name.
+func (node *PlaceNode) Name() string {
+	name, _, _, _ := node.JurisdictionalEntities()
+
+	return name
+}
+
+// County is the second part of the JurisdictionalName().
+//
+// County will only return a non-empty response if the JurisdictionalName is
+// exactly in the form of "Name,County,State,Country".
+func (node *PlaceNode) County() string {
+	_, county, _, _ := node.JurisdictionalEntities()
+
+	return county
+}
+
+// State is the third part of the JurisdictionalName().
+//
+// State will only return a non-empty response if the JurisdictionalName is
+// exactly in the form of "Name,County,State,Country".
+func (node *PlaceNode) State() string {
+	_, _, state, _ := node.JurisdictionalEntities()
+
+	return state
+}
+
+// Country is the forth part of the JurisdictionalName().
+//
+// Country will only return a non-empty response if the JurisdictionalName is
+// exactly in the form of "Name,County,State,Country".
+func (node *PlaceNode) Country() string {
+	_, _, _, country := node.JurisdictionalEntities()
+
+	return country
+}
+
+// Format shows the jurisdictional entities that are named in a sequence from
+// the lowest to the highest jurisdiction.
+//
+// The jurisdictions are separated by commas, and any jurisdiction's name that
+// is missing is still accounted for by a comma.
+//
+// When a PLAC.FORM structure is included in the HEADER of a GEDCOM
+// transmission, it implies that all place names follow this jurisdictional
+// format and each jurisdiction is accounted for by a comma, whether the name is
+// known or not.
+//
+// When the PLAC.FORM is subordinate to an event, it temporarily overrides the
+// implications made by the PLAC.FORM structure stated in the HEADER. This usage
+// is not common and, therefore, not encouraged. It should only be used when a
+// system has over-structured its place-names.
+//
+// See JurisdictionalName() for a more reliable way to determine the Format.
+func (node *PlaceNode) Format() *FormatNode {
+	n := First(NodesWithTag(node, TagFormat))
+
+	if IsNil(n) {
+		return nil
+	}
+
+	return n.(*FormatNode)
+}
+
+// PhoneticVariations of the place name are written in the same form as was the
+// place name used in the superior PlaceNode value, but phonetically written
+// using the method indicated by the subordinate Type.
+//
+// For example if hiragana was used to provide a reading of a name written in
+// kanji, then the Type value would indicate kana.
+//
+// See PhoneticVariationTypeHangul and PhoneticVariationTypeKana.
+func (node *PlaceNode) PhoneticVariations() []*PhoneticVariationNode {
+	t := (*PhoneticVariationNode)(nil)
+
+	return castNodesWithTag(node, TagPhonetic, t).([]*PhoneticVariationNode)
+}
+
+// RomanizedVariations of the place name are written in the same form prescribed
+// for the place name used in the superior PlaceNode context.
+//
+// The method used to romanize the name is indicated by the Value of the
+// subordinate Type().
+//
+// For example if romaji was used to provide a reading of a place name written
+// in kanji, then the Type subordinate to the RomanizedVariationNode would
+// indicate "romaji".
+func (node *PlaceNode) RomanizedVariations() []*RomanizedVariationNode {
+	t := (*RomanizedVariationNode)(nil)
+
+	return castNodesWithTag(node, TagRomanized, t).([]*RomanizedVariationNode)
+}
+
+func (node *PlaceNode) Map() *MapNode {
+	n := First(NodesWithTag(node, TagMap))
+
+	if IsNil(n) {
+		return nil
+	}
+
+	return n.(*MapNode)
+}
+
+func (node *PlaceNode) Notes() []*NoteNode {
+	t := (*NoteNode)(nil)
+
+	return castNodesWithTag(node, TagNote, t).([]*NoteNode)
+}
+
+// JurisdictionalEntities returns the name, county, state and country.
+//
+// See JurisdictionalName() for a full explanation.
+func (node *PlaceNode) JurisdictionalEntities() (string, string, string, string) {
+	jurisdictionalName := node.JurisdictionalName()
+	placeParts := strings.Split(jurisdictionalName, ",")
+
+	if len(placeParts) != 4 {
+		placeParts = []string{jurisdictionalName, "", "", ""}
+	}
+
+	name := strings.TrimSpace(placeParts[0])
+	county := strings.TrimSpace(placeParts[1])
+	state := strings.TrimSpace(placeParts[2])
+	country := strings.TrimSpace(placeParts[3])
+
+	return name, county, state, country
 }

--- a/place_node_test.go
+++ b/place_node_test.go
@@ -1,0 +1,353 @@
+package gedcom_test
+
+import (
+	"testing"
+
+	"github.com/elliotchance/gedcom"
+	"github.com/elliotchance/tf"
+	"github.com/stretchr/testify/assert"
+)
+
+var placeTests = []struct {
+	node    *gedcom.PlaceNode
+	name    string // Name()
+	county  string // County()
+	state   string // State()
+	country string // Country()
+}{
+	{
+		node:    nil,
+		name:    "",
+		county:  "",
+		state:   "",
+		country: "",
+	},
+	{
+		node:    gedcom.NewPlaceNode(nil, "Waterloo", "", nil),
+		name:    "Waterloo",
+		county:  "",
+		state:   "",
+		country: "",
+	},
+	{
+		node:    gedcom.NewPlaceNode(nil, "Waterloo, NSW", "", nil),
+		name:    "Waterloo, NSW",
+		county:  "",
+		state:   "",
+		country: "",
+	},
+	{
+		node:    gedcom.NewPlaceNode(nil, "Cove,Cache,Utah,USA.", "", nil),
+		name:    "Cove",
+		county:  "Cache",
+		state:   "Utah",
+		country: "USA.",
+	},
+	{
+		node:    gedcom.NewPlaceNode(nil, "Cove, Cache, Utah, USA.", "", nil),
+		name:    "Cove",
+		county:  "Cache",
+		state:   "Utah",
+		country: "USA.",
+	},
+}
+
+func TestNewPlaceNode(t *testing.T) {
+	doc := gedcom.NewDocument()
+	child := gedcom.NewNameNode(doc, "", "", nil)
+	node := gedcom.NewPlaceNode(doc, "foo", "bar", []gedcom.Node{child})
+
+	assert.NotNil(t, node)
+	assert.IsType(t, node, (*gedcom.PlaceNode)(nil))
+	assert.Equal(t, gedcom.TagPlace, node.Tag())
+	assert.Equal(t, []gedcom.Node{child}, node.Nodes())
+	assert.Equal(t, doc, node.Document())
+	assert.Equal(t, "foo", node.Value())
+	assert.Equal(t, "bar", node.Pointer())
+}
+
+func TestPlaceNode_Name(t *testing.T) {
+	Name := tf.Function(t, (*gedcom.PlaceNode).Name)
+
+	for _, test := range placeTests {
+		Name(test.node).Returns(test.name)
+	}
+}
+
+func TestPlaceNode_County(t *testing.T) {
+	County := tf.Function(t, (*gedcom.PlaceNode).County)
+
+	for _, test := range placeTests {
+		County(test.node).Returns(test.county)
+	}
+}
+
+func TestPlaceNode_State(t *testing.T) {
+	State := tf.Function(t, (*gedcom.PlaceNode).State)
+
+	for _, test := range placeTests {
+		State(test.node).Returns(test.state)
+	}
+}
+
+func TestPlaceNode_Country(t *testing.T) {
+	Country := tf.Function(t, (*gedcom.PlaceNode).Country)
+
+	for _, test := range placeTests {
+		Country(test.node).Returns(test.country)
+	}
+}
+
+func TestPlaceNode_Format(t *testing.T) {
+	var tests = []struct {
+		node     *gedcom.PlaceNode
+		expected *gedcom.FormatNode
+	}{
+		{
+			node:     nil,
+			expected: nil,
+		},
+		{
+			node:     gedcom.NewPlaceNode(nil, "", "", nil),
+			expected: nil,
+		},
+		{
+			node:     gedcom.NewPlaceNode(nil, "", "", []gedcom.Node{}),
+			expected: nil,
+		},
+		{
+			node: gedcom.NewPlaceNode(nil, "", "", []gedcom.Node{
+				gedcom.NewFormatNode(nil, "", "", []gedcom.Node{}),
+			}),
+			expected: gedcom.NewFormatNode(nil, "", "", []gedcom.Node{}),
+		},
+		{
+			node: gedcom.NewPlaceNode(nil, "", "", []gedcom.Node{
+				gedcom.NewNameNode(nil, "", "", []gedcom.Node{}),
+			}),
+			expected: nil,
+		},
+		{
+			node: gedcom.NewPlaceNode(nil, "", "", []gedcom.Node{
+				gedcom.NewNameNode(nil, "", "", []gedcom.Node{}),
+				gedcom.NewFormatNode(nil, "1", "", []gedcom.Node{}),
+				gedcom.NewFormatNode(nil, "2", "", []gedcom.Node{}),
+			}),
+			expected: gedcom.NewFormatNode(nil, "1", "", []gedcom.Node{}),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run("", func(t *testing.T) {
+			assert.Equal(t, test.node.Format(), test.expected)
+		})
+	}
+}
+
+func TestPlaceNode_PhoneticVariations(t *testing.T) {
+	var tests = []struct {
+		node     *gedcom.PlaceNode
+		expected []*gedcom.PhoneticVariationNode
+	}{
+		{
+			node:     nil,
+			expected: []*gedcom.PhoneticVariationNode{},
+		},
+		{
+			node:     gedcom.NewPlaceNode(nil, "", "", nil),
+			expected: []*gedcom.PhoneticVariationNode{},
+		},
+		{
+			node:     gedcom.NewPlaceNode(nil, "", "", []gedcom.Node{}),
+			expected: []*gedcom.PhoneticVariationNode{},
+		},
+		{
+			node: gedcom.NewPlaceNode(nil, "", "P1", []gedcom.Node{
+				gedcom.NewPhoneticVariationNode(nil, "", "", []gedcom.Node{}),
+			}),
+			expected: []*gedcom.PhoneticVariationNode{
+				gedcom.NewPhoneticVariationNode(nil, "", "", []gedcom.Node{}),
+			},
+		},
+		{
+			node: gedcom.NewPlaceNode(nil, "", "P1", []gedcom.Node{
+				gedcom.NewPhoneticVariationNode(nil, "", "", []gedcom.Node{}),
+				gedcom.NewSimpleNode(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
+			}),
+			expected: []*gedcom.PhoneticVariationNode{
+				gedcom.NewPhoneticVariationNode(nil, "", "", []gedcom.Node{}),
+			},
+		},
+		{
+			node: gedcom.NewPlaceNode(nil, "", "P1", []gedcom.Node{
+				gedcom.NewPhoneticVariationNode(nil, "foo", "", []gedcom.Node{}),
+				gedcom.NewSimpleNode(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
+				gedcom.NewPhoneticVariationNode(nil, "bar", "", []gedcom.Node{}),
+			}),
+			expected: []*gedcom.PhoneticVariationNode{
+				gedcom.NewPhoneticVariationNode(nil, "foo", "", []gedcom.Node{}),
+				gedcom.NewPhoneticVariationNode(nil, "bar", "", []gedcom.Node{}),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run("", func(t *testing.T) {
+			assert.Equal(t, test.node.PhoneticVariations(), test.expected)
+		})
+	}
+}
+
+func TestPlaceNode_RomanizedVariations(t *testing.T) {
+	var tests = []struct {
+		node     *gedcom.PlaceNode
+		expected []*gedcom.RomanizedVariationNode
+	}{
+		{
+			node:     nil,
+			expected: []*gedcom.RomanizedVariationNode{},
+		},
+		{
+			node:     gedcom.NewPlaceNode(nil, "", "", nil),
+			expected: []*gedcom.RomanizedVariationNode{},
+		},
+		{
+			node:     gedcom.NewPlaceNode(nil, "", "", []gedcom.Node{}),
+			expected: []*gedcom.RomanizedVariationNode{},
+		},
+		{
+			node: gedcom.NewPlaceNode(nil, "", "P1", []gedcom.Node{
+				gedcom.NewRomanizedVariationNode(nil, "", "", []gedcom.Node{}),
+			}),
+			expected: []*gedcom.RomanizedVariationNode{
+				gedcom.NewRomanizedVariationNode(nil, "", "", []gedcom.Node{}),
+			},
+		},
+		{
+			node: gedcom.NewPlaceNode(nil, "", "P1", []gedcom.Node{
+				gedcom.NewRomanizedVariationNode(nil, "", "", []gedcom.Node{}),
+				gedcom.NewSimpleNode(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
+			}),
+			expected: []*gedcom.RomanizedVariationNode{
+				gedcom.NewRomanizedVariationNode(nil, "", "", []gedcom.Node{}),
+			},
+		},
+		{
+			node: gedcom.NewPlaceNode(nil, "", "P1", []gedcom.Node{
+				gedcom.NewRomanizedVariationNode(nil, "foo", "", []gedcom.Node{}),
+				gedcom.NewSimpleNode(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
+				gedcom.NewRomanizedVariationNode(nil, "bar", "", []gedcom.Node{}),
+			}),
+			expected: []*gedcom.RomanizedVariationNode{
+				gedcom.NewRomanizedVariationNode(nil, "foo", "", []gedcom.Node{}),
+				gedcom.NewRomanizedVariationNode(nil, "bar", "", []gedcom.Node{}),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run("", func(t *testing.T) {
+			assert.Equal(t, test.node.RomanizedVariations(), test.expected)
+		})
+	}
+}
+
+func TestPlaceNode_Map(t *testing.T) {
+	var tests = []struct {
+		node     *gedcom.PlaceNode
+		expected *gedcom.MapNode
+	}{
+		{
+			node:     nil,
+			expected: nil,
+		},
+		{
+			node:     gedcom.NewPlaceNode(nil, "", "", nil),
+			expected: nil,
+		},
+		{
+			node:     gedcom.NewPlaceNode(nil, "", "", []gedcom.Node{}),
+			expected: nil,
+		},
+		{
+			node: gedcom.NewPlaceNode(nil, "", "", []gedcom.Node{
+				gedcom.NewMapNode(nil, "", "", []gedcom.Node{}),
+			}),
+			expected: gedcom.NewMapNode(nil, "", "", []gedcom.Node{}),
+		},
+		{
+			node: gedcom.NewPlaceNode(nil, "", "", []gedcom.Node{
+				gedcom.NewNameNode(nil, "", "", []gedcom.Node{}),
+			}),
+			expected: nil,
+		},
+		{
+			node: gedcom.NewPlaceNode(nil, "", "", []gedcom.Node{
+				gedcom.NewNameNode(nil, "", "", []gedcom.Node{}),
+				gedcom.NewMapNode(nil, "1", "", []gedcom.Node{}),
+				gedcom.NewMapNode(nil, "2", "", []gedcom.Node{}),
+			}),
+			expected: gedcom.NewMapNode(nil, "1", "", []gedcom.Node{}),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run("", func(t *testing.T) {
+			assert.Equal(t, test.node.Map(), test.expected)
+		})
+	}
+}
+
+func TestPlaceNode_Notes(t *testing.T) {
+	var tests = []struct {
+		node     *gedcom.PlaceNode
+		expected []*gedcom.NoteNode
+	}{
+		{
+			node:     nil,
+			expected: []*gedcom.NoteNode{},
+		},
+		{
+			node:     gedcom.NewPlaceNode(nil, "", "", nil),
+			expected: []*gedcom.NoteNode{},
+		},
+		{
+			node:     gedcom.NewPlaceNode(nil, "", "", []gedcom.Node{}),
+			expected: []*gedcom.NoteNode{},
+		},
+		{
+			node: gedcom.NewPlaceNode(nil, "", "P1", []gedcom.Node{
+				gedcom.NewNoteNode(nil, "", "", []gedcom.Node{}),
+			}),
+			expected: []*gedcom.NoteNode{
+				gedcom.NewNoteNode(nil, "", "", []gedcom.Node{}),
+			},
+		},
+		{
+			node: gedcom.NewPlaceNode(nil, "", "P1", []gedcom.Node{
+				gedcom.NewNoteNode(nil, "", "", []gedcom.Node{}),
+				gedcom.NewSimpleNode(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
+			}),
+			expected: []*gedcom.NoteNode{
+				gedcom.NewNoteNode(nil, "", "", []gedcom.Node{}),
+			},
+		},
+		{
+			node: gedcom.NewPlaceNode(nil, "", "P1", []gedcom.Node{
+				gedcom.NewNoteNode(nil, "foo", "", []gedcom.Node{}),
+				gedcom.NewSimpleNode(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
+				gedcom.NewNoteNode(nil, "bar", "", []gedcom.Node{}),
+			}),
+			expected: []*gedcom.NoteNode{
+				gedcom.NewNoteNode(nil, "foo", "", []gedcom.Node{}),
+				gedcom.NewNoteNode(nil, "bar", "", []gedcom.Node{}),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run("", func(t *testing.T) {
+			assert.Equal(t, test.node.Notes(), test.expected)
+		})
+	}
+}

--- a/romanized_variation_node.go
+++ b/romanized_variation_node.go
@@ -1,0 +1,40 @@
+package gedcom
+
+// Indicates the method used in transforming the text to a romanized variation.
+//
+// These constants can be used for RomanizedVariationNode.Type.Value. The value
+// is not limited to these constants. Any user defined value is also valid.
+const (
+	RomanizedVariationTypePinyin    = "pinyin"
+	RomanizedVariationTypeRomaji    = "romaji"
+	RomanizedVariationTypeWadegiles = "wadegiles"
+)
+
+// RomanizedVariationNode represents a romanized variation of a superior text
+// string.
+//
+// New in Gedcom 5.5.1.
+type RomanizedVariationNode struct {
+	*SimpleNode
+}
+
+// NewRomanizedVariationNode creates a new ROMN node.
+func NewRomanizedVariationNode(document *Document, value, pointer string, children []Node) *RomanizedVariationNode {
+	return &RomanizedVariationNode{
+		NewSimpleNode(document, TagRomanized, value, pointer, children),
+	}
+}
+
+func (node *RomanizedVariationNode) Type() *TypeNode {
+	return getType(node)
+}
+
+func getType(node Node) *TypeNode {
+	n := First(NodesWithTag(node, TagType))
+
+	if IsNil(n) {
+		return nil
+	}
+
+	return n.(*TypeNode)
+}

--- a/romanized_variation_node_test.go
+++ b/romanized_variation_node_test.go
@@ -1,0 +1,67 @@
+package gedcom_test
+
+import (
+	"github.com/elliotchance/gedcom"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestNewRomanizedVariationNode(t *testing.T) {
+	doc := gedcom.NewDocument()
+	child := gedcom.NewNameNode(doc, "", "", nil)
+	node := gedcom.NewRomanizedVariationNode(doc, "foo", "bar", []gedcom.Node{child})
+
+	assert.NotNil(t, node)
+	assert.IsType(t, node, (*gedcom.RomanizedVariationNode)(nil))
+	assert.Equal(t, gedcom.TagRomanized, node.Tag())
+	assert.Equal(t, []gedcom.Node{child}, node.Nodes())
+	assert.Equal(t, doc, node.Document())
+	assert.Equal(t, "foo", node.Value())
+	assert.Equal(t, "bar", node.Pointer())
+}
+
+func TestRomanizedVariationNode_Type(t *testing.T) {
+	var tests = []struct {
+		node     *gedcom.RomanizedVariationNode
+		expected *gedcom.TypeNode
+	}{
+		{
+			node:     nil,
+			expected: nil,
+		},
+		{
+			node:     gedcom.NewRomanizedVariationNode(nil, "", "", nil),
+			expected: nil,
+		},
+		{
+			node:     gedcom.NewRomanizedVariationNode(nil, "", "", []gedcom.Node{}),
+			expected: nil,
+		},
+		{
+			node: gedcom.NewRomanizedVariationNode(nil, "", "", []gedcom.Node{
+				gedcom.NewTypeNode(nil, "", "", []gedcom.Node{}),
+			}),
+			expected: gedcom.NewTypeNode(nil, "", "", []gedcom.Node{}),
+		},
+		{
+			node: gedcom.NewRomanizedVariationNode(nil, "", "", []gedcom.Node{
+				gedcom.NewNameNode(nil, "", "", []gedcom.Node{}),
+			}),
+			expected: nil,
+		},
+		{
+			node: gedcom.NewRomanizedVariationNode(nil, "", "", []gedcom.Node{
+				gedcom.NewNameNode(nil, "", "", []gedcom.Node{}),
+				gedcom.NewTypeNode(nil, "1", "", []gedcom.Node{}),
+				gedcom.NewTypeNode(nil, "2", "", []gedcom.Node{}),
+			}),
+			expected: gedcom.NewTypeNode(nil, "1", "", []gedcom.Node{}),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run("", func(t *testing.T) {
+			assert.Equal(t, test.node.Type(), test.expected)
+		})
+	}
+}

--- a/tag.go
+++ b/tag.go
@@ -334,11 +334,10 @@ var (
 	// preservation and reference.
 	TagFile = newTag("FILE", "File", tagOptionNone, tagSortIndividualInfo)
 
-	// A phonetic variation of a superior text string. New in Gedcom 5.5.1
+	// See PhoneticNode.
 	TagPhonetic = newTag("FONE", "Phonetic", tagOptionNone, tagSortIndividualInfo)
 
-	// An assigned name given to a consistent format in which information can be
-	// conveyed.
+	// See FormatNode.
 	TagFormat = newTag("FORM", "Format", tagOptionNone, tagSortIndividualInfo)
 
 	// Information about the use of GEDCOM in a transmission.
@@ -377,20 +376,17 @@ var (
 	// information.
 	TagLanguage = newTag("LANG", "Language", tagOptionNone, tagSortIndividualInfo)
 
-	// A value indicating a coordinate position on a line, plane, or space. New
-	// in Gedcom 5.5.1.
+	// See LatitudeNode.
 	TagLatitude = newTag("LATI", "Latitude", tagOptionNone, tagSortIndividualInfo)
 
 	// A role of an individual acting as a person receiving a bequest or legal
 	// devise.
 	TagLegatee = newTag("LEGA", "Legatee", tagOptionNone, tagSortIndividualInfo)
 
-	// A value indicating a coordinate position on a line, plane, or space. New
-	// in Gedcom 5.5.1.
+	// See LongitudeNode.
 	TagLongitude = newTag("LONG", "Longitude", tagOptionNone, tagSortIndividualInfo)
 
-	// Pertains to a representation of measurements usually presented in a
-	// graphical form. New in Gedcom 5.5.1
+	// See MapNode.
 	TagMap = newTag("MAP", "Map", tagOptionNone, tagSortIndividualInfo)
 
 	// An event of an official public notice given that two people intend to
@@ -444,8 +440,7 @@ var (
 	// or parent.
 	TagMarriageCount = newTag("NMR", "Marriage Count", tagOptionNone, tagSortIndividualInfo)
 
-	// Additional information provided by the submitter for understanding the
-	// enclosing data.
+	// See NoteNode.
 	TagNote = newTag("NOTE", "Note", tagOptionNone, tagSortIndividualInfo)
 
 	// Text which appears on a name line before the given and surname parts of a
@@ -487,7 +482,7 @@ var (
 	// A unique number assigned to access a specific telephone.
 	TagPhone = newTag("PHON", "Phone", tagOptionNone, tagSortIndividualInfo)
 
-	// A jurisdictional name to identify the place or location of an event.
+	// See PlaceNode.
 	TagPlace = newTag("PLAC", "Place", tagOptionNone, tagSortIndividualInfo)
 
 	// A code used by a postal service to identify an area to facilitate mail
@@ -613,10 +608,7 @@ var (
 	// At level 0, specifies the end of a GEDCOM transmission.
 	TagTrailer = newTag("TRLR", "Trailer", tagOptionNone, tagSortIndividualInfo)
 
-	// A further qualification to the meaning of the associated superior tag.
-	// The value does not have any computer processing reliability. It is more
-	// in the form of a short one or two word note that should be displayed any
-	// time the associated data is displayed.
+	// See TypeNode.
 	TagType = newTag("TYPE", "Type", tagOptionNone, tagSortIndividualInfo)
 
 	// Indicates which version of a product, item, or publication is being used

--- a/type_node.go
+++ b/type_node.go
@@ -1,0 +1,18 @@
+package gedcom
+
+// TypeNode represents a further qualification to the meaning of the associated
+// superior tag.
+//
+// The value does not have any computer processing reliability. It is more in
+// the form of a short one or two word note that should be displayed any time
+// the associated data is displayed.
+type TypeNode struct {
+	*SimpleNode
+}
+
+// NewTypeNode creates a new TYPE node.
+func NewTypeNode(document *Document, value, pointer string, children []Node) *TypeNode {
+	return &TypeNode{
+		NewSimpleNode(document, TagType, value, pointer, children),
+	}
+}

--- a/type_node_test.go
+++ b/type_node_test.go
@@ -1,0 +1,21 @@
+package gedcom_test
+
+import (
+	"github.com/elliotchance/gedcom"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestNewTypeNode(t *testing.T) {
+	doc := gedcom.NewDocument()
+	child := gedcom.NewNameNode(doc, "", "", nil)
+	node := gedcom.NewTypeNode(doc, "foo", "bar", []gedcom.Node{child})
+
+	assert.NotNil(t, node)
+	assert.IsType(t, node, (*gedcom.TypeNode)(nil))
+	assert.Equal(t, gedcom.TagType, node.Tag())
+	assert.Equal(t, []gedcom.Node{child}, node.Nodes())
+	assert.Equal(t, doc, node.Document())
+	assert.Equal(t, "foo", node.Value())
+	assert.Equal(t, "bar", node.Pointer())
+}


### PR DESCRIPTION
- Added more functions to PlaceNode to complete the PLAC spec.
- Added several new nodes; FormatNode, LatitudeNode, LongitudeNode, MapNode, NoteNode, PhoneticVariationNode, RomanizedVariationNode, TypeNode.
- Added CastNodes which creates a slice of a more specific node type.
- Added Phonetic and Romanized variation type constants.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/gedcom/132)
<!-- Reviewable:end -->
