### PR TITLE
Remove NewSimpleNode. Fixes #131

### DIFF
--- a/birth_node.go
+++ b/birth_node.go
@@ -8,7 +8,7 @@ type BirthNode struct {
 // NewBirthNode creates a new BIRT node.
 func NewBirthNode(document *Document, value, pointer string, children []Node) *BirthNode {
 	return &BirthNode{
-		NewSimpleNode(document, TagBirth, value, pointer, children),
+		newSimpleNode(document, TagBirth, value, pointer, children),
 	}
 }
 

--- a/date_node.go
+++ b/date_node.go
@@ -137,7 +137,7 @@ type DateNode struct {
 // NewDateNode creates a new DATE node.
 func NewDateNode(document *Document, value, pointer string, children []Node) *DateNode {
 	return &DateNode{
-		NewSimpleNode(document, TagDate, value, pointer, children),
+		newSimpleNode(document, TagDate, value, pointer, children),
 		false, Date{}, Date{},
 	}
 }

--- a/decoder.go
+++ b/decoder.go
@@ -158,24 +158,28 @@ func parseLine(document *Document, line string) (Node, int, error) {
 // If the node tag is recognised as a more specific type, such as *DateNode then
 // that will be returned. Otherwise a *SimpleNode will be used.
 func NewNode(document *Document, tag Tag, value, pointer string) Node {
+	return NewNodeWithChildren(document, tag, value, pointer, nil)
+}
+
+func NewNodeWithChildren(document *Document, tag Tag, value, pointer string, children []Node) Node {
 	switch tag {
 	case TagBirth:
-		return NewBirthNode(document, value, pointer, nil)
+		return NewBirthNode(document, value, pointer, children)
 
 	case TagDate:
-		return NewDateNode(document, value, pointer, nil)
+		return NewDateNode(document, value, pointer, children)
 
 	case TagEvent:
-		return NewEventNode(document, value, pointer, nil)
+		return NewEventNode(document, value, pointer, children)
 
 	case TagFamily:
-		return NewFamilyNode(document, pointer, nil)
+		return NewFamilyNode(document, pointer, children)
 
 	case TagFormat:
 		return NewFormatNode(document, value, pointer, nil)
 
 	case TagIndividual:
-		return NewIndividualNode(document, value, pointer, nil)
+		return NewIndividualNode(document, value, pointer, children)
 
 	case TagLatitude:
 		return NewLatitudeNode(document, value, pointer, nil)
@@ -187,7 +191,7 @@ func NewNode(document *Document, tag Tag, value, pointer string) Node {
 		return NewMapNode(document, value, pointer, nil)
 
 	case TagName:
-		return NewNameNode(document, value, pointer, nil)
+		return NewNameNode(document, value, pointer, children)
 
 	case TagNote:
 		return NewNoteNode(document, value, pointer, nil)
@@ -196,20 +200,20 @@ func NewNode(document *Document, tag Tag, value, pointer string) Node {
 		return NewPhoneticVariationNode(document, value, pointer, nil)
 
 	case TagPlace:
-		return NewPlaceNode(document, value, pointer, nil)
+		return NewPlaceNode(document, value, pointer, children)
 
 	case TagResidence:
-		return NewResidenceNode(document, value, pointer, nil)
+		return NewResidenceNode(document, value, pointer, children)
 
 	case TagRomanized:
 		return NewRomanizedVariationNode(document, value, pointer, nil)
 
 	case TagSource:
-		return NewSourceNode(document, value, pointer, nil)
+		return NewSourceNode(document, value, pointer, children)
 
 	case TagType:
 		return NewTypeNode(document, value, pointer, nil)
 	}
 
-	return NewSimpleNode(document, tag, value, pointer, nil)
+	return newSimpleNode(document, tag, value, pointer, children)
 }

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -17,75 +17,75 @@ var tests = map[string]*gedcom.Document{
 	},
 	"0 HEAD": {
 		Nodes: []gedcom.Node{
-			gedcom.NewSimpleNode(nil, gedcom.TagHeader, "", "", nil),
+			gedcom.NewNode(nil, gedcom.TagHeader, "", ""),
 		},
 	},
 	"0 HEAD\n1 CHAR UTF-8": {
 		Nodes: []gedcom.Node{
-			gedcom.NewSimpleNode(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagCharacterSet, "UTF-8", "", nil),
+			gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
+				gedcom.NewNode(nil, gedcom.TagCharacterSet, "UTF-8", ""),
 			}),
 		},
 	},
 	"0 HEAD\n\n1 CHAR UTF-8\n": {
 		Nodes: []gedcom.Node{
-			gedcom.NewSimpleNode(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagCharacterSet, "UTF-8", "", nil),
+			gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
+				gedcom.NewNode(nil, gedcom.TagCharacterSet, "UTF-8", ""),
 			}),
 		},
 	},
 	"0 HEAD\n1 CHAR UTF-8\n1 SOUR Ancestry.com Family Trees": {
 		Nodes: []gedcom.Node{
-			gedcom.NewSimpleNode(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagCharacterSet, "UTF-8", "", nil),
+			gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
+				gedcom.NewNode(nil, gedcom.TagCharacterSet, "UTF-8", ""),
 				gedcom.NewSourceNode(nil, "Ancestry.com Family Trees", "", nil),
 			}),
 		},
 	},
 	"0 HEAD\n1 CHAR UTF-8\n1 CHAR UTF-8": {
 		Nodes: []gedcom.Node{
-			gedcom.NewSimpleNode(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagCharacterSet, "UTF-8", "", nil),
-				gedcom.NewSimpleNode(nil, gedcom.TagCharacterSet, "UTF-8", "", nil),
+			gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
+				gedcom.NewNode(nil, gedcom.TagCharacterSet, "UTF-8", ""),
+				gedcom.NewNode(nil, gedcom.TagCharacterSet, "UTF-8", ""),
 			}),
 		},
 	},
 	"0 HEAD\n1 SOUR Ancestry.com Family Trees": {
 		Nodes: []gedcom.Node{
-			gedcom.NewSimpleNode(nil, gedcom.TagHeader, "", "", []gedcom.Node{
+			gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
 				gedcom.NewSourceNode(nil, "Ancestry.com Family Trees", "", nil),
 			}),
 		},
 	},
 	"0 HEAD\n1 BIRT": {
 		Nodes: []gedcom.Node{
-			gedcom.NewSimpleNode(nil, gedcom.TagHeader, "", "", []gedcom.Node{
+			gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
 				gedcom.NewBirthNode(nil, "", "", nil),
 			}),
 		},
 	},
 	"0 HEAD\n1 GEDC\n2 VERS (2010.3)": {
 		Nodes: []gedcom.Node{
-			gedcom.NewSimpleNode(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagGedcomInformation, "", "", []gedcom.Node{
-					gedcom.NewSimpleNode(nil, gedcom.TagVersion, "(2010.3)", "", nil),
+			gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
+				gedcom.NewNodeWithChildren(nil, gedcom.TagGedcomInformation, "", "", []gedcom.Node{
+					gedcom.NewNode(nil, gedcom.TagVersion, "(2010.3)", ""),
 				}),
 			}),
 		},
 	},
 	"0 HEAD\n1 GEDC\n2 VERS 5.5": {
 		Nodes: []gedcom.Node{
-			gedcom.NewSimpleNode(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagGedcomInformation, "", "", []gedcom.Node{
-					gedcom.NewSimpleNode(nil, gedcom.TagVersion, "5.5", "", nil),
+			gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
+				gedcom.NewNodeWithChildren(nil, gedcom.TagGedcomInformation, "", "", []gedcom.Node{
+					gedcom.NewNode(nil, gedcom.TagVersion, "5.5", ""),
 				}),
 			}),
 		},
 	},
 	"0 HEAD\n1 GEDC\n2 FORM LINEAGE-LINKED": {
 		Nodes: []gedcom.Node{
-			gedcom.NewSimpleNode(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagGedcomInformation, "", "", []gedcom.Node{
+			gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
+				gedcom.NewNodeWithChildren(nil, gedcom.TagGedcomInformation, "", "", []gedcom.Node{
 					gedcom.NewFormatNode(nil, "LINEAGE-LINKED", "", nil),
 				}),
 			}),
@@ -93,7 +93,7 @@ var tests = map[string]*gedcom.Document{
 	},
 	"0 HEAD\n1 BIRT\n2 PLAC Camperdown, Nsw, Australia": {
 		Nodes: []gedcom.Node{
-			gedcom.NewSimpleNode(nil, gedcom.TagHeader, "", "", []gedcom.Node{
+			gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
 				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
 					gedcom.NewPlaceNode(nil, "Camperdown, Nsw, Australia", "", nil),
 				}),
@@ -102,45 +102,45 @@ var tests = map[string]*gedcom.Document{
 	},
 	"0 HEAD\n1 NAME Elliot Rupert de Peyster /Chance/": {
 		Nodes: []gedcom.Node{
-			gedcom.NewSimpleNode(nil, gedcom.TagHeader, "", "", []gedcom.Node{
+			gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
 				gedcom.NewNameNode(nil, "Elliot Rupert de Peyster /Chance/", "", nil),
 			}),
 		},
 	},
 	"0 HEAD\n0 @P1@ INDI": {
 		Nodes: []gedcom.Node{
-			gedcom.NewSimpleNode(nil, gedcom.TagHeader, "", "", nil),
+			gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", nil),
 			gedcom.NewIndividualNode(nil, "", "P1", nil),
 		},
 	},
 	"0 HEAD\n1 SEX M\n0 @P1@ INDI": {
 		Nodes: []gedcom.Node{
-			gedcom.NewSimpleNode(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagSex, "M", "", nil),
+			gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
+				gedcom.NewNode(nil, gedcom.TagSex, "M", ""),
 			}),
 			gedcom.NewIndividualNode(nil, "", "P1", nil),
 		},
 	},
 	"0 HEAD\n1 SEX M": {
 		Nodes: []gedcom.Node{
-			gedcom.NewSimpleNode(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagSex, "M", "", nil),
+			gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
+				gedcom.NewNode(nil, gedcom.TagSex, "M", ""),
 			}),
 		},
 	},
 	"0 HEAD\n1 BIRT\n2 PLAC Camperdown, Nsw, Australia\n1 SEX M": {
 		Nodes: []gedcom.Node{
-			gedcom.NewSimpleNode(nil, gedcom.TagHeader, "", "", []gedcom.Node{
+			gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
 				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
 					gedcom.NewPlaceNode(nil, "Camperdown, Nsw, Australia", "", nil),
 				}),
-				gedcom.NewSimpleNode(nil, gedcom.TagSex, "M", "", nil),
+				gedcom.NewNode(nil, gedcom.TagSex, "M", ""),
 			}),
 		},
 	},
 	"0 HEAD\n0 @P1@ INDI\n1 BIRT": {
 		Nodes: []gedcom.Node{
-			gedcom.NewSimpleNode(nil, gedcom.TagHeader, "", "", nil),
+			gedcom.NewNode(nil, gedcom.TagHeader, "", ""),
 			gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
 				gedcom.NewBirthNode(nil, "", "", nil),
 			}),
@@ -148,8 +148,8 @@ var tests = map[string]*gedcom.Document{
 	},
 	"0 HEAD\n1 GEDC\n2 FORM LINEAGE-LINKED\n0 @P1@ INDI": {
 		Nodes: []gedcom.Node{
-			gedcom.NewSimpleNode(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagGedcomInformation, "", "", []gedcom.Node{
+			gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
+				gedcom.NewNodeWithChildren(nil, gedcom.TagGedcomInformation, "", "", []gedcom.Node{
 					gedcom.NewFormatNode(nil, "LINEAGE-LINKED", "", nil),
 				}),
 			}),
@@ -158,55 +158,55 @@ var tests = map[string]*gedcom.Document{
 	},
 	"0 HEAD0\n1 HEAD1\n2 HEAD2\n3 HEAD3\n0 HEAD00": {
 		Nodes: []gedcom.Node{
-			gedcom.NewSimpleNode(nil, gedcom.TagFromString("HEAD0"), "", "", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagFromString("HEAD1"), "", "", []gedcom.Node{
-					gedcom.NewSimpleNode(nil, gedcom.TagFromString("HEAD2"), "", "", []gedcom.Node{
-						gedcom.NewSimpleNode(nil, gedcom.TagFromString("HEAD3"), "", "", nil),
+			gedcom.NewNodeWithChildren(nil, gedcom.TagFromString("HEAD0"), "", "", []gedcom.Node{
+				gedcom.NewNodeWithChildren(nil, gedcom.TagFromString("HEAD1"), "", "", []gedcom.Node{
+					gedcom.NewNodeWithChildren(nil, gedcom.TagFromString("HEAD2"), "", "", []gedcom.Node{
+						gedcom.NewNode(nil, gedcom.TagFromString("HEAD3"), "", ""),
 					}),
 				}),
 			}),
-			gedcom.NewSimpleNode(nil, gedcom.TagFromString("HEAD00"), "", "", nil),
+			gedcom.NewNode(nil, gedcom.TagFromString("HEAD00"), "", ""),
 		},
 	},
 	"0 HEAD0\n1 HEAD1\n2 HEAD2\n3 HEAD3\n1 HEAD10": {
 		Nodes: []gedcom.Node{
-			gedcom.NewSimpleNode(nil, gedcom.TagFromString("HEAD0"), "", "", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagFromString("HEAD1"), "", "", []gedcom.Node{
-					gedcom.NewSimpleNode(nil, gedcom.TagFromString("HEAD2"), "", "", []gedcom.Node{
-						gedcom.NewSimpleNode(nil, gedcom.TagFromString("HEAD3"), "", "", nil),
+			gedcom.NewNodeWithChildren(nil, gedcom.TagFromString("HEAD0"), "", "", []gedcom.Node{
+				gedcom.NewNodeWithChildren(nil, gedcom.TagFromString("HEAD1"), "", "", []gedcom.Node{
+					gedcom.NewNodeWithChildren(nil, gedcom.TagFromString("HEAD2"), "", "", []gedcom.Node{
+						gedcom.NewNode(nil, gedcom.TagFromString("HEAD3"), "", ""),
 					}),
 				}),
-				gedcom.NewSimpleNode(nil, gedcom.TagFromString("HEAD10"), "", "", nil),
+				gedcom.NewNode(nil, gedcom.TagFromString("HEAD10"), "", ""),
 			}),
 		},
 	},
 	"0 HEAD0\r1 HEAD1": {
 		Nodes: []gedcom.Node{
-			gedcom.NewSimpleNode(nil, gedcom.TagFromString("HEAD0"), "", "", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagFromString("HEAD1"), "", "", nil),
+			gedcom.NewNodeWithChildren(nil, gedcom.TagFromString("HEAD0"), "", "", []gedcom.Node{
+				gedcom.NewNode(nil, gedcom.TagFromString("HEAD1"), "", ""),
 			}),
 		},
 	},
 	"0 HEAD0\r\n1 HEAD1": {
 		Nodes: []gedcom.Node{
-			gedcom.NewSimpleNode(nil, gedcom.TagFromString("HEAD0"), "", "", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagFromString("HEAD1"), "", "", nil),
+			gedcom.NewNodeWithChildren(nil, gedcom.TagFromString("HEAD0"), "", "", []gedcom.Node{
+				gedcom.NewNode(nil, gedcom.TagFromString("HEAD1"), "", ""),
 			}),
 		},
 	},
 	"0 HEAD0\n1 HEAD1\n1 HEAD10\n2 HEAD2": {
 		Nodes: []gedcom.Node{
-			gedcom.NewSimpleNode(nil, gedcom.TagFromString("HEAD0"), "", "", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagFromString("HEAD1"), "", "", nil),
-				gedcom.NewSimpleNode(nil, gedcom.TagFromString("HEAD10"), "", "", []gedcom.Node{
-					gedcom.NewSimpleNode(nil, gedcom.TagFromString("HEAD2"), "", "", nil),
+			gedcom.NewNodeWithChildren(nil, gedcom.TagFromString("HEAD0"), "", "", []gedcom.Node{
+				gedcom.NewNode(nil, gedcom.TagFromString("HEAD1"), "", ""),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagFromString("HEAD10"), "", "", []gedcom.Node{
+					gedcom.NewNode(nil, gedcom.TagFromString("HEAD2"), "", ""),
 				}),
 			}),
 		},
 	},
 	"0 HEAD\n1 BIRT ": {
 		Nodes: []gedcom.Node{
-			gedcom.NewSimpleNode(nil, gedcom.TagHeader, "", "", []gedcom.Node{
+			gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
 				gedcom.NewBirthNode(nil, "", "", nil),
 			}),
 		},
@@ -217,7 +217,7 @@ var tests = map[string]*gedcom.Document{
 				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
 					gedcom.NewDateNode(nil, "1851", "", nil),
 				}),
-				gedcom.NewSimpleNode(nil, gedcom.TagDeath, "", "", []gedcom.Node{
+				gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "", "", []gedcom.Node{
 					gedcom.NewDateNode(nil, "1856", "", nil),
 				}),
 			}),
@@ -226,8 +226,8 @@ var tests = map[string]*gedcom.Document{
 	"0 @F1@ FAM\n1 HUSB @P2@\n1 WIFE @P3@": {
 		Nodes: []gedcom.Node{
 			gedcom.NewFamilyNode(nil, "F1", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagHusband, "@P2@", "", nil),
-				gedcom.NewSimpleNode(nil, gedcom.TagWife, "@P3@", "", nil),
+				gedcom.NewNode(nil, gedcom.TagHusband, "@P2@", ""),
+				gedcom.NewNode(nil, gedcom.TagWife, "@P3@", ""),
 			}),
 		},
 	},
@@ -301,7 +301,7 @@ func TestNewNode(t *testing.T) {
 		{gedcom.TagRomanized, gedcom.NewRomanizedVariationNode(nil, v, p, nil)},
 		{gedcom.TagSource, gedcom.NewSourceNode(nil, v, p, nil)},
 		{gedcom.TagType, gedcom.NewTypeNode(nil, v, p, nil)},
-		{gedcom.TagVersion, gedcom.NewSimpleNode(nil, gedcom.TagVersion, v, p, nil)},
+		{gedcom.TagVersion, gedcom.NewNode(nil, gedcom.TagVersion, v, p)},
 	} {
 		t.Run(test.tag.String(), func(t *testing.T) {
 			assert.Equal(t, test.expected, gedcom.NewNode(nil, test.tag, v, p))

--- a/document_test.go
+++ b/document_test.go
@@ -43,7 +43,7 @@ var documentTests = []struct {
 				gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
 					gedcom.NewNameNode(nil, "Joe /Bloggs/", "", []gedcom.Node{}),
 				}),
-				gedcom.NewSimpleNode(nil, gedcom.TagVersion, "", "", []gedcom.Node{}),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagVersion, "", "", []gedcom.Node{}),
 				gedcom.NewIndividualNode(nil, "", "P2", []gedcom.Node{
 					gedcom.NewNameNode(nil, "John /Doe/", "", []gedcom.Node{}),
 				}),

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -14,7 +14,7 @@ func TestGedcomLine(t *testing.T) {
 	GedcomLine(0, gedcom.NewBirthNode(nil, "foo", "72", nil)).
 		Returns("0 @72@ BIRT foo")
 
-	GedcomLine(3, gedcom.NewSimpleNode(nil, gedcom.TagDeath, "bar", "baz", nil)).
+	GedcomLine(3, gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "bar", "baz", nil)).
 		Returns("3 @baz@ DEAT bar")
 
 	GedcomLine(2, gedcom.NewDateNode(nil, "3 SEP 1945", "", nil)).

--- a/event_node.go
+++ b/event_node.go
@@ -9,7 +9,7 @@ type EventNode struct {
 // EventNode creates a new EVEN node.
 func NewEventNode(document *Document, value, pointer string, children []Node) *EventNode {
 	return &EventNode{
-		NewSimpleNode(document, TagEvent, value, pointer, children),
+		newSimpleNode(document, TagEvent, value, pointer, children),
 	}
 }
 

--- a/family_node.go
+++ b/family_node.go
@@ -9,7 +9,7 @@ type FamilyNode struct {
 
 func NewFamilyNode(document *Document, pointer string, children []Node) *FamilyNode {
 	return &FamilyNode{
-		NewSimpleNode(document, TagFamily, "", pointer, children),
+		newSimpleNode(document, TagFamily, "", pointer, children),
 		false, false, nil, nil,
 	}
 }

--- a/family_node_test.go
+++ b/family_node_test.go
@@ -26,7 +26,7 @@ var familyTests = []struct {
 		doc: &gedcom.Document{
 			Nodes: []gedcom.Node{
 				gedcom.NewFamilyNode(nil, "F1", []gedcom.Node{
-					gedcom.NewSimpleNode(nil, gedcom.TagHusband, "@P1@", "", []gedcom.Node{}),
+					gedcom.NewNodeWithChildren(nil, gedcom.TagHusband, "@P1@", "", []gedcom.Node{}),
 				}),
 				gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{}),
 			},
@@ -38,7 +38,7 @@ var familyTests = []struct {
 		doc: &gedcom.Document{
 			Nodes: []gedcom.Node{
 				gedcom.NewFamilyNode(nil, "F2", []gedcom.Node{
-					gedcom.NewSimpleNode(nil, gedcom.TagWife, "@P3@", "", []gedcom.Node{}),
+					gedcom.NewNodeWithChildren(nil, gedcom.TagWife, "@P3@", "", []gedcom.Node{}),
 				}),
 				gedcom.NewIndividualNode(nil, "", "P3", []gedcom.Node{}),
 			},
@@ -106,12 +106,12 @@ func TestFamilyNode_Similarity(t *testing.T) {
 			doc: &gedcom.Document{
 				Nodes: []gedcom.Node{
 					gedcom.NewFamilyNode(nil, "F1", []gedcom.Node{
-						gedcom.NewSimpleNode(nil, gedcom.TagHusband, "@P1@", "", nil),
-						gedcom.NewSimpleNode(nil, gedcom.TagWife, "@P2@", "", nil),
+						gedcom.NewNodeWithChildren(nil, gedcom.TagHusband, "@P1@", "", nil),
+						gedcom.NewNodeWithChildren(nil, gedcom.TagWife, "@P2@", "", nil),
 					}),
 					gedcom.NewFamilyNode(nil, "F2", []gedcom.Node{
-						gedcom.NewSimpleNode(nil, gedcom.TagHusband, "@P3@", "", nil),
-						gedcom.NewSimpleNode(nil, gedcom.TagWife, "@P4@", "", nil),
+						gedcom.NewNodeWithChildren(nil, gedcom.TagHusband, "@P3@", "", nil),
+						gedcom.NewNodeWithChildren(nil, gedcom.TagWife, "@P4@", "", nil),
 					}),
 					gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
 						name("Elliot Rupert de Peyster /Chance/"),
@@ -144,12 +144,12 @@ func TestFamilyNode_Similarity(t *testing.T) {
 			doc: &gedcom.Document{
 				Nodes: []gedcom.Node{
 					gedcom.NewFamilyNode(nil, "F1", []gedcom.Node{
-						gedcom.NewSimpleNode(nil, gedcom.TagHusband, "@P1@", "", nil),
-						gedcom.NewSimpleNode(nil, gedcom.TagWife, "@P2@", "", nil),
+						gedcom.NewNodeWithChildren(nil, gedcom.TagHusband, "@P1@", "", nil),
+						gedcom.NewNodeWithChildren(nil, gedcom.TagWife, "@P2@", "", nil),
 					}),
 					gedcom.NewFamilyNode(nil, "F2", []gedcom.Node{
-						gedcom.NewSimpleNode(nil, gedcom.TagHusband, "@P3@", "", nil),
-						gedcom.NewSimpleNode(nil, gedcom.TagWife, "@P4@", "", nil),
+						gedcom.NewNodeWithChildren(nil, gedcom.TagHusband, "@P3@", "", nil),
+						gedcom.NewNodeWithChildren(nil, gedcom.TagWife, "@P4@", "", nil),
 					}),
 					gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
 						name("Elliot Rupert de Peyster /Chance/"),
@@ -179,12 +179,12 @@ func TestFamilyNode_Similarity(t *testing.T) {
 			doc: &gedcom.Document{
 				Nodes: []gedcom.Node{
 					gedcom.NewFamilyNode(nil, "F1", []gedcom.Node{
-						gedcom.NewSimpleNode(nil, gedcom.TagHusband, "@P1@", "", nil),
-						gedcom.NewSimpleNode(nil, gedcom.TagWife, "@P2@", "", nil),
+						gedcom.NewNodeWithChildren(nil, gedcom.TagHusband, "@P1@", "", nil),
+						gedcom.NewNodeWithChildren(nil, gedcom.TagWife, "@P2@", "", nil),
 					}),
 					gedcom.NewFamilyNode(nil, "F2", []gedcom.Node{
-						gedcom.NewSimpleNode(nil, gedcom.TagHusband, "@P3@", "", nil),
-						gedcom.NewSimpleNode(nil, gedcom.TagWife, "@P4@", "", nil),
+						gedcom.NewNodeWithChildren(nil, gedcom.TagHusband, "@P3@", "", nil),
+						gedcom.NewNodeWithChildren(nil, gedcom.TagWife, "@P4@", "", nil),
 					}),
 					gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
 						name("Elliot Rupert de Peyster /Chance/"),

--- a/filter_test.go
+++ b/filter_test.go
@@ -214,7 +214,7 @@ func TestBlacklistTagFilter(t *testing.T) {
 
 func TestOfficialTagFilter(t *testing.T) {
 	root := gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-		gedcom.NewSimpleNode(nil, gedcom.UnofficialTagCreated, "Elliot /Chance/", "", []gedcom.Node{
+		gedcom.NewNodeWithChildren(nil, gedcom.UnofficialTagCreated, "Elliot /Chance/", "", []gedcom.Node{
 			gedcom.NewDateNode(nil, "3 Mar 2007", "", nil),
 		}),
 		gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
@@ -264,7 +264,7 @@ func TestSimpleNameFilter(t *testing.T) {
 					gedcom.NewDateNode(nil, "6 MAY 1989", "", nil),
 				}),
 				gedcom.NewNameNode(nil, "Elliot /Chance/", "", []gedcom.Node{
-					gedcom.NewSimpleNode(nil, gedcom.TagSurname, "Smith", "", nil),
+					gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, "Smith", "", nil),
 				}),
 			}),
 			expected: `0 @P1@ INDI
@@ -276,8 +276,8 @@ func TestSimpleNameFilter(t *testing.T) {
 		{
 			root: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
 				gedcom.NewNameNode(nil, "", "", []gedcom.Node{
-					gedcom.NewSimpleNode(nil, gedcom.TagGivenName, "Bob", "", nil),
-					gedcom.NewSimpleNode(nil, gedcom.TagSurname, "Smith", "", nil),
+					gedcom.NewNodeWithChildren(nil, gedcom.TagGivenName, "Bob", "", nil),
+					gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, "Smith", "", nil),
 				}),
 				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
 					gedcom.NewDateNode(nil, "6 MAY 1989", "", nil),

--- a/format_node.go
+++ b/format_node.go
@@ -9,6 +9,6 @@ type FormatNode struct {
 // NewFormatNode creates a new FORM node.
 func NewFormatNode(document *Document, value, pointer string, children []Node) *FormatNode {
 	return &FormatNode{
-		NewSimpleNode(document, TagFormat, value, pointer, children),
+		newSimpleNode(document, TagFormat, value, pointer, children),
 	}
 }

--- a/gedcom2json/transform_test.go
+++ b/gedcom2json/transform_test.go
@@ -17,7 +17,7 @@ var transformTests = []struct {
 	{
 		doc: &gedcom.Document{
 			Nodes: []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagVersion, "5.5", "", nil),
+				gedcom.NewNode(nil, gedcom.TagVersion, "5.5", ""),
 			},
 		},
 		expected: []interface{}{

--- a/individual_node.go
+++ b/individual_node.go
@@ -20,7 +20,7 @@ type SpouseChildren map[*IndividualNode]IndividualNodes
 
 func NewIndividualNode(document *Document, value, pointer string, children []Node) *IndividualNode {
 	return &IndividualNode{
-		NewSimpleNode(document, TagIndividual, value, pointer, children),
+		newSimpleNode(document, TagIndividual, value, pointer, children),
 		false, false, nil, nil,
 	}
 }

--- a/individual_node_test.go
+++ b/individual_node_test.go
@@ -35,7 +35,7 @@ var individualTests = []struct {
 	{
 		node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
 			gedcom.NewNameNode(nil, "Joe /Bloggs/", "", []gedcom.Node{}),
-			gedcom.NewSimpleNode(nil, gedcom.TagVersion, "", "", []gedcom.Node{}),
+			gedcom.NewNodeWithChildren(nil, gedcom.TagVersion, "", "", []gedcom.Node{}),
 			gedcom.NewNameNode(nil, "John /Doe/", "", []gedcom.Node{}),
 		}),
 		names: []*gedcom.NameNode{
@@ -46,7 +46,7 @@ var individualTests = []struct {
 	},
 	{
 		node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-			gedcom.NewSimpleNode(nil, gedcom.TagSex, "M", "", []gedcom.Node{}),
+			gedcom.NewNodeWithChildren(nil, gedcom.TagSex, "M", "", []gedcom.Node{}),
 		}),
 		names: []*gedcom.NameNode{},
 		sex:   gedcom.SexMale,
@@ -54,7 +54,7 @@ var individualTests = []struct {
 	{
 		node: gedcom.NewIndividualNode(nil, "", "P2", []gedcom.Node{
 			gedcom.NewNameNode(nil, "Joan /Bloggs/", "", []gedcom.Node{}),
-			gedcom.NewSimpleNode(nil, gedcom.TagSex, "F", "", []gedcom.Node{}),
+			gedcom.NewNodeWithChildren(nil, gedcom.TagSex, "F", "", []gedcom.Node{}),
 		}),
 		names: []*gedcom.NameNode{
 			gedcom.NewNameNode(nil, "Joan /Bloggs/", "", []gedcom.Node{}),
@@ -115,7 +115,7 @@ func TestIndividualNode_Births(t *testing.T) {
 		{
 			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
 				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{}),
-				gedcom.NewSimpleNode(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
 			}),
 			births: []*gedcom.BirthNode{
 				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{}),
@@ -124,7 +124,7 @@ func TestIndividualNode_Births(t *testing.T) {
 		{
 			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
 				gedcom.NewBirthNode(nil, "foo", "", []gedcom.Node{}),
-				gedcom.NewSimpleNode(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
 				gedcom.NewBirthNode(nil, "bar", "", []gedcom.Node{}),
 			}),
 			births: []*gedcom.BirthNode{
@@ -160,36 +160,36 @@ func TestIndividualNode_Baptisms(t *testing.T) {
 		},
 		{
 			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagBaptism, "", "", []gedcom.Node{}),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagBaptism, "", "", []gedcom.Node{}),
 			}),
 			baptisms: []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagBaptism, "", "", []gedcom.Node{}),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagBaptism, "", "", []gedcom.Node{}),
 			},
 		},
 		{
 			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagLDSBaptism, "", "", []gedcom.Node{}),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagLDSBaptism, "", "", []gedcom.Node{}),
 			}),
 			baptisms: []gedcom.Node{},
 		},
 		{
 			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagBaptism, "", "", []gedcom.Node{}),
-				gedcom.NewSimpleNode(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagBaptism, "", "", []gedcom.Node{}),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
 			}),
 			baptisms: []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagBaptism, "", "", []gedcom.Node{}),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagBaptism, "", "", []gedcom.Node{}),
 			},
 		},
 		{
 			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagBaptism, "foo", "", []gedcom.Node{}),
-				gedcom.NewSimpleNode(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
-				gedcom.NewSimpleNode(nil, gedcom.TagBaptism, "bar", "", []gedcom.Node{}),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagBaptism, "foo", "", []gedcom.Node{}),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagBaptism, "bar", "", []gedcom.Node{}),
 			}),
 			baptisms: []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagBaptism, "foo", "", []gedcom.Node{}),
-				gedcom.NewSimpleNode(nil, gedcom.TagBaptism, "bar", "", []gedcom.Node{}),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagBaptism, "foo", "", []gedcom.Node{}),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagBaptism, "bar", "", []gedcom.Node{}),
 			},
 		},
 	}
@@ -220,30 +220,30 @@ func TestIndividualNode_Deaths(t *testing.T) {
 		},
 		{
 			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
 			}),
 			deaths: []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
 			},
 		},
 		{
 			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
 				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{}),
 			}),
 			deaths: []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
 			},
 		},
 		{
 			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagDeath, "foo", "", []gedcom.Node{}),
-				gedcom.NewSimpleNode(nil, gedcom.TagBurial, "", "", []gedcom.Node{}),
-				gedcom.NewSimpleNode(nil, gedcom.TagDeath, "bar", "", []gedcom.Node{}),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "foo", "", []gedcom.Node{}),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagBurial, "", "", []gedcom.Node{}),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "bar", "", []gedcom.Node{}),
 			}),
 			deaths: []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagDeath, "foo", "", []gedcom.Node{}),
-				gedcom.NewSimpleNode(nil, gedcom.TagDeath, "bar", "", []gedcom.Node{}),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "foo", "", []gedcom.Node{}),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "bar", "", []gedcom.Node{}),
 			},
 		},
 	}
@@ -274,30 +274,30 @@ func TestIndividualNode_Burials(t *testing.T) {
 		},
 		{
 			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagBurial, "", "", []gedcom.Node{}),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagBurial, "", "", []gedcom.Node{}),
 			}),
 			burials: []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagBurial, "", "", []gedcom.Node{}),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagBurial, "", "", []gedcom.Node{}),
 			},
 		},
 		{
 			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagBurial, "", "", []gedcom.Node{}),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagBurial, "", "", []gedcom.Node{}),
 				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{}),
 			}),
 			burials: []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagBurial, "", "", []gedcom.Node{}),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagBurial, "", "", []gedcom.Node{}),
 			},
 		},
 		{
 			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagBurial, "foo", "", []gedcom.Node{}),
-				gedcom.NewSimpleNode(nil, gedcom.TagBaptism, "", "", []gedcom.Node{}),
-				gedcom.NewSimpleNode(nil, gedcom.TagBurial, "bar", "", []gedcom.Node{}),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagBurial, "foo", "", []gedcom.Node{}),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagBaptism, "", "", []gedcom.Node{}),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagBurial, "bar", "", []gedcom.Node{}),
 			}),
 			burials: []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagBurial, "foo", "", []gedcom.Node{}),
-				gedcom.NewSimpleNode(nil, gedcom.TagBurial, "bar", "", []gedcom.Node{}),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagBurial, "foo", "", []gedcom.Node{}),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagBurial, "bar", "", []gedcom.Node{}),
 			},
 		},
 	}
@@ -338,35 +338,35 @@ func getDocument() *gedcom.Document {
 	//  -----
 	// P4   P5
 	f1 := gedcom.NewFamilyNode(nil, "F1", []gedcom.Node{
-		gedcom.NewSimpleNode(nil, gedcom.TagHusband, "@P1@", "", nil),
-		gedcom.NewSimpleNode(nil, gedcom.TagWife, "@P3@", "", nil),
-		gedcom.NewSimpleNode(nil, gedcom.TagChild, "@P4@", "", nil),
-		gedcom.NewSimpleNode(nil, gedcom.TagChild, "@P5@", "", nil),
+		gedcom.NewNodeWithChildren(nil, gedcom.TagHusband, "@P1@", "", nil),
+		gedcom.NewNodeWithChildren(nil, gedcom.TagWife, "@P3@", "", nil),
+		gedcom.NewNodeWithChildren(nil, gedcom.TagChild, "@P4@", "", nil),
+		gedcom.NewNodeWithChildren(nil, gedcom.TagChild, "@P5@", "", nil),
 	})
 
 	// P1 - P2
 	//    |
 	//   P6
 	f2 := gedcom.NewFamilyNode(nil, "F2", []gedcom.Node{
-		gedcom.NewSimpleNode(nil, gedcom.TagHusband, "@P1@", "", nil),
-		gedcom.NewSimpleNode(nil, gedcom.TagWife, "@P2@", "", nil),
-		gedcom.NewSimpleNode(nil, gedcom.TagChild, "@P6@", "", nil),
+		gedcom.NewNodeWithChildren(nil, gedcom.TagHusband, "@P1@", "", nil),
+		gedcom.NewNodeWithChildren(nil, gedcom.TagWife, "@P2@", "", nil),
+		gedcom.NewNodeWithChildren(nil, gedcom.TagChild, "@P6@", "", nil),
 	})
 
 	// P6 - ?
 	//    |
 	//   P7
 	f3 := gedcom.NewFamilyNode(nil, "F3", []gedcom.Node{
-		gedcom.NewSimpleNode(nil, gedcom.TagHusband, "@P6@", "", nil),
-		gedcom.NewSimpleNode(nil, gedcom.TagChild, "@P7@", "", nil),
+		gedcom.NewNodeWithChildren(nil, gedcom.TagHusband, "@P6@", "", nil),
+		gedcom.NewNodeWithChildren(nil, gedcom.TagChild, "@P7@", "", nil),
 	})
 
 	// ? - P3
 	//   |
 	//   P6
 	f4 := gedcom.NewFamilyNode(nil, "F4", []gedcom.Node{
-		gedcom.NewSimpleNode(nil, gedcom.TagWife, "@P3@", "", nil),
-		gedcom.NewSimpleNode(nil, gedcom.TagChild, "@P6@", "", nil),
+		gedcom.NewNodeWithChildren(nil, gedcom.TagWife, "@P3@", "", nil),
+		gedcom.NewNodeWithChildren(nil, gedcom.TagChild, "@P6@", "", nil),
 	})
 
 	return &gedcom.Document{
@@ -530,36 +530,36 @@ func TestIndividualNode_LDSBaptisms(t *testing.T) {
 		},
 		{
 			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagLDSBaptism, "", "", []gedcom.Node{}),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagLDSBaptism, "", "", []gedcom.Node{}),
 			}),
 			baptisms: []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagLDSBaptism, "", "", []gedcom.Node{}),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagLDSBaptism, "", "", []gedcom.Node{}),
 			},
 		},
 		{
 			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagBaptism, "", "", []gedcom.Node{}),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagBaptism, "", "", []gedcom.Node{}),
 			}),
 			baptisms: []gedcom.Node{},
 		},
 		{
 			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagLDSBaptism, "", "", []gedcom.Node{}),
-				gedcom.NewSimpleNode(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagLDSBaptism, "", "", []gedcom.Node{}),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
 			}),
 			baptisms: []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagLDSBaptism, "", "", []gedcom.Node{}),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagLDSBaptism, "", "", []gedcom.Node{}),
 			},
 		},
 		{
 			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagLDSBaptism, "foo", "", []gedcom.Node{}),
-				gedcom.NewSimpleNode(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
-				gedcom.NewSimpleNode(nil, gedcom.TagLDSBaptism, "bar", "", []gedcom.Node{}),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagLDSBaptism, "foo", "", []gedcom.Node{}),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagLDSBaptism, "bar", "", []gedcom.Node{}),
 			}),
 			baptisms: []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagLDSBaptism, "foo", "", []gedcom.Node{}),
-				gedcom.NewSimpleNode(nil, gedcom.TagLDSBaptism, "bar", "", []gedcom.Node{}),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagLDSBaptism, "foo", "", []gedcom.Node{}),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagLDSBaptism, "bar", "", []gedcom.Node{}),
 			},
 		},
 	}
@@ -603,7 +603,7 @@ func TestIndividualNode_EstimatedBirthDate(t *testing.T) {
 		},
 		{
 			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagBaptism, "", "", []gedcom.Node{
+				gedcom.NewNodeWithChildren(nil, gedcom.TagBaptism, "", "", []gedcom.Node{
 					gedcom.NewDateNode(nil, "Abt. Dec 1980", "", nil),
 				}),
 			}),
@@ -611,7 +611,7 @@ func TestIndividualNode_EstimatedBirthDate(t *testing.T) {
 		},
 		{
 			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagLDSBaptism, "", "", []gedcom.Node{
+				gedcom.NewNodeWithChildren(nil, gedcom.TagLDSBaptism, "", "", []gedcom.Node{
 					gedcom.NewDateNode(nil, "Abt. Nov 1980", "", nil),
 				}),
 			}),
@@ -624,7 +624,7 @@ func TestIndividualNode_EstimatedBirthDate(t *testing.T) {
 				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
 					gedcom.NewDateNode(nil, "1 Aug 1980", "", nil),
 				}),
-				gedcom.NewSimpleNode(nil, gedcom.TagBaptism, "", "", []gedcom.Node{
+				gedcom.NewNodeWithChildren(nil, gedcom.TagBaptism, "", "", []gedcom.Node{
 					gedcom.NewDateNode(nil, "Abt. Jan 1980", "", nil),
 				}),
 			}),
@@ -644,7 +644,7 @@ func TestIndividualNode_EstimatedBirthDate(t *testing.T) {
 				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
 					gedcom.NewDateNode(nil, "1 Aug 1980", "", nil),
 				}),
-				gedcom.NewSimpleNode(nil, gedcom.TagLDSBaptism, "", "", []gedcom.Node{
+				gedcom.NewNodeWithChildren(nil, gedcom.TagLDSBaptism, "", "", []gedcom.Node{
 					gedcom.NewDateNode(nil, "23 Mar 1979", "", nil),
 				}),
 			}),
@@ -653,14 +653,14 @@ func TestIndividualNode_EstimatedBirthDate(t *testing.T) {
 		{
 			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
 				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{}),
-				gedcom.NewSimpleNode(nil, gedcom.TagLDSBaptism, "", "", []gedcom.Node{}),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagLDSBaptism, "", "", []gedcom.Node{}),
 			}),
 			expected: nil,
 		},
 		{
 			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
 				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{}),
-				gedcom.NewSimpleNode(nil, gedcom.TagLDSBaptism, "", "", []gedcom.Node{
+				gedcom.NewNodeWithChildren(nil, gedcom.TagLDSBaptism, "", "", []gedcom.Node{
 					gedcom.NewDateNode(nil, "1 Aug 1980", "", nil),
 				}),
 			}),
@@ -705,7 +705,7 @@ func TestIndividualNode_EstimatedDeathDate(t *testing.T) {
 		// A single date.
 		{
 			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagDeath, "", "", []gedcom.Node{
+				gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "", "", []gedcom.Node{
 					gedcom.NewDateNode(nil, "1 Aug 1980", "", nil),
 				}),
 			}),
@@ -713,7 +713,7 @@ func TestIndividualNode_EstimatedDeathDate(t *testing.T) {
 		},
 		{
 			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagBurial, "", "", []gedcom.Node{
+				gedcom.NewNodeWithChildren(nil, gedcom.TagBurial, "", "", []gedcom.Node{
 					gedcom.NewDateNode(nil, "Abt. Dec 1980", "", nil),
 				}),
 			}),
@@ -724,7 +724,7 @@ func TestIndividualNode_EstimatedDeathDate(t *testing.T) {
 		{
 			// Multiple death dates always returns the earliest.
 			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagDeath, "", "", []gedcom.Node{
+				gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "", "", []gedcom.Node{
 					gedcom.NewDateNode(nil, "1 Aug 1980", "", nil),
 					gedcom.NewDateNode(nil, "Mar 1980", "", nil),
 					gedcom.NewDateNode(nil, "Jun 1980", "", nil),
@@ -735,7 +735,7 @@ func TestIndividualNode_EstimatedDeathDate(t *testing.T) {
 		{
 			// Multiple burial dates always returns the earliest.
 			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagBurial, "", "", []gedcom.Node{
+				gedcom.NewNodeWithChildren(nil, gedcom.TagBurial, "", "", []gedcom.Node{
 					gedcom.NewDateNode(nil, "3 Aug 1980", "", nil),
 					gedcom.NewDateNode(nil, "Apr 1980", "", nil),
 				}),
@@ -745,10 +745,10 @@ func TestIndividualNode_EstimatedDeathDate(t *testing.T) {
 		{
 			// Death is before burial.
 			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagDeath, "", "", []gedcom.Node{
+				gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "", "", []gedcom.Node{
 					gedcom.NewDateNode(nil, "1 Aug 1980", "", nil),
 				}),
-				gedcom.NewSimpleNode(nil, gedcom.TagBurial, "", "", []gedcom.Node{
+				gedcom.NewNodeWithChildren(nil, gedcom.TagBurial, "", "", []gedcom.Node{
 					gedcom.NewDateNode(nil, "3 Aug 1980", "", nil),
 				}),
 			}),
@@ -757,10 +757,10 @@ func TestIndividualNode_EstimatedDeathDate(t *testing.T) {
 		{
 			// Burial is before death.
 			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagDeath, "", "", []gedcom.Node{
+				gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "", "", []gedcom.Node{
 					gedcom.NewDateNode(nil, "3 Aug 1980", "", nil),
 				}),
-				gedcom.NewSimpleNode(nil, gedcom.TagBurial, "", "", []gedcom.Node{
+				gedcom.NewNodeWithChildren(nil, gedcom.TagBurial, "", "", []gedcom.Node{
 					gedcom.NewDateNode(nil, "1 Aug 1980", "", nil),
 				}),
 			}),
@@ -788,7 +788,7 @@ func born(value string) *gedcom.BirthNode {
 }
 
 func died(value string) gedcom.Node {
-	return gedcom.NewSimpleNode(nil, gedcom.TagDeath, "", "", []gedcom.Node{
+	return gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "", "", []gedcom.Node{
 		gedcom.NewDateNode(nil, value, "", []gedcom.Node{}),
 	})
 }
@@ -798,13 +798,13 @@ func name(value string) gedcom.Node {
 }
 
 func baptised(value string) gedcom.Node {
-	return gedcom.NewSimpleNode(nil, gedcom.TagBaptism, "", "", []gedcom.Node{
+	return gedcom.NewNodeWithChildren(nil, gedcom.TagBaptism, "", "", []gedcom.Node{
 		gedcom.NewDateNode(nil, value, "", []gedcom.Node{}),
 	})
 }
 
 func buried(value string) gedcom.Node {
-	return gedcom.NewSimpleNode(nil, gedcom.TagBurial, "", "", []gedcom.Node{
+	return gedcom.NewNodeWithChildren(nil, gedcom.TagBurial, "", "", []gedcom.Node{
 		gedcom.NewDateNode(nil, value, "", []gedcom.Node{}),
 	})
 }
@@ -1234,17 +1234,17 @@ func family(pointer, husband, wife string, children ...string) *gedcom.FamilyNod
 	nodes := []gedcom.Node{}
 
 	if husband != "" {
-		nodes = append(nodes, gedcom.NewSimpleNode(nil,
+		nodes = append(nodes, gedcom.NewNodeWithChildren(nil,
 			gedcom.TagHusband, "@"+husband+"@", "", nil))
 	}
 
 	if wife != "" {
-		nodes = append(nodes, gedcom.NewSimpleNode(nil,
+		nodes = append(nodes, gedcom.NewNodeWithChildren(nil,
 			gedcom.TagWife, "@"+wife+"@", "", nil))
 	}
 
 	for _, child := range children {
-		nodes = append(nodes, gedcom.NewSimpleNode(nil,
+		nodes = append(nodes, gedcom.NewNodeWithChildren(nil,
 			gedcom.TagChild, "@"+child+"@", "", nil))
 	}
 
@@ -1323,7 +1323,7 @@ func TestIndividualNode_AllEvents(t *testing.T) {
 		{
 			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
 				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{}),
-				gedcom.NewSimpleNode(nil, gedcom.TagNote, "", "", []gedcom.Node{}),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagNote, "", "", []gedcom.Node{}),
 			}),
 			events: []gedcom.Node{
 				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{}),
@@ -1332,22 +1332,22 @@ func TestIndividualNode_AllEvents(t *testing.T) {
 		{
 			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
 				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{}),
-				gedcom.NewSimpleNode(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
 			}),
 			events: []gedcom.Node{
 				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{}),
-				gedcom.NewSimpleNode(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
 			},
 		},
 		{
 			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
 				gedcom.NewBirthNode(nil, "foo", "", []gedcom.Node{}),
-				gedcom.NewSimpleNode(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
 				gedcom.NewBirthNode(nil, "bar", "", []gedcom.Node{}),
 			}),
 			events: []gedcom.Node{
 				gedcom.NewBirthNode(nil, "foo", "", []gedcom.Node{}),
-				gedcom.NewSimpleNode(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
 				gedcom.NewBirthNode(nil, "bar", "", []gedcom.Node{}),
 			},
 		},

--- a/latitude_node.go
+++ b/latitude_node.go
@@ -11,6 +11,6 @@ type LatitudeNode struct {
 // NewLatitudeNode creates a new LATI node.
 func NewLatitudeNode(document *Document, value, pointer string, children []Node) *LatitudeNode {
 	return &LatitudeNode{
-		NewSimpleNode(document, TagLatitude, value, pointer, children),
+		newSimpleNode(document, TagLatitude, value, pointer, children),
 	}
 }

--- a/longitude_node.go
+++ b/longitude_node.go
@@ -11,6 +11,6 @@ type LongitudeNode struct {
 // NewLongitudeNode creates a new LONG node.
 func NewLongitudeNode(document *Document, value, pointer string, children []Node) *LongitudeNode {
 	return &LongitudeNode{
-		NewSimpleNode(document, TagLongitude, value, pointer, children),
+		newSimpleNode(document, TagLongitude, value, pointer, children),
 	}
 }

--- a/map_node.go
+++ b/map_node.go
@@ -11,7 +11,7 @@ type MapNode struct {
 // NewMapNode creates a new MAP node.
 func NewMapNode(document *Document, value, pointer string, children []Node) *MapNode {
 	return &MapNode{
-		NewSimpleNode(document, TagMap, value, pointer, children),
+		newSimpleNode(document, TagMap, value, pointer, children),
 	}
 }
 

--- a/name_node.go
+++ b/name_node.go
@@ -30,7 +30,7 @@ type NameNode struct {
 
 func NewNameNode(document *Document, value, pointer string, children []Node) *NameNode {
 	return &NameNode{
-		NewSimpleNode(document, TagName, value, pointer, children),
+		newSimpleNode(document, TagName, value, pointer, children),
 	}
 }
 

--- a/name_node_test.go
+++ b/name_node_test.go
@@ -135,8 +135,8 @@ var nameTests = []struct {
 		// The GivenName overrides the givenName name if provided. When multiple
 		// GivenNames are provided then it will always use the first one.
 		node: gedcom.NewNameNode(nil, "First /Last/ II", "", []gedcom.Node{
-			gedcom.NewSimpleNode(nil, gedcom.TagGivenName, " Other  Name ", "", nil),
-			gedcom.NewSimpleNode(nil, gedcom.TagGivenName, "Uh-oh", "", nil),
+			gedcom.NewNodeWithChildren(nil, gedcom.TagGivenName, " Other  Name ", "", nil),
+			gedcom.NewNodeWithChildren(nil, gedcom.TagGivenName, "Uh-oh", "", nil),
 		}),
 		title:         "",
 		prefix:        "",
@@ -151,8 +151,8 @@ var nameTests = []struct {
 		// The Surname overrides the surname name if provided. When multiple
 		// Surnames are provided then it will always use the first one.
 		node: gedcom.NewNameNode(nil, "First /Last/ II", "", []gedcom.Node{
-			gedcom.NewSimpleNode(nil, gedcom.TagSurname, " Other  name ", "", nil),
-			gedcom.NewSimpleNode(nil, gedcom.TagSurname, "uh-oh", "", nil),
+			gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, " Other  name ", "", nil),
+			gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, "uh-oh", "", nil),
 		}),
 		title:         "",
 		prefix:        "",
@@ -165,8 +165,8 @@ var nameTests = []struct {
 	},
 	{
 		node: gedcom.NewNameNode(nil, "First /Last/ Esq.", "", []gedcom.Node{
-			gedcom.NewSimpleNode(nil, gedcom.TagNamePrefix, " Mr ", "", nil),
-			gedcom.NewSimpleNode(nil, gedcom.TagNamePrefix, "Dr", "", nil),
+			gedcom.NewNodeWithChildren(nil, gedcom.TagNamePrefix, " Mr ", "", nil),
+			gedcom.NewNodeWithChildren(nil, gedcom.TagNamePrefix, "Dr", "", nil),
 		}),
 		title:         "",
 		prefix:        "Mr",
@@ -182,9 +182,9 @@ var nameTests = []struct {
 		// When multiple name suffixes are provided then it will always use the
 		// first one.
 		node: gedcom.NewNameNode(nil, "First /Last/ Suffix", "", []gedcom.Node{
-			gedcom.NewSimpleNode(nil, gedcom.TagNameSuffix, " Esq. ", "", nil),
-			gedcom.NewSimpleNode(nil, gedcom.TagNameSuffix, "Dr", "", nil),
-			gedcom.NewSimpleNode(nil, gedcom.TagNamePrefix, "Sir", "", nil),
+			gedcom.NewNodeWithChildren(nil, gedcom.TagNameSuffix, " Esq. ", "", nil),
+			gedcom.NewNodeWithChildren(nil, gedcom.TagNameSuffix, "Dr", "", nil),
+			gedcom.NewNodeWithChildren(nil, gedcom.TagNamePrefix, "Sir", "", nil),
 		}),
 		title:         "",
 		prefix:        "Sir",
@@ -197,8 +197,8 @@ var nameTests = []struct {
 	},
 	{
 		node: gedcom.NewNameNode(nil, "First /Last/ Esq.", "", []gedcom.Node{
-			gedcom.NewSimpleNode(nil, gedcom.TagSurnamePrefix, " Foo ", "", nil),
-			gedcom.NewSimpleNode(nil, gedcom.TagSurnamePrefix, "Bar", "", nil),
+			gedcom.NewNodeWithChildren(nil, gedcom.TagSurnamePrefix, " Foo ", "", nil),
+			gedcom.NewNodeWithChildren(nil, gedcom.TagSurnamePrefix, "Bar", "", nil),
 		}),
 		title:         "",
 		prefix:        "",
@@ -211,8 +211,8 @@ var nameTests = []struct {
 	},
 	{
 		node: gedcom.NewNameNode(nil, "First /Last/ Esq.", "", []gedcom.Node{
-			gedcom.NewSimpleNode(nil, gedcom.TagTitle, " Grand  Duke ", "", nil),
-			gedcom.NewSimpleNode(nil, gedcom.TagTitle, "Nobody", "", nil),
+			gedcom.NewNodeWithChildren(nil, gedcom.TagTitle, " Grand  Duke ", "", nil),
+			gedcom.NewNodeWithChildren(nil, gedcom.TagTitle, "Nobody", "", nil),
 		}),
 		title:         "Grand Duke",
 		prefix:        "",
@@ -302,12 +302,12 @@ func TestNameNode_Format(t *testing.T) {
 	Format(nil, "%f %l").Returns("")
 
 	name := gedcom.NewNameNode(nil, "", "", []gedcom.Node{
-		gedcom.NewSimpleNode(nil, gedcom.TagGivenName, "Given", "", nil),
-		gedcom.NewSimpleNode(nil, gedcom.TagSurname, "Surname", "", nil),
-		gedcom.NewSimpleNode(nil, gedcom.TagNamePrefix, "Prefix", "", nil),
-		gedcom.NewSimpleNode(nil, gedcom.TagNameSuffix, "Suffix", "", nil),
-		gedcom.NewSimpleNode(nil, gedcom.TagSurnamePrefix, "SurnamePrefix", "", nil),
-		gedcom.NewSimpleNode(nil, gedcom.TagTitle, "Title", "", nil),
+		gedcom.NewNodeWithChildren(nil, gedcom.TagGivenName, "Given", "", nil),
+		gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, "Surname", "", nil),
+		gedcom.NewNodeWithChildren(nil, gedcom.TagNamePrefix, "Prefix", "", nil),
+		gedcom.NewNodeWithChildren(nil, gedcom.TagNameSuffix, "Suffix", "", nil),
+		gedcom.NewNodeWithChildren(nil, gedcom.TagSurnamePrefix, "SurnamePrefix", "", nil),
+		gedcom.NewNodeWithChildren(nil, gedcom.TagTitle, "Title", "", nil),
 	})
 
 	Format(name, "").Returns("")

--- a/nodes_test.go
+++ b/nodes_test.go
@@ -17,39 +17,39 @@ var nodesWithTagTests = []struct {
 	{gedcom.NewNameNode(nil, "", "", nil), gedcom.TagHeader, []gedcom.Node{}},
 	{
 		gedcom.NewNameNode(nil, "", "", []gedcom.Node{
-			gedcom.NewSimpleNode(nil, gedcom.TagSurname, "", "", nil),
+			gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, "", "", nil),
 		}),
 		gedcom.TagHeader,
 		[]gedcom.Node{},
 	},
 	{
 		gedcom.NewNameNode(nil, "", "", []gedcom.Node{
-			gedcom.NewSimpleNode(nil, gedcom.TagSurname, "", "", nil),
+			gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, "", "", nil),
 		}),
 		gedcom.TagSurname,
 		[]gedcom.Node{
-			gedcom.NewSimpleNode(nil, gedcom.TagSurname, "", "", nil),
+			gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, "", "", nil),
 		},
 	},
 	{
 		gedcom.NewNameNode(nil, "", "", []gedcom.Node{
-			gedcom.NewSimpleNode(nil, gedcom.TagHeader, "", "", nil),
-			gedcom.NewSimpleNode(nil, gedcom.TagSurname, "", "", nil),
+			gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", nil),
+			gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, "", "", nil),
 		}),
 		gedcom.TagSurname,
 		[]gedcom.Node{
-			gedcom.NewSimpleNode(nil, gedcom.TagSurname, "", "", nil),
+			gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, "", "", nil),
 		},
 	},
 	{
 		gedcom.NewNameNode(nil, "", "", []gedcom.Node{
-			gedcom.NewSimpleNode(nil, gedcom.TagSurname, "", "", nil),
-			gedcom.NewSimpleNode(nil, gedcom.TagSurname, "", "", nil),
+			gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, "", "", nil),
+			gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, "", "", nil),
 		}),
 		gedcom.TagSurname,
 		[]gedcom.Node{
-			gedcom.NewSimpleNode(nil, gedcom.TagSurname, "", "", nil),
-			gedcom.NewSimpleNode(nil, gedcom.TagSurname, "", "", nil),
+			gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, "", "", nil),
+			gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, "", "", nil),
 		},
 	},
 }
@@ -70,67 +70,67 @@ func TestNodesWithTagPath(t *testing.T) {
 	}{
 		{
 			gedcom.NewNameNode(nil, "", "", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagSurname, "", "", nil),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, "", "", nil),
 			}),
 			[]gedcom.Tag{},
 			[]gedcom.Node{},
 		},
 		{
 			gedcom.NewNameNode(nil, "", "", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagSurname, "", "", []gedcom.Node{
-					gedcom.NewSimpleNode(nil, gedcom.TagText, "", "", nil),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, "", "", []gedcom.Node{
+					gedcom.NewNodeWithChildren(nil, gedcom.TagText, "", "", nil),
 				}),
 			}),
 			[]gedcom.Tag{gedcom.TagSurname},
 			[]gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagSurname, "", "", []gedcom.Node{
-					gedcom.NewSimpleNode(nil, gedcom.TagText, "", "", nil),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, "", "", []gedcom.Node{
+					gedcom.NewNodeWithChildren(nil, gedcom.TagText, "", "", nil),
 				}),
 			},
 		},
 		{
 			gedcom.NewNameNode(nil, "", "", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagSurname, "", "", []gedcom.Node{
-					gedcom.NewSimpleNode(nil, gedcom.TagText, "", "", nil),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, "", "", []gedcom.Node{
+					gedcom.NewNodeWithChildren(nil, gedcom.TagText, "", "", nil),
 				}),
 			}),
 			[]gedcom.Tag{gedcom.TagSurname, gedcom.TagText},
 			[]gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagText, "", "", nil),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagText, "", "", nil),
 			},
 		},
 		{
 			gedcom.NewNameNode(nil, "", "", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagSurname, "", "", []gedcom.Node{
-					gedcom.NewSimpleNode(nil, gedcom.TagText, "", "1", nil),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, "", "", []gedcom.Node{
+					gedcom.NewNodeWithChildren(nil, gedcom.TagText, "", "1", nil),
 				}),
-				gedcom.NewSimpleNode(nil, gedcom.TagSurname, "", "", []gedcom.Node{
-					gedcom.NewSimpleNode(nil, gedcom.TagText, "", "2", nil),
-				}),
-			}),
-			[]gedcom.Tag{gedcom.TagSurname, gedcom.TagText},
-			[]gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagText, "", "1", nil),
-				gedcom.NewSimpleNode(nil, gedcom.TagText, "", "2", nil),
-			},
-		},
-		{
-			gedcom.NewNameNode(nil, "", "", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagSurname, "", "", []gedcom.Node{
-					gedcom.NewSimpleNode(nil, gedcom.TagText, "", "1", nil),
-					gedcom.NewSimpleNode(nil, gedcom.TagText, "", "2", nil),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, "", "", []gedcom.Node{
+					gedcom.NewNodeWithChildren(nil, gedcom.TagText, "", "2", nil),
 				}),
 			}),
 			[]gedcom.Tag{gedcom.TagSurname, gedcom.TagText},
 			[]gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagText, "", "1", nil),
-				gedcom.NewSimpleNode(nil, gedcom.TagText, "", "2", nil),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagText, "", "1", nil),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagText, "", "2", nil),
 			},
 		},
 		{
 			gedcom.NewNameNode(nil, "", "", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagSurname, "", "", []gedcom.Node{
-					gedcom.NewSimpleNode(nil, gedcom.TagText, "", "", nil),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, "", "", []gedcom.Node{
+					gedcom.NewNodeWithChildren(nil, gedcom.TagText, "", "1", nil),
+					gedcom.NewNodeWithChildren(nil, gedcom.TagText, "", "2", nil),
+				}),
+			}),
+			[]gedcom.Tag{gedcom.TagSurname, gedcom.TagText},
+			[]gedcom.Node{
+				gedcom.NewNodeWithChildren(nil, gedcom.TagText, "", "1", nil),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagText, "", "2", nil),
+			},
+		},
+		{
+			gedcom.NewNameNode(nil, "", "", []gedcom.Node{
+				gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, "", "", []gedcom.Node{
+					gedcom.NewNodeWithChildren(nil, gedcom.TagText, "", "", nil),
 				}),
 			}),
 			[]gedcom.Tag{gedcom.TagGivenName, gedcom.TagText},
@@ -138,8 +138,8 @@ func TestNodesWithTagPath(t *testing.T) {
 		},
 		{
 			gedcom.NewNameNode(nil, "", "", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagSurname, "", "", []gedcom.Node{
-					gedcom.NewSimpleNode(nil, gedcom.TagText, "", "", nil),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, "", "", []gedcom.Node{
+					gedcom.NewNodeWithChildren(nil, gedcom.TagText, "", "", nil),
 				}),
 			}),
 			[]gedcom.Tag{gedcom.TagSurname, gedcom.TagSurname},
@@ -147,8 +147,8 @@ func TestNodesWithTagPath(t *testing.T) {
 		},
 		{
 			gedcom.NewNameNode(nil, "", "", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagSurname, "", "", []gedcom.Node{
-					gedcom.NewSimpleNode(nil, gedcom.TagText, "", "", nil),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, "", "", []gedcom.Node{
+					gedcom.NewNodeWithChildren(nil, gedcom.TagText, "", "", nil),
 				}),
 			}),
 			[]gedcom.Tag{gedcom.TagSurname, gedcom.TagGivenName},
@@ -174,8 +174,8 @@ func TestNodesWithTagPath(t *testing.T) {
 }
 
 func TestHasNestedNode(t *testing.T) {
-	surname := gedcom.NewSimpleNode(nil, gedcom.TagSurname, "", "", nil)
-	givenName := gedcom.NewSimpleNode(nil, gedcom.TagGivenName, "", "", nil)
+	surname := gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, "", "", nil)
+	givenName := gedcom.NewNodeWithChildren(nil, gedcom.TagGivenName, "", "", nil)
 
 	tests := []struct {
 		node       gedcom.Node
@@ -223,7 +223,7 @@ func TestHasNestedNode(t *testing.T) {
 			gedcom.NewNameNode(nil, "", "", []gedcom.Node{
 				surname,
 			}),
-			gedcom.NewSimpleNode(nil, gedcom.TagSurname, "", "", nil),
+			gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, "", "", nil),
 			false,
 		},
 		{
@@ -235,7 +235,7 @@ func TestHasNestedNode(t *testing.T) {
 		},
 		{
 			gedcom.NewNameNode(nil, "", "", []gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagGivenName, "", "", []gedcom.Node{
+				gedcom.NewNodeWithChildren(nil, gedcom.TagGivenName, "", "", []gedcom.Node{
 					givenName,
 				}),
 			}),

--- a/note_node.go
+++ b/note_node.go
@@ -9,6 +9,6 @@ type NoteNode struct {
 // NewNoteNode creates a new NOTE node.
 func NewNoteNode(document *Document, value, pointer string, children []Node) *NoteNode {
 	return &NoteNode{
-		NewSimpleNode(document, TagNote, value, pointer, children),
+		newSimpleNode(document, TagNote, value, pointer, children),
 	}
 }

--- a/phonetic_variation_node.go
+++ b/phonetic_variation_node.go
@@ -24,7 +24,7 @@ type PhoneticVariationNode struct {
 // NewPhoneticVariationNode creates a new FONE node.
 func NewPhoneticVariationNode(document *Document, value, pointer string, children []Node) *PhoneticVariationNode {
 	return &PhoneticVariationNode{
-		NewSimpleNode(document, TagPhonetic, value, pointer, children),
+		newSimpleNode(document, TagPhonetic, value, pointer, children),
 	}
 }
 

--- a/place_node.go
+++ b/place_node.go
@@ -17,7 +17,7 @@ type PlaceNode struct {
 // http://wiki-en.genealogy.net/GEDCOM/PLAC-Tag
 func NewPlaceNode(document *Document, value, pointer string, children []Node) *PlaceNode {
 	return &PlaceNode{
-		NewSimpleNode(document, TagPlace, value, pointer, children),
+		newSimpleNode(document, TagPlace, value, pointer, children),
 	}
 }
 

--- a/place_node_test.go
+++ b/place_node_test.go
@@ -172,7 +172,7 @@ func TestPlaceNode_PhoneticVariations(t *testing.T) {
 		{
 			node: gedcom.NewPlaceNode(nil, "", "P1", []gedcom.Node{
 				gedcom.NewPhoneticVariationNode(nil, "", "", []gedcom.Node{}),
-				gedcom.NewSimpleNode(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
 			}),
 			expected: []*gedcom.PhoneticVariationNode{
 				gedcom.NewPhoneticVariationNode(nil, "", "", []gedcom.Node{}),
@@ -181,7 +181,7 @@ func TestPlaceNode_PhoneticVariations(t *testing.T) {
 		{
 			node: gedcom.NewPlaceNode(nil, "", "P1", []gedcom.Node{
 				gedcom.NewPhoneticVariationNode(nil, "foo", "", []gedcom.Node{}),
-				gedcom.NewSimpleNode(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
 				gedcom.NewPhoneticVariationNode(nil, "bar", "", []gedcom.Node{}),
 			}),
 			expected: []*gedcom.PhoneticVariationNode{
@@ -226,7 +226,7 @@ func TestPlaceNode_RomanizedVariations(t *testing.T) {
 		{
 			node: gedcom.NewPlaceNode(nil, "", "P1", []gedcom.Node{
 				gedcom.NewRomanizedVariationNode(nil, "", "", []gedcom.Node{}),
-				gedcom.NewSimpleNode(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
 			}),
 			expected: []*gedcom.RomanizedVariationNode{
 				gedcom.NewRomanizedVariationNode(nil, "", "", []gedcom.Node{}),
@@ -235,7 +235,7 @@ func TestPlaceNode_RomanizedVariations(t *testing.T) {
 		{
 			node: gedcom.NewPlaceNode(nil, "", "P1", []gedcom.Node{
 				gedcom.NewRomanizedVariationNode(nil, "foo", "", []gedcom.Node{}),
-				gedcom.NewSimpleNode(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
 				gedcom.NewRomanizedVariationNode(nil, "bar", "", []gedcom.Node{}),
 			}),
 			expected: []*gedcom.RomanizedVariationNode{
@@ -326,7 +326,7 @@ func TestPlaceNode_Notes(t *testing.T) {
 		{
 			node: gedcom.NewPlaceNode(nil, "", "P1", []gedcom.Node{
 				gedcom.NewNoteNode(nil, "", "", []gedcom.Node{}),
-				gedcom.NewSimpleNode(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
 			}),
 			expected: []*gedcom.NoteNode{
 				gedcom.NewNoteNode(nil, "", "", []gedcom.Node{}),
@@ -335,7 +335,7 @@ func TestPlaceNode_Notes(t *testing.T) {
 		{
 			node: gedcom.NewPlaceNode(nil, "", "P1", []gedcom.Node{
 				gedcom.NewNoteNode(nil, "foo", "", []gedcom.Node{}),
-				gedcom.NewSimpleNode(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
 				gedcom.NewNoteNode(nil, "bar", "", []gedcom.Node{}),
 			}),
 			expected: []*gedcom.NoteNode{

--- a/residence_node.go
+++ b/residence_node.go
@@ -8,7 +8,7 @@ type ResidenceNode struct {
 // NewResidenceNode creates a new RESI node.
 func NewResidenceNode(document *Document, value, pointer string, children []Node) *ResidenceNode {
 	return &ResidenceNode{
-		NewSimpleNode(document, TagResidence, value, pointer, children),
+		newSimpleNode(document, TagResidence, value, pointer, children),
 	}
 }
 

--- a/romanized_variation_node.go
+++ b/romanized_variation_node.go
@@ -21,7 +21,7 @@ type RomanizedVariationNode struct {
 // NewRomanizedVariationNode creates a new ROMN node.
 func NewRomanizedVariationNode(document *Document, value, pointer string, children []Node) *RomanizedVariationNode {
 	return &RomanizedVariationNode{
-		NewSimpleNode(document, TagRomanized, value, pointer, children),
+		newSimpleNode(document, TagRomanized, value, pointer, children),
 	}
 }
 

--- a/simple_node.go
+++ b/simple_node.go
@@ -12,10 +12,9 @@ type SimpleNode struct {
 
 // NewSimpleNode creates a non-specific node.
 //
-// Note: You should not use this constructor for general use. Instead use
-// NewNode which will return a *SimpleNode if a more appropriate node type
-// exists for the tag.
-func NewSimpleNode(document *Document, tag Tag, value, pointer string, children []Node) *SimpleNode {
+// Unlike all of the other node types this constructor is not public because it
+// is used internally by NewNode if a specific node type can not be determined.
+func newSimpleNode(document *Document, tag Tag, value, pointer string, children []Node) *SimpleNode {
 	return &SimpleNode{
 		document: document,
 		tag:      tag,

--- a/simple_node_test.go
+++ b/simple_node_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestSimpleNode_ChildNodes(t *testing.T) {
-	node := gedcom.NewSimpleNode(nil, gedcom.TagText, "", "", nil)
+	node := gedcom.NewNodeWithChildren(nil, gedcom.TagText, "", "", nil)
 
 	assert.Len(t, node.Nodes(), 0)
 }
@@ -29,38 +29,39 @@ func TestIsNil(t *testing.T) {
 func TestSimpleNode_Equals(t *testing.T) {
 	Equals := tf.Function(t, (*gedcom.SimpleNode).Equals)
 
-	s0 := (*gedcom.SimpleNode)(nil)
+	left := []*gedcom.SimpleNode{
+		(*gedcom.SimpleNode)(nil),
+		gedcom.NewNode(nil, gedcom.TagVersion, "", "").(*gedcom.SimpleNode),
+		gedcom.NewNode(nil, gedcom.TagVersion, "a", "").(*gedcom.SimpleNode),
+		gedcom.NewNode(nil, gedcom.TagVersion, "", "b").(*gedcom.SimpleNode),
+		gedcom.NewNode(nil, gedcom.TagVersion, "a", "b").(*gedcom.SimpleNode),
+	}
 
-	// These are the same.
-	s1 := gedcom.NewSimpleNode(nil, gedcom.TagName, "", "", nil)
-	s2 := gedcom.NewNameNode(nil, "", "", nil)
+	right := []gedcom.Node{
+		(*gedcom.SimpleNode)(nil),
+		gedcom.NewNode(nil, gedcom.TagVersion, "", "").(*gedcom.SimpleNode),
+		gedcom.NewNode(nil, gedcom.TagVersion, "a", "").(*gedcom.SimpleNode),
+		gedcom.NewNode(nil, gedcom.TagVersion, "", "b").(*gedcom.SimpleNode),
+		gedcom.NewNode(nil, gedcom.TagVersion, "a", "b").(*gedcom.SimpleNode),
+		gedcom.NewNameNode(nil, "", "", nil),
+	}
 
-	// These are different in some way from each other.
-	s3 := gedcom.NewSimpleNode(nil, gedcom.TagName, "", "a", nil)
-	s4 := gedcom.NewNameNode(nil, "a", "", nil)
-	s5 := gedcom.NewNameNode(nil, "", "b", nil)
-	s6 := gedcom.NewSimpleNode(nil, gedcom.TagVersion, "", "a", nil)
+	const N = false
+	const Y = true
 
-	// Nils
-	Equals(s0, s0).Returns(false)
-	Equals(s0, s1).Returns(false)
-	Equals(s1, s0).Returns(false)
+	expected := [][]bool{
+		{N, N, N, N, N, N},
+		{N, Y, N, N, N, N},
+		{N, N, Y, N, N, N},
+		{N, N, N, Y, N, N},
+		{N, N, N, N, Y, N},
+	}
 
-	Equals(s1, s1).Returns(true)
-	Equals(s1, s2).Returns(true)
-
-	Equals(s1, s3).Returns(false)
-	Equals(s1, s4).Returns(false)
-	Equals(s1, s5).Returns(false)
-
-	Equals(s3, s3).Returns(true)
-	Equals(s3, s4).Returns(false)
-	Equals(s3, s5).Returns(false)
-	Equals(s3, s6).Returns(false)
-	Equals(s6, s3).Returns(false)
-	Equals(s6, s4).Returns(false)
-	Equals(s6, s5).Returns(false)
-	Equals(s6, s6).Returns(true)
+	for i, l := range left {
+		for j, r := range right {
+			Equals(l, r).Returns(expected[i][j])
+		}
+	}
 }
 
 func TestSimpleNode_Tag(t *testing.T) {

--- a/source_node.go
+++ b/source_node.go
@@ -7,7 +7,7 @@ type SourceNode struct {
 
 func NewSourceNode(document *Document, value, pointer string, children []Node) *SourceNode {
 	return &SourceNode{
-		NewSimpleNode(document, TagSource, value, pointer, children),
+		newSimpleNode(document, TagSource, value, pointer, children),
 	}
 }
 

--- a/type_node.go
+++ b/type_node.go
@@ -13,6 +13,6 @@ type TypeNode struct {
 // NewTypeNode creates a new TYPE node.
 func NewTypeNode(document *Document, value, pointer string, children []Node) *TypeNode {
 	return &TypeNode{
-		NewSimpleNode(document, TagType, value, pointer, children),
+		newSimpleNode(document, TagType, value, pointer, children),
 	}
 }

--- a/util_test.go
+++ b/util_test.go
@@ -103,7 +103,7 @@ func TestValue(t *testing.T) {
 		want string
 	}{
 		{nil, ""},
-		{gedcom.NewSimpleNode(nil, gedcom.TagVersion, "foo", "", nil), "foo"},
+		{gedcom.NewNodeWithChildren(nil, gedcom.TagVersion, "foo", "", nil), "foo"},
 		{gedcom.NewNameNode(nil, "foo bar", "", nil), "foo bar"},
 	}
 
@@ -156,7 +156,7 @@ func TestPointer(t *testing.T) {
 		want string
 	}{
 		{nil, ""},
-		{gedcom.NewSimpleNode(nil, gedcom.TagVersion, "foo", "a", nil), "a"},
+		{gedcom.NewNodeWithChildren(nil, gedcom.TagVersion, "foo", "a", nil), "a"},
 		{gedcom.NewNameNode(nil, "foo bar", "b", nil), "b"},
 	}
 
@@ -173,7 +173,7 @@ func TestString(t *testing.T) {
 		want string
 	}{
 		{nil, ""},
-		{gedcom.NewSimpleNode(nil, gedcom.TagVersion, "foo", "", nil), "foo"},
+		{gedcom.NewNodeWithChildren(nil, gedcom.TagVersion, "foo", "", nil), "foo"},
 		{gedcom.NewNameNode(nil, "foo bar", "", nil), "foo bar"},
 	}
 
@@ -192,7 +192,7 @@ func TestDates(t *testing.T) {
 		{nil, nil},
 		{
 			[]gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagVersion, "foo", "", nil),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagVersion, "foo", "", nil),
 			},
 			nil,
 		},
@@ -262,7 +262,7 @@ func TestPlaces(t *testing.T) {
 		{nil, nil},
 		{
 			[]gedcom.Node{
-				gedcom.NewSimpleNode(nil, gedcom.TagVersion, "foo", "", nil),
+				gedcom.NewNodeWithChildren(nil, gedcom.TagVersion, "foo", "", nil),
 			},
 			nil,
 		},


### PR DESCRIPTION
Having both NewSimpleNode and NewNode was confusing and error prone. Now SimpleNodes will be created by NewNode only if there is no more appropriate type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/gedcom/133)
<!-- Reviewable:end -->
