### PR TITLE
Adding Surnames page. Fixes #127

### DIFF
--- a/gedcom2html/event_statistics.go
+++ b/gedcom2html/event_statistics.go
@@ -5,7 +5,6 @@ import (
 	"github.com/elliotchance/gedcom"
 	"github.com/elliotchance/gedcom/html"
 	"sort"
-	"strconv"
 )
 
 type eventStatistics struct {
@@ -33,7 +32,7 @@ func (c *eventStatistics) String() string {
 	}
 
 	rows := []fmt.Stringer{
-		newKeyedTableRow("Total", strconv.Itoa(total), true),
+		newKeyedTableRow("Total", html.NewNumber(total).String(), true),
 	}
 
 	keys := []string{}
@@ -45,7 +44,7 @@ func (c *eventStatistics) String() string {
 
 	for _, name := range keys {
 		rows = append(rows,
-			newKeyedTableRow(name, strconv.Itoa(counts[name]), true))
+			newKeyedTableRow(name, html.NewNumber(counts[name]).String(), true))
 	}
 
 	return newCard("Events", noBadgeCount,

--- a/gedcom2html/page.go
+++ b/gedcom2html/page.go
@@ -58,3 +58,7 @@ func pageSource(source *gedcom.SourceNode) string {
 func pageStatistics() string {
 	return "statistics.html"
 }
+
+func pageSurnames() string {
+	return "surnames.html"
+}

--- a/gedcom2html/place_link.go
+++ b/gedcom2html/place_link.go
@@ -18,6 +18,10 @@ func newPlaceLink(document *gedcom.Document, place string) *placeLink {
 }
 
 func (c *placeLink) String() string {
+	if c.place == "" {
+		return ""
+	}
+
 	return html.Sprintf(`<a href="%s">%s%s</a>`,
 		pagePlace(c.document, c.place), newOcticon("location", ""), c.place)
 }

--- a/gedcom2html/surname_in_list.go
+++ b/gedcom2html/surname_in_list.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"github.com/elliotchance/gedcom"
+	"github.com/elliotchance/gedcom/html"
+)
+
+type surnameInList struct {
+	document *gedcom.Document
+	surname  string
+}
+
+func newSurnameInList(document *gedcom.Document, surname string) *surnameInList {
+	return &surnameInList{
+		document: document,
+		surname:  surname,
+	}
+}
+
+func (c *surnameInList) String() string {
+	count := 0
+	for _, individual := range c.document.Individuals() {
+		if individual.Name().Surname() == c.surname {
+			count++
+		}
+	}
+
+	return html.Sprintf(`
+		<tr>
+			<td>%s</td>
+			<td>%s</td>
+		</tr>`,
+		newSurnameLink(c.surname), html.NewNumber(count))
+}

--- a/gedcom2html/surname_link.go
+++ b/gedcom2html/surname_link.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"github.com/elliotchance/gedcom/html"
+	"unicode"
+)
+
+type surnameLink struct {
+	surname string
+}
+
+func newSurnameLink(surname string) *surnameLink {
+	return &surnameLink{
+		surname: surname,
+	}
+}
+
+func (c *surnameLink) String() string {
+	return html.Sprintf(`
+		<a href="%s#%s">%s</a>`, pageIndividuals(unicode.ToLower(rune(c.surname[0]))), c.surname, c.surname)
+}

--- a/gedcom2html/surname_list_page.go
+++ b/gedcom2html/surname_list_page.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"fmt"
+	"github.com/elliotchance/gedcom"
+	"github.com/elliotchance/gedcom/html"
+)
+
+type surnameListPage struct {
+	document          *gedcom.Document
+	googleAnalyticsID string
+}
+
+func newSurnameListPage(document *gedcom.Document, googleAnalyticsID string) *surnameListPage {
+	return &surnameListPage{
+		document:          document,
+		googleAnalyticsID: googleAnalyticsID,
+	}
+}
+
+func (c *surnameListPage) String() string {
+	table := []fmt.Stringer{
+		html.NewTableHead("Surname", "Number of Individuals"),
+	}
+
+	for _, surname := range getSurnames(c.document) {
+		table = append(table, newSurnameInList(c.document, surname))
+	}
+
+	return html.NewPage("Surnames", html.NewComponents(
+		newHeader(c.document, "", selectedSurnamesTab),
+		html.NewRow(
+			html.NewColumn(html.EntireRow, html.NewTable("", table...)),
+		),
+	), c.googleAnalyticsID).String()
+}


### PR DESCRIPTION
- The Surnames page lists the surnames with an individual count.
- Fixed missing commas on some of the Statistics for events.
- Added options to optionally disable each of the pages.
- Fixed bug where an empty place would display the icon without the name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/gedcom/137)
<!-- Reviewable:end -->
