### PR TITLE
Fix Decoder with BOM. Fixes #139

### DIFF
--- a/decoder_test.go
+++ b/decoder_test.go
@@ -241,6 +241,14 @@ var tests = map[string]*gedcom.Document{
 			gedcom.NewNameNode(nil, "κόσμε", "", nil),
 		},
 	},
+	"\xEF\xBB\xBF0 HEAD\n1 CHAR UTF-8": {
+		Nodes: []gedcom.Node{
+			gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
+				gedcom.NewNode(nil, gedcom.TagCharacterSet, "UTF-8", ""),
+			}),
+		},
+		HasBOM: true,
+	},
 }
 
 func TestDecoder_Decode(t *testing.T) {
@@ -248,6 +256,7 @@ func TestDecoder_Decode(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			decoder := gedcom.NewDecoder(strings.NewReader(ged))
 			actual, err := decoder.Decode()
+			actual.HasBOM = expected.HasBOM
 
 			assert.NoError(t, err, ged)
 

--- a/document.go
+++ b/document.go
@@ -13,6 +13,17 @@ type Document struct {
 	Nodes        []Node
 	pointerCache map[string]Node
 	families     []*FamilyNode
+
+	// HasBOM controls if the encoded stream will start with the Byte Order
+	// Mark.
+	//
+	// This is not recommended by the UTF-8 standard and many applications will
+	// have problems reading the data. However, streams that were decoded
+	// containing the BOM will retain it so that the re-encoded stream is as
+	// compatible and similar to the original stream as possible.
+	//
+	// Also see Decoder.consumeOptionalBOM().
+	HasBOM bool
 }
 
 // String will render the entire GEDCOM document.

--- a/encoder.go
+++ b/encoder.go
@@ -37,15 +37,17 @@ func (enc *Encoder) renderNode(indent int, node Node) error {
 }
 
 // Encode will write the GEDCOM document to the Writer.
-func (enc *Encoder) Encode() error {
+func (enc *Encoder) Encode() (err error) {
+	err = enc.restoreOptionalBOM()
+
 	for _, node := range enc.document.Nodes {
-		err := enc.renderNode(0, node)
+		err = enc.renderNode(0, node)
 		if err != nil {
-			return err
+			return
 		}
 	}
 
-	return nil
+	return
 }
 
 // GedcomLine converts a node into its single line GEDCOM value. It is used
@@ -82,4 +84,13 @@ func GedcomLine(indent int, node Node) string {
 	}
 
 	return buf.String()
+}
+
+// See Decoder.consumeOptionalBOM for more information.
+func (enc *Encoder) restoreOptionalBOM() (err error) {
+	if enc.document.HasBOM {
+		_, err = enc.w.Write(byteOrderMark)
+	}
+
+	return
 }


### PR DESCRIPTION
Streams that start with a Byte Order Mark are now understood correctly. The BOM is automatically restored to keep compatibility and consistency, but it can be disabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/gedcom/140)
<!-- Reviewable:end -->
