### PR TITLE
Compile and upload releases. Fixes #141

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,19 +5,22 @@ sudo: false
 language: go
 
 go:
-  - 1.8.x
-  - 1.9.x
+  - 1.11.x
   - 1.10.x
+  - 1.9.x
+  - 1.8.x
 
-env:
-  global:
-    - DEP_VERSION="0.4.1"
+stages:
+  - Test
+  - name: Release
+    if: tag =~ ^v
 
 # Only clone the most recent commit.
 git:
   depth: 1
 
 before_install:
+  - DEP_VERSION="0.4.1"
   # Download the binary to bin folder in $GOPATH
   - curl -L -s https://github.com/golang/dep/releases/download/v${DEP_VERSION}/dep-linux-amd64 -o $GOPATH/bin/dep
   # Make the binary executable
@@ -27,14 +30,38 @@ install: dep ensure
 
 script:
   # Check that all files are Go formatted. Only run this on the latest Go.
-  - if [[ "$TRAVIS_GO_VERSION" == 1.10* ]]; then
+  - if [[ "$TRAVIS_GO_VERSION" == 1.11* ]]; then
     $(exit $(go fmt ./... | wc -l)); fi
 
-  # Run all the tests with the race detector enabled.
-  - go test -race ./...
-  
+  - make test
+
   # We only run code coverage on the gedcom package for now.
-  - go test -race -coverprofile=coverage.txt -covermode=atomic
+  - if [[ "$TRAVIS_GO_VERSION" == 1.11* ]]; then
+    go test -race -coverprofile=coverage.txt -covermode=atomic; fi
 
 after_success:
-  - bash <(curl -s https://codecov.io/bash)
+  - if [[ "$TRAVIS_GO_VERSION" == 1.11* ]]; then
+    bash <(curl -s https://codecov.io/bash); fi
+
+jobs:
+  include:
+    - stage: Release
+      script:
+        - GOOS=linux GOARCH=amd64 make zip
+        - GOOS=darwin GOARCH=amd64 make zip
+        - GOOS=windows GOARCH=amd64 make zip
+        - GOOS=windows GOARCH=386 make zip
+
+      deploy:
+        provider: releases
+        api_key:
+          secure: j1woYgRSru2tvqeVDXFJsWSkZi/am7a/+/tuM8j61G28hZ/tz6AKvFHqjbCl/vRIp6Yx3B+wieCKNxyH25iTKIhTL3y6p8RATaABdrZXnVlZDw+4svkkA1dAyTkueST4S2jtVxLeCca4FVIXd2NCnau3kzBWG+TzRvWo6mc592vFA3POv1VBD9eYYEwnwR0vmU4VzWjHaPex+ENua08PGKhOIO4trGg/AtsJvQl8W50ecanrL7h+tFRQUSkZvTT0RHJEGpvFPd101Kl+hI+h2y1Sdoo94OdAhzoDu59yaVxBiz/ScOOxWjpIAkgix5AkwKk5JXKONrP+eFSe+BgjIU9LiH2El9fyubKRq0/QrUNnaIF/+eCDznGE+G99/qkZkrfBwHlqNzktdQnLriqT1Of3wnja5jVOrOypzkdeza943oAOrDI/ShwL6mWShjjCJ3Qio7C+ljJkSdEQjhgzlqhioVigMZdX7KGEDPn/VtoV8snL6ckj3rLXKBno8UQmDZp0xH1sFNOliO/6Id2XgwcSV6WWYdOm3s1foK6kJrUwBeJ2JMvXVxJGQHl6bc9AOxLPTy2puUCOjgenNRSkaNBXJtEtMDpzspYBQpJ0+lhyCOw+tVYTbXat7hAo3kAoTgv26Qo/VQF9soe2iXChsltMlFBYyZKb0wVjTRWUxm8=
+        skip_cleanup: true
+        file:
+          - gedcom-linux-amd64.zip
+          - gedcom-darwin-amd64.zip
+          - gedcom-windows-amd64.zip
+          - gedcom-windows-386.zip
+        on:
+          repo: elliotchance/gedcom
+          all_branches: true

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+test:
+ 	# Run all the tests with the race detector enabled.
+	go test -race ./...
+
+zip:
+	rm -rf bin
+	mkdir bin
+	go build -o bin/gedcom2html ./gedcom2html
+	go build -o bin/gedcom2json ./gedcom2json
+	go build -o bin/gedcom2text ./gedcom2text
+	go build -o bin/gedcomdiff ./gedcomdiff
+	go build -o bin/gedcomtune ./gedcomtune
+	zip gedcom-$(GOOS)-$(GOARCH).zip -r bin
+
+.PHONY: test zip

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ github.com/elliotchance/gedcom
 exporting and diffing GEDCOM files.
 
    * [Project Goals](#project-goals)
+   * [Installation](#installation)
    * [GEDCOM Document](#gedcom-document)
       * [Decoding](#decoding)
       * [Encoding](#encoding)
@@ -44,6 +45,20 @@ information can be manipulated and ingested by other applications.
 
 4. Provide more advanced functionality to deal with comparing and diffing GEDCOM
 files.
+
+Installation
+============
+
+You can download the latest binaries for Mac, Windows or Linux on the
+[Releases][15] page. This will not require you to install Go or any other
+dependencies.
+
+If you wish to build it from source you must include the dependencies with:
+
+```bash
+dep ensure
+```
+
 
 GEDCOM Document
 ===============
@@ -342,3 +357,4 @@ You can (and probably should) also use
 [12]: https://godoc.org/github.com/elliotchance/gedcom#SimpleNameFilter
 [13]: https://godoc.org/github.com/elliotchance/gedcom#NameNode.Format
 [14]: https://godoc.org/github.com/elliotchance/gedcom#NameNode
+[15]: https://github.com/elliotchance/gedcom/releases


### PR DESCRIPTION
This makes it much easier for people that don't have or want a Go environment to be able to use the gedcom tools.

This also adds support for Go 1.11.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/gedcom/144)
<!-- Reviewable:end -->
