### PR TITLE
Fixed a bug with IsLiving

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -31,9 +31,7 @@ func NewDecoder(r io.Reader) *Decoder {
 // A blank GEDCOM or a GEDCOM that only contains empty lines is valid and a
 // Document will be returned with zero nodes.
 func (dec *Decoder) Decode() (*Document, error) {
-	document := &Document{
-		Nodes: []Node{},
-	}
+	document := NewDocument()
 	indents := []Node{}
 
 	document.HasBOM = dec.consumeOptionalBOM()

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -10,10 +10,10 @@ import (
 
 var tests = map[string]*gedcom.Document{
 	"": {
-		Nodes: []gedcom.Node{},
+		Nodes: nil,
 	},
 	"\n\n": {
-		Nodes: []gedcom.Node{},
+		Nodes: nil,
 	},
 	"0 HEAD": {
 		Nodes: []gedcom.Node{
@@ -257,6 +257,7 @@ func TestDecoder_Decode(t *testing.T) {
 			decoder := gedcom.NewDecoder(strings.NewReader(ged))
 			actual, err := decoder.Decode()
 			actual.HasBOM = expected.HasBOM
+			expected.MaxLivingAge = gedcom.DefaultMaxLivingAge
 
 			assert.NoError(t, err, ged)
 

--- a/document.go
+++ b/document.go
@@ -13,6 +13,10 @@ const DefaultMaxLivingAge = 100.0
 // Document represents a whole GEDCOM document. It is possible for a
 // Document to contain zero Nodes, this means the GEDCOM file was empty. It
 // may also (and usually) contain several Nodes.
+//
+// You should not instantiate a Document yourself because there are sensible
+// defaults that need to be setup. Use one of the NewDocument constructors
+// instead.
 type Document struct {
 	Nodes        []Node
 	pointerCache map[string]Node

--- a/document_test.go
+++ b/document_test.go
@@ -135,7 +135,7 @@ func TestNewDocumentFromString(t *testing.T) {
 	}{
 		{
 			"",
-			&gedcom.Document{Nodes: []gedcom.Node{}},
+			&gedcom.Document{},
 			nil,
 		},
 		{
@@ -156,6 +156,11 @@ func TestNewDocumentFromString(t *testing.T) {
 	} {
 		t.Run(test.ged, func(t *testing.T) {
 			result, err := gedcom.NewDocumentFromString(test.ged)
+
+			if test.expected != nil {
+				test.expected.MaxLivingAge = gedcom.DefaultMaxLivingAge
+			}
+
 			assert.Equal(t, err, test.err)
 			assert.Equal(t, test.expected, result)
 		})

--- a/gedcom2html/badge_pill_test.go
+++ b/gedcom2html/badge_pill_test.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"testing"
 	"github.com/elliotchance/tf"
+	"testing"
 )
 
 func Test_badgePill_String(t *testing.T) {

--- a/html/anchor_test.go
+++ b/html/anchor_test.go
@@ -1,8 +1,8 @@
 package html
 
 import (
-	"testing"
 	"github.com/elliotchance/tf"
+	"testing"
 )
 
 func TestAnchor_String(t *testing.T) {

--- a/individual_node.go
+++ b/individual_node.go
@@ -1,6 +1,8 @@
 package gedcom
 
-import "time"
+import (
+	"time"
+)
 
 // IndividualNode represents a person.
 type IndividualNode struct {
@@ -209,6 +211,10 @@ func (node *IndividualNode) IsLiving() bool {
 
 	if node.Document() != nil {
 		maxLivingAge = node.Document().MaxLivingAge
+	}
+
+	if maxLivingAge == 0 {
+		return true
 	}
 
 	nowYear := float64(time.Now().Year())

--- a/individual_node_test.go
+++ b/individual_node_test.go
@@ -1317,13 +1317,19 @@ func TestIndividualNode_IsLiving(t *testing.T) {
 		}),
 	})).Returns(true)
 
-	doc = gedcom.NewDocument()
 	doc.MaxLivingAge = 25
 	IsLiving(gedcom.NewIndividualNode(doc, "", "", []gedcom.Node{
 		gedcom.NewBirthNode(doc, "", "", []gedcom.Node{
 			gedcom.NewDateNode(doc, "3 Sep 1945", "", nil),
 		}),
 	})).Returns(false)
+
+	doc.MaxLivingAge = 0
+	IsLiving(gedcom.NewIndividualNode(doc, "", "", []gedcom.Node{
+		gedcom.NewBirthNode(doc, "", "", []gedcom.Node{
+			gedcom.NewDateNode(doc, "3 Sep 1945", "", nil),
+		}),
+	})).Returns(true)
 }
 
 func TestIndividualNode_Children(t *testing.T) {

--- a/node.go
+++ b/node.go
@@ -73,9 +73,8 @@ func NodeGedcom(node Node) string {
 		return ""
 	}
 
-	document := &Document{
-		Nodes: []Node{node},
-	}
+	document := NewDocument()
+	document.Nodes = []Node{node}
 
 	return document.String()
 }


### PR DESCRIPTION
There was a bug that caused copied documents to avoid using the appropriate constructor that would have setup the MaxLivingAge. This utimately meant that indviduals were returning true under some cases for IsLiving.

There was also a related bug found where MaxLivingAge == 0 did not always perform the way the documentation outlined.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/gedcom/156)
<!-- Reviewable:end -->
