### PR TITLE
Remove Document.Nodes

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -62,7 +62,7 @@ func (dec *Decoder) Decode() (*Document, error) {
 
 		// Add a root node to the document.
 		if indent == 0 {
-			document.Nodes = append(document.Nodes, node)
+			document.AddNode(node)
 
 			// There can be multiple root nodes so make sure we always reset all
 			// indent pointers.

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -9,264 +9,234 @@ import (
 )
 
 var tests = map[string]*gedcom.Document{
-	"": {
-		Nodes: nil,
-	},
-	"\n\n": {
-		Nodes: nil,
-	},
-	"0 HEAD": {
-		Nodes: []gedcom.Node{
-			gedcom.NewNode(nil, gedcom.TagHeader, "", ""),
-		},
-	},
-	"0 HEAD\n1 CHAR UTF-8": {
-		Nodes: []gedcom.Node{
-			gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-				gedcom.NewNode(nil, gedcom.TagCharacterSet, "UTF-8", ""),
+	"":     gedcom.NewDocumentWithNodes(nil),
+	"\n\n": gedcom.NewDocumentWithNodes(nil),
+	"0 HEAD": gedcom.NewDocumentWithNodes([]gedcom.Node{
+		gedcom.NewNode(nil, gedcom.TagHeader, "", ""),
+	}),
+	"0 HEAD\n1 CHAR UTF-8": gedcom.NewDocumentWithNodes([]gedcom.Node{
+		gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
+			gedcom.NewNode(nil, gedcom.TagCharacterSet, "UTF-8", ""),
+		}),
+	}),
+	"0 HEAD\n\n1 CHAR UTF-8\n": gedcom.NewDocumentWithNodes([]gedcom.Node{
+		gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
+			gedcom.NewNode(nil, gedcom.TagCharacterSet, "UTF-8", ""),
+		}),
+	}),
+	"0 HEAD\n1 CHAR UTF-8\n1 SOUR Ancestry.com Family Trees": gedcom.NewDocumentWithNodes([]gedcom.Node{
+		gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
+			gedcom.NewNode(nil, gedcom.TagCharacterSet, "UTF-8", ""),
+			gedcom.NewSourceNode(nil, "Ancestry.com Family Trees", "", nil),
+		}),
+	}),
+	"0 HEAD\n1 CHAR UTF-8\n1 CHAR UTF-8": gedcom.NewDocumentWithNodes([]gedcom.Node{
+		gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
+			gedcom.NewNode(nil, gedcom.TagCharacterSet, "UTF-8", ""),
+			gedcom.NewNode(nil, gedcom.TagCharacterSet, "UTF-8", ""),
+		}),
+	}),
+	"0 HEAD\n1 SOUR Ancestry.com Family Trees": gedcom.NewDocumentWithNodes([]gedcom.Node{
+		gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
+			gedcom.NewSourceNode(nil, "Ancestry.com Family Trees", "", nil),
+		}),
+	}),
+	"0 HEAD\n1 BIRT": gedcom.NewDocumentWithNodes([]gedcom.Node{
+		gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
+			gedcom.NewBirthNode(nil, "", "", nil),
+		}),
+	}),
+	"0 HEAD\n1 GEDC\n2 VERS (2010.3)": gedcom.NewDocumentWithNodes([]gedcom.Node{
+		gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
+			gedcom.NewNodeWithChildren(nil, gedcom.TagGedcomInformation, "", "", []gedcom.Node{
+				gedcom.NewNode(nil, gedcom.TagVersion, "(2010.3)", ""),
 			}),
-		},
-	},
-	"0 HEAD\n\n1 CHAR UTF-8\n": {
-		Nodes: []gedcom.Node{
-			gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-				gedcom.NewNode(nil, gedcom.TagCharacterSet, "UTF-8", ""),
+		}),
+	}),
+	"0 HEAD\n1 GEDC\n2 VERS 5.5": gedcom.NewDocumentWithNodes([]gedcom.Node{
+		gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
+			gedcom.NewNodeWithChildren(nil, gedcom.TagGedcomInformation, "", "", []gedcom.Node{
+				gedcom.NewNode(nil, gedcom.TagVersion, "5.5", ""),
 			}),
-		},
-	},
-	"0 HEAD\n1 CHAR UTF-8\n1 SOUR Ancestry.com Family Trees": {
-		Nodes: []gedcom.Node{
-			gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-				gedcom.NewNode(nil, gedcom.TagCharacterSet, "UTF-8", ""),
-				gedcom.NewSourceNode(nil, "Ancestry.com Family Trees", "", nil),
+		}),
+	}),
+	"0 HEAD\n1 GEDC\n2 FORM LINEAGE-LINKED": gedcom.NewDocumentWithNodes([]gedcom.Node{
+		gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
+			gedcom.NewNodeWithChildren(nil, gedcom.TagGedcomInformation, "", "", []gedcom.Node{
+				gedcom.NewFormatNode(nil, "LINEAGE-LINKED", "", nil),
 			}),
-		},
-	},
-	"0 HEAD\n1 CHAR UTF-8\n1 CHAR UTF-8": {
-		Nodes: []gedcom.Node{
-			gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-				gedcom.NewNode(nil, gedcom.TagCharacterSet, "UTF-8", ""),
-				gedcom.NewNode(nil, gedcom.TagCharacterSet, "UTF-8", ""),
+		}),
+	}),
+	"0 HEAD\n1 BIRT\n2 PLAC Camperdown, Nsw, Australia": gedcom.NewDocumentWithNodes([]gedcom.Node{
+		gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
+			gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
+				gedcom.NewPlaceNode(nil, "Camperdown, Nsw, Australia", "", nil),
 			}),
-		},
-	},
-	"0 HEAD\n1 SOUR Ancestry.com Family Trees": {
-		Nodes: []gedcom.Node{
-			gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-				gedcom.NewSourceNode(nil, "Ancestry.com Family Trees", "", nil),
+		}),
+	}),
+	"0 HEAD\n1 NAME Elliot Rupert de Peyster /Chance/": gedcom.NewDocumentWithNodes([]gedcom.Node{
+		gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
+			gedcom.NewNameNode(nil, "Elliot Rupert de Peyster /Chance/", "", nil),
+		}),
+	}),
+	"0 HEAD\n0 @P1@ INDI": gedcom.NewDocumentWithNodes([]gedcom.Node{
+		gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", nil),
+		gedcom.NewIndividualNode(nil, "", "P1", nil),
+	}),
+	"0 HEAD\n1 SEX M\n0 @P1@ INDI": gedcom.NewDocumentWithNodes([]gedcom.Node{
+		gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
+			gedcom.NewNode(nil, gedcom.TagSex, "M", ""),
+		}),
+		gedcom.NewIndividualNode(nil, "", "P1", nil),
+	}),
+	"0 HEAD\n1 SEX M": gedcom.NewDocumentWithNodes([]gedcom.Node{
+		gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
+			gedcom.NewNode(nil, gedcom.TagSex, "M", ""),
+		}),
+	}),
+	"0 HEAD\n1 BIRT\n2 PLAC Camperdown, Nsw, Australia\n1 SEX M": gedcom.NewDocumentWithNodes([]gedcom.Node{
+		gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
+			gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
+				gedcom.NewPlaceNode(nil, "Camperdown, Nsw, Australia", "", nil),
 			}),
-		},
-	},
-	"0 HEAD\n1 BIRT": {
-		Nodes: []gedcom.Node{
-			gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-				gedcom.NewBirthNode(nil, "", "", nil),
+			gedcom.NewNode(nil, gedcom.TagSex, "M", ""),
+		}),
+	}),
+	"0 HEAD\n0 @P1@ INDI\n1 BIRT": gedcom.NewDocumentWithNodes([]gedcom.Node{
+		gedcom.NewNode(nil, gedcom.TagHeader, "", ""),
+		gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
+			gedcom.NewBirthNode(nil, "", "", nil),
+		}),
+	}),
+	"0 HEAD\n1 GEDC\n2 FORM LINEAGE-LINKED\n0 @P1@ INDI": gedcom.NewDocumentWithNodes([]gedcom.Node{
+		gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
+			gedcom.NewNodeWithChildren(nil, gedcom.TagGedcomInformation, "", "", []gedcom.Node{
+				gedcom.NewFormatNode(nil, "LINEAGE-LINKED", "", nil),
 			}),
-		},
-	},
-	"0 HEAD\n1 GEDC\n2 VERS (2010.3)": {
-		Nodes: []gedcom.Node{
-			gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-				gedcom.NewNodeWithChildren(nil, gedcom.TagGedcomInformation, "", "", []gedcom.Node{
-					gedcom.NewNode(nil, gedcom.TagVersion, "(2010.3)", ""),
+		}),
+		gedcom.NewIndividualNode(nil, "", "P1", nil),
+	}),
+	"0 HEAD0\n1 HEAD1\n2 HEAD2\n3 HEAD3\n0 HEAD00": gedcom.NewDocumentWithNodes([]gedcom.Node{
+		gedcom.NewNodeWithChildren(nil, gedcom.TagFromString("HEAD0"), "", "", []gedcom.Node{
+			gedcom.NewNodeWithChildren(nil, gedcom.TagFromString("HEAD1"), "", "", []gedcom.Node{
+				gedcom.NewNodeWithChildren(nil, gedcom.TagFromString("HEAD2"), "", "", []gedcom.Node{
+					gedcom.NewNode(nil, gedcom.TagFromString("HEAD3"), "", ""),
 				}),
 			}),
-		},
-	},
-	"0 HEAD\n1 GEDC\n2 VERS 5.5": {
-		Nodes: []gedcom.Node{
-			gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-				gedcom.NewNodeWithChildren(nil, gedcom.TagGedcomInformation, "", "", []gedcom.Node{
-					gedcom.NewNode(nil, gedcom.TagVersion, "5.5", ""),
+		}),
+		gedcom.NewNode(nil, gedcom.TagFromString("HEAD00"), "", ""),
+	}),
+	"0 HEAD0\n1 HEAD1\n2 HEAD2\n3 HEAD3\n1 HEAD10": gedcom.NewDocumentWithNodes([]gedcom.Node{
+		gedcom.NewNodeWithChildren(nil, gedcom.TagFromString("HEAD0"), "", "", []gedcom.Node{
+			gedcom.NewNodeWithChildren(nil, gedcom.TagFromString("HEAD1"), "", "", []gedcom.Node{
+				gedcom.NewNodeWithChildren(nil, gedcom.TagFromString("HEAD2"), "", "", []gedcom.Node{
+					gedcom.NewNode(nil, gedcom.TagFromString("HEAD3"), "", ""),
 				}),
 			}),
-		},
-	},
-	"0 HEAD\n1 GEDC\n2 FORM LINEAGE-LINKED": {
-		Nodes: []gedcom.Node{
-			gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-				gedcom.NewNodeWithChildren(nil, gedcom.TagGedcomInformation, "", "", []gedcom.Node{
-					gedcom.NewFormatNode(nil, "LINEAGE-LINKED", "", nil),
-				}),
+			gedcom.NewNode(nil, gedcom.TagFromString("HEAD10"), "", ""),
+		}),
+	}),
+	"0 HEAD0\r1 HEAD1": gedcom.NewDocumentWithNodes([]gedcom.Node{
+		gedcom.NewNodeWithChildren(nil, gedcom.TagFromString("HEAD0"), "", "", []gedcom.Node{
+			gedcom.NewNode(nil, gedcom.TagFromString("HEAD1"), "", ""),
+		}),
+	}),
+	"0 HEAD0\r\n1 HEAD1": gedcom.NewDocumentWithNodes([]gedcom.Node{
+		gedcom.NewNodeWithChildren(nil, gedcom.TagFromString("HEAD0"), "", "", []gedcom.Node{
+			gedcom.NewNode(nil, gedcom.TagFromString("HEAD1"), "", ""),
+		}),
+	}),
+	"0 HEAD0\n1 HEAD1\n1 HEAD10\n2 HEAD2": gedcom.NewDocumentWithNodes([]gedcom.Node{
+		gedcom.NewNodeWithChildren(nil, gedcom.TagFromString("HEAD0"), "", "", []gedcom.Node{
+			gedcom.NewNode(nil, gedcom.TagFromString("HEAD1"), "", ""),
+			gedcom.NewNodeWithChildren(nil, gedcom.TagFromString("HEAD10"), "", "", []gedcom.Node{
+				gedcom.NewNode(nil, gedcom.TagFromString("HEAD2"), "", ""),
 			}),
-		},
-	},
-	"0 HEAD\n1 BIRT\n2 PLAC Camperdown, Nsw, Australia": {
-		Nodes: []gedcom.Node{
-			gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
-					gedcom.NewPlaceNode(nil, "Camperdown, Nsw, Australia", "", nil),
-				}),
+		}),
+	}),
+	"0 HEAD\n1 BIRT ": gedcom.NewDocumentWithNodes([]gedcom.Node{
+		gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
+			gedcom.NewBirthNode(nil, "", "", nil),
+		}),
+	}),
+	"0 @P221@ INDI\n1 BIRT\n2 DATE 1851\n1 DEAT\n2 DATE 1856": gedcom.NewDocumentWithNodes([]gedcom.Node{
+		gedcom.NewIndividualNode(nil, "", "P221", []gedcom.Node{
+			gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
+				gedcom.NewDateNode(nil, "1851", "", nil),
 			}),
-		},
-	},
-	"0 HEAD\n1 NAME Elliot Rupert de Peyster /Chance/": {
-		Nodes: []gedcom.Node{
-			gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-				gedcom.NewNameNode(nil, "Elliot Rupert de Peyster /Chance/", "", nil),
+			gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "", "", []gedcom.Node{
+				gedcom.NewDateNode(nil, "1856", "", nil),
 			}),
-		},
-	},
-	"0 HEAD\n0 @P1@ INDI": {
-		Nodes: []gedcom.Node{
-			gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", nil),
-			gedcom.NewIndividualNode(nil, "", "P1", nil),
-		},
-	},
-	"0 HEAD\n1 SEX M\n0 @P1@ INDI": {
-		Nodes: []gedcom.Node{
-			gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-				gedcom.NewNode(nil, gedcom.TagSex, "M", ""),
-			}),
-			gedcom.NewIndividualNode(nil, "", "P1", nil),
-		},
-	},
-	"0 HEAD\n1 SEX M": {
-		Nodes: []gedcom.Node{
-			gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-				gedcom.NewNode(nil, gedcom.TagSex, "M", ""),
-			}),
-		},
-	},
-	"0 HEAD\n1 BIRT\n2 PLAC Camperdown, Nsw, Australia\n1 SEX M": {
-		Nodes: []gedcom.Node{
-			gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
-					gedcom.NewPlaceNode(nil, "Camperdown, Nsw, Australia", "", nil),
-				}),
-				gedcom.NewNode(nil, gedcom.TagSex, "M", ""),
-			}),
-		},
-	},
-	"0 HEAD\n0 @P1@ INDI\n1 BIRT": {
-		Nodes: []gedcom.Node{
-			gedcom.NewNode(nil, gedcom.TagHeader, "", ""),
-			gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewBirthNode(nil, "", "", nil),
-			}),
-		},
-	},
-	"0 HEAD\n1 GEDC\n2 FORM LINEAGE-LINKED\n0 @P1@ INDI": {
-		Nodes: []gedcom.Node{
-			gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-				gedcom.NewNodeWithChildren(nil, gedcom.TagGedcomInformation, "", "", []gedcom.Node{
-					gedcom.NewFormatNode(nil, "LINEAGE-LINKED", "", nil),
-				}),
-			}),
-			gedcom.NewIndividualNode(nil, "", "P1", nil),
-		},
-	},
-	"0 HEAD0\n1 HEAD1\n2 HEAD2\n3 HEAD3\n0 HEAD00": {
-		Nodes: []gedcom.Node{
-			gedcom.NewNodeWithChildren(nil, gedcom.TagFromString("HEAD0"), "", "", []gedcom.Node{
-				gedcom.NewNodeWithChildren(nil, gedcom.TagFromString("HEAD1"), "", "", []gedcom.Node{
-					gedcom.NewNodeWithChildren(nil, gedcom.TagFromString("HEAD2"), "", "", []gedcom.Node{
-						gedcom.NewNode(nil, gedcom.TagFromString("HEAD3"), "", ""),
-					}),
-				}),
-			}),
-			gedcom.NewNode(nil, gedcom.TagFromString("HEAD00"), "", ""),
-		},
-	},
-	"0 HEAD0\n1 HEAD1\n2 HEAD2\n3 HEAD3\n1 HEAD10": {
-		Nodes: []gedcom.Node{
-			gedcom.NewNodeWithChildren(nil, gedcom.TagFromString("HEAD0"), "", "", []gedcom.Node{
-				gedcom.NewNodeWithChildren(nil, gedcom.TagFromString("HEAD1"), "", "", []gedcom.Node{
-					gedcom.NewNodeWithChildren(nil, gedcom.TagFromString("HEAD2"), "", "", []gedcom.Node{
-						gedcom.NewNode(nil, gedcom.TagFromString("HEAD3"), "", ""),
-					}),
-				}),
-				gedcom.NewNode(nil, gedcom.TagFromString("HEAD10"), "", ""),
-			}),
-		},
-	},
-	"0 HEAD0\r1 HEAD1": {
-		Nodes: []gedcom.Node{
-			gedcom.NewNodeWithChildren(nil, gedcom.TagFromString("HEAD0"), "", "", []gedcom.Node{
-				gedcom.NewNode(nil, gedcom.TagFromString("HEAD1"), "", ""),
-			}),
-		},
-	},
-	"0 HEAD0\r\n1 HEAD1": {
-		Nodes: []gedcom.Node{
-			gedcom.NewNodeWithChildren(nil, gedcom.TagFromString("HEAD0"), "", "", []gedcom.Node{
-				gedcom.NewNode(nil, gedcom.TagFromString("HEAD1"), "", ""),
-			}),
-		},
-	},
-	"0 HEAD0\n1 HEAD1\n1 HEAD10\n2 HEAD2": {
-		Nodes: []gedcom.Node{
-			gedcom.NewNodeWithChildren(nil, gedcom.TagFromString("HEAD0"), "", "", []gedcom.Node{
-				gedcom.NewNode(nil, gedcom.TagFromString("HEAD1"), "", ""),
-				gedcom.NewNodeWithChildren(nil, gedcom.TagFromString("HEAD10"), "", "", []gedcom.Node{
-					gedcom.NewNode(nil, gedcom.TagFromString("HEAD2"), "", ""),
-				}),
-			}),
-		},
-	},
-	"0 HEAD\n1 BIRT ": {
-		Nodes: []gedcom.Node{
-			gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-				gedcom.NewBirthNode(nil, "", "", nil),
-			}),
-		},
-	},
-	"0 @P221@ INDI\n1 BIRT\n2 DATE 1851\n1 DEAT\n2 DATE 1856": {
-		Nodes: []gedcom.Node{
-			gedcom.NewIndividualNode(nil, "", "P221", []gedcom.Node{
-				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
-					gedcom.NewDateNode(nil, "1851", "", nil),
-				}),
-				gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "", "", []gedcom.Node{
-					gedcom.NewDateNode(nil, "1856", "", nil),
-				}),
-			}),
-		},
-	},
-	"0 @F1@ FAM\n1 HUSB @P2@\n1 WIFE @P3@": {
-		Nodes: []gedcom.Node{
-			gedcom.NewFamilyNode(nil, "F1", []gedcom.Node{
-				gedcom.NewNode(nil, gedcom.TagHusband, "@P2@", ""),
-				gedcom.NewNode(nil, gedcom.TagWife, "@P3@", ""),
-			}),
-		},
-	},
-	"0 DATE 1856": {
-		Nodes: []gedcom.Node{
-			gedcom.NewDateNode(nil, "1856", "", nil),
-		},
-	},
-	"0 NAME κόσμε": {
-		Nodes: []gedcom.Node{
-			gedcom.NewNameNode(nil, "κόσμε", "", nil),
-		},
-	},
-	"\xEF\xBB\xBF0 HEAD\n1 CHAR UTF-8": {
-		Nodes: []gedcom.Node{
-			gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-				gedcom.NewNode(nil, gedcom.TagCharacterSet, "UTF-8", ""),
-			}),
-		},
-		HasBOM: true,
-	},
+		}),
+	}),
+	"0 @F1@ FAM\n1 HUSB @P2@\n1 WIFE @P3@": gedcom.NewDocumentWithNodes([]gedcom.Node{
+		gedcom.NewFamilyNode(nil, "F1", []gedcom.Node{
+			gedcom.NewNode(nil, gedcom.TagHusband, "@P2@", ""),
+			gedcom.NewNode(nil, gedcom.TagWife, "@P3@", ""),
+		}),
+	}),
+	"0 DATE 1856": gedcom.NewDocumentWithNodes([]gedcom.Node{
+		gedcom.NewDateNode(nil, "1856", "", nil),
+	}),
+	"0 NAME κόσμε": gedcom.NewDocumentWithNodes([]gedcom.Node{
+		gedcom.NewNameNode(nil, "κόσμε", "", nil),
+	}),
 }
 
 func TestDecoder_Decode(t *testing.T) {
 	for ged, expected := range tests {
 		t.Run("", func(t *testing.T) {
 			decoder := gedcom.NewDecoder(strings.NewReader(ged))
-			actual, err := decoder.Decode()
-			actual.HasBOM = expected.HasBOM
-			expected.MaxLivingAge = gedcom.DefaultMaxLivingAge
 
+			actual, err := decoder.Decode()
 			assert.NoError(t, err, ged)
 
-			for _, n := range expected.Nodes {
+			expected.MaxLivingAge = gedcom.DefaultMaxLivingAge
+
+			for _, n := range expected.Nodes() {
 				n.SetDocument(expected)
 			}
-			assert.Equal(t, expected, actual, ged)
+
+			assertDocumentEqual(t, expected, actual, ged)
 		})
 	}
+
+	t.Run("BOM", func(t *testing.T) {
+		ged := "\xEF\xBB\xBF0 HEAD\n1 CHAR UTF-8"
+		decoder := gedcom.NewDecoder(strings.NewReader(ged))
+		expected := gedcom.NewDocumentWithNodes([]gedcom.Node{
+			gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
+				gedcom.NewNode(nil, gedcom.TagCharacterSet, "UTF-8", ""),
+			}),
+		})
+		expected.HasBOM = true
+
+		actual, err := decoder.Decode()
+		assert.NoError(t, err, ged)
+
+		expected.MaxLivingAge = gedcom.DefaultMaxLivingAge
+
+		for _, n := range expected.Nodes() {
+			n.SetDocument(expected)
+		}
+
+		assertDocumentEqual(t, expected, actual, ged)
+	})
+}
+
+func assertDocumentEqual(t *testing.T, expected, actual *gedcom.Document, msgAndArgs ...interface{}) {
+	assert.Equal(t, expected.String(), actual.String(), msgAndArgs...)
+
+	if !assert.Equal(t, len(expected.Nodes()), len(actual.Nodes()), msgAndArgs...) {
+		return
+	}
+
+	for i, n := range expected.Nodes() {
+		assert.Equal(t, n, actual.Nodes()[i], msgAndArgs...)
+	}
+
+	assert.Equal(t, expected.MaxLivingAge, actual.MaxLivingAge, msgAndArgs...)
+	assert.Equal(t, expected.HasBOM, actual.HasBOM, msgAndArgs...)
 }
 
 func trimSpaces(s string) string {

--- a/document.go
+++ b/document.go
@@ -15,12 +15,16 @@ const DefaultMaxLivingAge = 100.0
 // may also (and usually) contain several Nodes.
 //
 // You should not instantiate a Document yourself because there are sensible
-// defaults that need to be setup. Use one of the NewDocument constructors
-// instead.
+// defaults and cache that need to be setup. Use one of the NewDocument
+// constructors instead.
 type Document struct {
-	Nodes        []Node
+	// nodes is private because we need to track changes.
+	nodes []Node
+
+	// pointerCache is setup once when the document is created.
 	pointerCache map[string]Node
-	families     []*FamilyNode
+
+	families []*FamilyNode
 
 	// HasBOM controls if the encoded stream will start with the Byte Order
 	// Mark.
@@ -54,10 +58,11 @@ func (doc *Document) String() string {
 	return buf.String()
 }
 
+// Individuals returns all of the people in the document.
 func (doc *Document) Individuals() IndividualNodes {
 	individuals := IndividualNodes{}
 
-	for _, node := range doc.Nodes {
+	for _, node := range doc.Nodes() {
 		if n, ok := node.(*IndividualNode); ok {
 			individuals = append(individuals, n)
 		}
@@ -66,12 +71,15 @@ func (doc *Document) Individuals() IndividualNodes {
 	return individuals
 }
 
+// NodeByPointer returns the Node for a pointer value.
+//
+// If the pointer does not exist nil is returned.
 func (doc *Document) NodeByPointer(ptr string) Node {
 	// Build the cache once.
 	if doc.pointerCache == nil {
 		doc.pointerCache = map[string]Node{}
 
-		for _, node := range doc.Nodes {
+		for _, node := range doc.Nodes() {
 			if node.Pointer() != "" {
 				doc.pointerCache[node.Pointer()] = node
 			}
@@ -81,6 +89,7 @@ func (doc *Document) NodeByPointer(ptr string) Node {
 	return doc.pointerCache[ptr]
 }
 
+// Families returns the family entities in the document.
 func (doc *Document) Families() (families []*FamilyNode) {
 	if doc.families != nil {
 		return doc.families
@@ -92,7 +101,7 @@ func (doc *Document) Families() (families []*FamilyNode) {
 
 	families = []*FamilyNode{}
 
-	for _, node := range doc.Nodes {
+	for _, node := range doc.Nodes() {
 		if n, ok := node.(*FamilyNode); ok {
 			families = append(families, n)
 		}
@@ -105,7 +114,7 @@ func (doc *Document) Families() (families []*FamilyNode) {
 func (doc *Document) Places() map[*PlaceNode]Node {
 	places := map[*PlaceNode]Node{}
 
-	for _, node := range doc.Nodes {
+	for _, node := range doc.Nodes() {
 		extractPlaces(node, places)
 	}
 
@@ -128,13 +137,37 @@ func extractPlaces(n Node, dest map[*PlaceNode]Node) {
 func (doc *Document) Sources() []*SourceNode {
 	sources := []*SourceNode{}
 
-	for _, node := range doc.Nodes {
+	for _, node := range doc.Nodes() {
 		if n, ok := node.(*SourceNode); ok {
 			sources = append(sources, n)
 		}
 	}
 
 	return sources
+}
+
+// AddNode appends a node to the document.
+//
+// If the node is nil this function has no effect.
+//
+// If the node already exists it will be added again. This will cause problems
+// with duplicate references.
+func (doc *Document) AddNode(node Node) *Document {
+	if !IsNil(node) {
+		doc.nodes = append(doc.nodes, node)
+		doc.pointerCache = nil
+	}
+
+	return doc
+}
+
+// Nodes returns the root nodes for the document.
+//
+// It is important that the slice returned is not manually manipulated (such as
+// appending) because it may cause the internal cache to all out of sync. You
+// may manipulate the nodes themselves.
+func (doc *Document) Nodes() []Node {
+	return doc.nodes
 }
 
 // NewDocumentFromGEDCOMFile returns a decoded Document from the provided file.
@@ -166,4 +199,12 @@ func NewDocument() *Document {
 	return &Document{
 		MaxLivingAge: DefaultMaxLivingAge,
 	}
+}
+
+// NewDocumentWithNodes creates a new document with the provided root nodes.
+func NewDocumentWithNodes(nodes []Node) *Document {
+	document := NewDocument()
+	document.nodes = nodes
+
+	return document
 }

--- a/document_test.go
+++ b/document_test.go
@@ -16,19 +16,17 @@ var documentTests = []struct {
 	p2          gedcom.Node
 }{
 	{
-		doc:         &gedcom.Document{},
+		doc:         gedcom.NewDocument(),
 		individuals: gedcom.IndividualNodes{},
 		p2:          nil,
 		families:    []*gedcom.FamilyNode{},
 	},
 	{
-		doc: &gedcom.Document{
-			Nodes: []gedcom.Node{
-				gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-					gedcom.NewNameNode(nil, "Joe /Bloggs/", "", []gedcom.Node{}),
-				}),
-			},
-		},
+		doc: gedcom.NewDocumentWithNodes([]gedcom.Node{
+			gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
+				gedcom.NewNameNode(nil, "Joe /Bloggs/", "", []gedcom.Node{}),
+			}),
+		}),
 		individuals: gedcom.IndividualNodes{
 			gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
 				gedcom.NewNameNode(nil, "Joe /Bloggs/", "", []gedcom.Node{}),
@@ -38,17 +36,15 @@ var documentTests = []struct {
 		families: []*gedcom.FamilyNode{},
 	},
 	{
-		doc: &gedcom.Document{
-			Nodes: []gedcom.Node{
-				gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-					gedcom.NewNameNode(nil, "Joe /Bloggs/", "", []gedcom.Node{}),
-				}),
-				gedcom.NewNodeWithChildren(nil, gedcom.TagVersion, "", "", []gedcom.Node{}),
-				gedcom.NewIndividualNode(nil, "", "P2", []gedcom.Node{
-					gedcom.NewNameNode(nil, "John /Doe/", "", []gedcom.Node{}),
-				}),
-			},
-		},
+		doc: gedcom.NewDocumentWithNodes([]gedcom.Node{
+			gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
+				gedcom.NewNameNode(nil, "Joe /Bloggs/", "", []gedcom.Node{}),
+			}),
+			gedcom.NewNodeWithChildren(nil, gedcom.TagVersion, "", "", []gedcom.Node{}),
+			gedcom.NewIndividualNode(nil, "", "P2", []gedcom.Node{
+				gedcom.NewNameNode(nil, "John /Doe/", "", []gedcom.Node{}),
+			}),
+		}),
 		individuals: gedcom.IndividualNodes{
 			gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
 				gedcom.NewNameNode(nil, "Joe /Bloggs/", "", []gedcom.Node{}),
@@ -63,14 +59,12 @@ var documentTests = []struct {
 		families: []*gedcom.FamilyNode{},
 	},
 	{
-		doc: &gedcom.Document{
-			Nodes: []gedcom.Node{
-				gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-					gedcom.NewNameNode(nil, "Joe /Bloggs/", "", []gedcom.Node{}),
-				}),
-				gedcom.NewFamilyNode(nil, "F1", []gedcom.Node{}),
-			},
-		},
+		doc: gedcom.NewDocumentWithNodes([]gedcom.Node{
+			gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
+				gedcom.NewNameNode(nil, "Joe /Bloggs/", "", []gedcom.Node{}),
+			}),
+			gedcom.NewFamilyNode(nil, "F1", []gedcom.Node{}),
+		}),
 		individuals: gedcom.IndividualNodes{
 			gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
 				gedcom.NewNameNode(nil, "Joe /Bloggs/", "", []gedcom.Node{}),
@@ -82,14 +76,12 @@ var documentTests = []struct {
 		},
 	},
 	{
-		doc: &gedcom.Document{
-			Nodes: []gedcom.Node{
-				gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-					gedcom.NewNameNode(nil, "Joe /Bloggs/", "", []gedcom.Node{}),
-				}),
-				gedcom.NewFamilyNode(nil, "F3", []gedcom.Node{}),
-			},
-		},
+		doc: gedcom.NewDocumentWithNodes([]gedcom.Node{
+			gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
+				gedcom.NewNameNode(nil, "Joe /Bloggs/", "", []gedcom.Node{}),
+			}),
+			gedcom.NewFamilyNode(nil, "F3", []gedcom.Node{}),
+		}),
 		individuals: gedcom.IndividualNodes{
 			gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
 				gedcom.NewNameNode(nil, "Joe /Bloggs/", "", []gedcom.Node{}),
@@ -135,7 +127,7 @@ func TestNewDocumentFromString(t *testing.T) {
 	}{
 		{
 			"",
-			&gedcom.Document{},
+			gedcom.NewDocument(),
 			nil,
 		},
 		{
@@ -170,5 +162,47 @@ func TestNewDocumentFromString(t *testing.T) {
 func TestNewDocument(t *testing.T) {
 	doc := gedcom.NewDocument()
 
-	assert.Len(t, doc.Nodes, 0)
+	assert.Len(t, doc.Nodes(), 0)
+}
+
+func TestDocument_AddNode(t *testing.T) {
+	t.Run("One", func(t *testing.T) {
+		doc := gedcom.NewDocument()
+		nameNode := gedcom.NewNameNode(doc, "foo", "", nil)
+
+		doc.AddNode(nameNode)
+
+		assert.Equal(t, doc.Nodes(), []gedcom.Node{nameNode})
+	})
+
+	t.Run("Two", func(t *testing.T) {
+		doc := gedcom.NewDocument()
+		nameNode1 := gedcom.NewNameNode(doc, "foo", "", nil)
+		nameNode2 := gedcom.NewNameNode(doc, "foo", "", nil)
+
+		doc.AddNode(nameNode1)
+		doc.AddNode(nameNode2)
+
+		assert.Equal(t, doc.Nodes(), []gedcom.Node{nameNode1, nameNode2})
+	})
+
+	t.Run("Duplicate", func(t *testing.T) {
+		doc := gedcom.NewDocument()
+		nameNode := gedcom.NewNameNode(doc, "foo", "", nil)
+
+		doc.AddNode(nameNode)
+		doc.AddNode(nameNode)
+
+		assert.Equal(t, doc.Nodes(), []gedcom.Node{nameNode, nameNode})
+	})
+
+	t.Run("Nil", func(t *testing.T) {
+		doc := gedcom.NewDocument()
+		nameNode := gedcom.NewNameNode(doc, "foo", "", nil)
+
+		doc.AddNode(nil)
+		doc.AddNode(nameNode)
+
+		assert.Equal(t, doc.Nodes(), []gedcom.Node{nameNode})
+	})
 }

--- a/encoder.go
+++ b/encoder.go
@@ -40,7 +40,7 @@ func (enc *Encoder) renderNode(indent int, node Node) error {
 func (enc *Encoder) Encode() (err error) {
 	err = enc.restoreOptionalBOM()
 
-	for _, node := range enc.document.Nodes {
+	for _, node := range enc.document.Nodes() {
 		err = enc.renderNode(0, node)
 		if err != nil {
 			return

--- a/family_node_test.go
+++ b/family_node_test.go
@@ -14,35 +14,29 @@ var familyTests = []struct {
 	wife    *gedcom.IndividualNode
 }{
 	{
-		doc: &gedcom.Document{
-			Nodes: []gedcom.Node{
-				gedcom.NewFamilyNode(nil, "F1", nil),
-			},
-		},
+		doc: gedcom.NewDocumentWithNodes([]gedcom.Node{
+			gedcom.NewFamilyNode(nil, "F1", nil),
+		}),
 		husband: nil,
 		wife:    nil,
 	},
 	{
-		doc: &gedcom.Document{
-			Nodes: []gedcom.Node{
-				gedcom.NewFamilyNode(nil, "F1", []gedcom.Node{
-					gedcom.NewNodeWithChildren(nil, gedcom.TagHusband, "@P1@", "", []gedcom.Node{}),
-				}),
-				gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{}),
-			},
-		},
+		doc: gedcom.NewDocumentWithNodes([]gedcom.Node{
+			gedcom.NewFamilyNode(nil, "F1", []gedcom.Node{
+				gedcom.NewNodeWithChildren(nil, gedcom.TagHusband, "@P1@", "", []gedcom.Node{}),
+			}),
+			gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{}),
+		}),
 		husband: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{}),
 		wife:    nil,
 	},
 	{
-		doc: &gedcom.Document{
-			Nodes: []gedcom.Node{
-				gedcom.NewFamilyNode(nil, "F2", []gedcom.Node{
-					gedcom.NewNodeWithChildren(nil, gedcom.TagWife, "@P3@", "", []gedcom.Node{}),
-				}),
-				gedcom.NewIndividualNode(nil, "", "P3", []gedcom.Node{}),
-			},
-		},
+		doc: gedcom.NewDocumentWithNodes([]gedcom.Node{
+			gedcom.NewFamilyNode(nil, "F2", []gedcom.Node{
+				gedcom.NewNodeWithChildren(nil, gedcom.TagWife, "@P3@", "", []gedcom.Node{}),
+			}),
+			gedcom.NewIndividualNode(nil, "", "P3", []gedcom.Node{}),
+		}),
 		husband: nil,
 		wife:    gedcom.NewIndividualNode(nil, "", "P3", []gedcom.Node{}),
 	},
@@ -51,7 +45,7 @@ var familyTests = []struct {
 func TestFamilyNode_Husband(t *testing.T) {
 	for _, test := range familyTests {
 		t.Run("", func(t *testing.T) {
-			node := test.doc.Nodes[0].(*gedcom.FamilyNode)
+			node := test.doc.Nodes()[0].(*gedcom.FamilyNode)
 			node.SetDocument(test.doc)
 			assert.Equal(t, node.Husband(), test.husband)
 		})
@@ -65,7 +59,7 @@ func TestFamilyNode_Husband(t *testing.T) {
 func TestFamilyNode_Wife(t *testing.T) {
 	for _, test := range familyTests {
 		t.Run("", func(t *testing.T) {
-			node := test.doc.Nodes[0].(*gedcom.FamilyNode)
+			node := test.doc.Nodes()[0].(*gedcom.FamilyNode)
 			assert.Equal(t, node.Wife(), test.wife)
 		})
 	}
@@ -82,129 +76,119 @@ func TestFamilyNode_Similarity(t *testing.T) {
 	}{
 		// Empty cases.
 		{
-			doc: &gedcom.Document{
-				Nodes: []gedcom.Node{
-					gedcom.NewFamilyNode(nil, "F1", nil),
-					gedcom.NewFamilyNode(nil, "F2", nil),
-				},
-			},
+			doc: gedcom.NewDocumentWithNodes([]gedcom.Node{
+				gedcom.NewFamilyNode(nil, "F1", nil),
+				gedcom.NewFamilyNode(nil, "F2", nil),
+			}),
 			expected: 0.5,
 		},
 		{
-			doc: &gedcom.Document{
-				Nodes: []gedcom.Node{
-					gedcom.NewFamilyNode(nil, "F1", []gedcom.Node{}),
-					gedcom.NewFamilyNode(nil, "F2", []gedcom.Node{}),
-				},
-			},
+			doc: gedcom.NewDocumentWithNodes([]gedcom.Node{
+				gedcom.NewFamilyNode(nil, "F1", []gedcom.Node{}),
+				gedcom.NewFamilyNode(nil, "F2", []gedcom.Node{}),
+			}),
 			expected: 0.5,
 		},
 
 		// Perfect cases.
 		{
 			// All details match exactly.
-			doc: &gedcom.Document{
-				Nodes: []gedcom.Node{
-					gedcom.NewFamilyNode(nil, "F1", []gedcom.Node{
-						gedcom.NewNodeWithChildren(nil, gedcom.TagHusband, "@P1@", "", nil),
-						gedcom.NewNodeWithChildren(nil, gedcom.TagWife, "@P2@", "", nil),
-					}),
-					gedcom.NewFamilyNode(nil, "F2", []gedcom.Node{
-						gedcom.NewNodeWithChildren(nil, gedcom.TagHusband, "@P3@", "", nil),
-						gedcom.NewNodeWithChildren(nil, gedcom.TagWife, "@P4@", "", nil),
-					}),
-					gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-						name("Elliot Rupert de Peyster /Chance/"),
-						born("4 Jan 1843"),
-						died("17 Mar 1907"),
-					}),
-					gedcom.NewIndividualNode(nil, "", "P2", []gedcom.Node{
-						name("Dina Victoria /Wyche/"),
-						born("Abt. Feb 1837"),
-						died("8 Apr 1923"),
-					}),
-					gedcom.NewIndividualNode(nil, "", "P3", []gedcom.Node{
-						name("Elliot Rupert de Peyster /Chance/"),
-						born("4 Jan 1843"),
-						died("17 Mar 1907"),
-					}),
-					gedcom.NewIndividualNode(nil, "", "P4", []gedcom.Node{
-						name("Dina Victoria /Wyche/"),
-						born("Abt. Feb 1837"),
-						died("8 Apr 1923"),
-					}),
-				},
-			},
+			doc: gedcom.NewDocumentWithNodes([]gedcom.Node{
+				gedcom.NewFamilyNode(nil, "F1", []gedcom.Node{
+					gedcom.NewNodeWithChildren(nil, gedcom.TagHusband, "@P1@", "", nil),
+					gedcom.NewNodeWithChildren(nil, gedcom.TagWife, "@P2@", "", nil),
+				}),
+				gedcom.NewFamilyNode(nil, "F2", []gedcom.Node{
+					gedcom.NewNodeWithChildren(nil, gedcom.TagHusband, "@P3@", "", nil),
+					gedcom.NewNodeWithChildren(nil, gedcom.TagWife, "@P4@", "", nil),
+				}),
+				gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
+					name("Elliot Rupert de Peyster /Chance/"),
+					born("4 Jan 1843"),
+					died("17 Mar 1907"),
+				}),
+				gedcom.NewIndividualNode(nil, "", "P2", []gedcom.Node{
+					name("Dina Victoria /Wyche/"),
+					born("Abt. Feb 1837"),
+					died("8 Apr 1923"),
+				}),
+				gedcom.NewIndividualNode(nil, "", "P3", []gedcom.Node{
+					name("Elliot Rupert de Peyster /Chance/"),
+					born("4 Jan 1843"),
+					died("17 Mar 1907"),
+				}),
+				gedcom.NewIndividualNode(nil, "", "P4", []gedcom.Node{
+					name("Dina Victoria /Wyche/"),
+					born("Abt. Feb 1837"),
+					died("8 Apr 1923"),
+				}),
+			}),
 			expected: 1.0,
 		},
 
 		// Almost perfect matches.
 		{
 			// Name is more/less complete.
-			doc: &gedcom.Document{
-				Nodes: []gedcom.Node{
-					gedcom.NewFamilyNode(nil, "F1", []gedcom.Node{
-						gedcom.NewNodeWithChildren(nil, gedcom.TagHusband, "@P1@", "", nil),
-						gedcom.NewNodeWithChildren(nil, gedcom.TagWife, "@P2@", "", nil),
-					}),
-					gedcom.NewFamilyNode(nil, "F2", []gedcom.Node{
-						gedcom.NewNodeWithChildren(nil, gedcom.TagHusband, "@P3@", "", nil),
-						gedcom.NewNodeWithChildren(nil, gedcom.TagWife, "@P4@", "", nil),
-					}),
-					gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-						name("Elliot Rupert de Peyster /Chance/"),
-						born("4 Jan 1843"),
-						died("17 Mar 1907"),
-					}),
-					gedcom.NewIndividualNode(nil, "", "P2", []gedcom.Node{
-						name("Dina Victoria /Wyche/"),
-						born("Abt. Feb 1837"),
-					}),
-					gedcom.NewIndividualNode(nil, "", "P3", []gedcom.Node{
-						name("Elliot R. d. P. /Chance/"),
-						born("4 Jan 1843"),
-						died("17 Mar 1907"),
-					}),
-					gedcom.NewIndividualNode(nil, "", "P4", []gedcom.Node{
-						name("Dina /Wyche/"),
-						born("Bef. Mar 1837"),
-					}),
-				},
-			},
+			doc: gedcom.NewDocumentWithNodes([]gedcom.Node{
+				gedcom.NewFamilyNode(nil, "F1", []gedcom.Node{
+					gedcom.NewNodeWithChildren(nil, gedcom.TagHusband, "@P1@", "", nil),
+					gedcom.NewNodeWithChildren(nil, gedcom.TagWife, "@P2@", "", nil),
+				}),
+				gedcom.NewFamilyNode(nil, "F2", []gedcom.Node{
+					gedcom.NewNodeWithChildren(nil, gedcom.TagHusband, "@P3@", "", nil),
+					gedcom.NewNodeWithChildren(nil, gedcom.TagWife, "@P4@", "", nil),
+				}),
+				gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
+					name("Elliot Rupert de Peyster /Chance/"),
+					born("4 Jan 1843"),
+					died("17 Mar 1907"),
+				}),
+				gedcom.NewIndividualNode(nil, "", "P2", []gedcom.Node{
+					name("Dina Victoria /Wyche/"),
+					born("Abt. Feb 1837"),
+				}),
+				gedcom.NewIndividualNode(nil, "", "P3", []gedcom.Node{
+					name("Elliot R. d. P. /Chance/"),
+					born("4 Jan 1843"),
+					died("17 Mar 1907"),
+				}),
+				gedcom.NewIndividualNode(nil, "", "P4", []gedcom.Node{
+					name("Dina /Wyche/"),
+					born("Bef. Mar 1837"),
+				}),
+			}),
 			expected: 0.8904318416381887,
 		},
 
 		// These ones are way off.
 		{
-			doc: &gedcom.Document{
-				Nodes: []gedcom.Node{
-					gedcom.NewFamilyNode(nil, "F1", []gedcom.Node{
-						gedcom.NewNodeWithChildren(nil, gedcom.TagHusband, "@P1@", "", nil),
-						gedcom.NewNodeWithChildren(nil, gedcom.TagWife, "@P2@", "", nil),
-					}),
-					gedcom.NewFamilyNode(nil, "F2", []gedcom.Node{
-						gedcom.NewNodeWithChildren(nil, gedcom.TagHusband, "@P3@", "", nil),
-						gedcom.NewNodeWithChildren(nil, gedcom.TagWife, "@P4@", "", nil),
-					}),
-					gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-						name("Elliot Rupert de Peyster /Chance/"),
-						born("4 Jan 1843"),
-						died("17 Mar 1907"),
-					}),
-					gedcom.NewIndividualNode(nil, "", "P2", []gedcom.Node{
-						name("Dina Victoria /Wyche/"),
-						born("Abt. Feb 1837"),
-					}),
-					gedcom.NewIndividualNode(nil, "", "P3", []gedcom.Node{
-						name("Bob /Jones/"),
-						born("1627"),
-					}),
-					gedcom.NewIndividualNode(nil, "", "P4", []gedcom.Node{
-						name("Jane /Doe/"),
-						born("Sep 1845"),
-					}),
-				},
-			},
+			doc: gedcom.NewDocumentWithNodes([]gedcom.Node{
+				gedcom.NewFamilyNode(nil, "F1", []gedcom.Node{
+					gedcom.NewNodeWithChildren(nil, gedcom.TagHusband, "@P1@", "", nil),
+					gedcom.NewNodeWithChildren(nil, gedcom.TagWife, "@P2@", "", nil),
+				}),
+				gedcom.NewFamilyNode(nil, "F2", []gedcom.Node{
+					gedcom.NewNodeWithChildren(nil, gedcom.TagHusband, "@P3@", "", nil),
+					gedcom.NewNodeWithChildren(nil, gedcom.TagWife, "@P4@", "", nil),
+				}),
+				gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
+					name("Elliot Rupert de Peyster /Chance/"),
+					born("4 Jan 1843"),
+					died("17 Mar 1907"),
+				}),
+				gedcom.NewIndividualNode(nil, "", "P2", []gedcom.Node{
+					name("Dina Victoria /Wyche/"),
+					born("Abt. Feb 1837"),
+				}),
+				gedcom.NewIndividualNode(nil, "", "P3", []gedcom.Node{
+					name("Bob /Jones/"),
+					born("1627"),
+				}),
+				gedcom.NewIndividualNode(nil, "", "P4", []gedcom.Node{
+					name("Jane /Doe/"),
+					born("Sep 1845"),
+				}),
+			}),
 			expected: 0.37700025152486955,
 		},
 	}

--- a/gedcom2json/transform.go
+++ b/gedcom2json/transform.go
@@ -38,7 +38,7 @@ type TransformOptions struct {
 func Transform(doc *gedcom.Document, options TransformOptions) []interface{} {
 	r := []interface{}{}
 
-	for _, node := range doc.Nodes {
+	for _, node := range doc.Nodes() {
 		newNode := transformNode(node, options)
 		if newNode != nil {
 			r = append(r, newNode)

--- a/gedcom2json/transform_test.go
+++ b/gedcom2json/transform_test.go
@@ -11,15 +11,13 @@ var transformTests = []struct {
 	expected []interface{}
 }{
 	{
-		doc:      &gedcom.Document{},
+		doc:      gedcom.NewDocument(),
 		expected: []interface{}{},
 	},
 	{
-		doc: &gedcom.Document{
-			Nodes: []gedcom.Node{
-				gedcom.NewNode(nil, gedcom.TagVersion, "5.5", ""),
-			},
-		},
+		doc: gedcom.NewDocumentWithNodes([]gedcom.Node{
+			gedcom.NewNode(nil, gedcom.TagVersion, "5.5", ""),
+		}),
 		expected: []interface{}{
 			map[string]interface{}{
 				"tag": "VERS",
@@ -28,13 +26,11 @@ var transformTests = []struct {
 		},
 	},
 	{
-		doc: &gedcom.Document{
-			Nodes: []gedcom.Node{
-				gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-					gedcom.NewNameNode(nil, "Joe /Bloggs/", "", []gedcom.Node{}),
-				}),
-			},
-		},
+		doc: gedcom.NewDocumentWithNodes([]gedcom.Node{
+			gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
+				gedcom.NewNameNode(nil, "Joe /Bloggs/", "", []gedcom.Node{}),
+			}),
+		}),
 		expected: []interface{}{
 			map[string]interface{}{
 				"tag": "INDI",

--- a/individual_node_test.go
+++ b/individual_node_test.go
@@ -369,12 +369,10 @@ func getDocument() *gedcom.Document {
 		gedcom.NewNodeWithChildren(nil, gedcom.TagChild, "@P6@", "", nil),
 	})
 
-	return &gedcom.Document{
-		Nodes: []gedcom.Node{
-			p1, p2, p3, p4, p5, p6, p7, p8,
-			f1, f2, f3, f4,
-		},
-	}
+	return gedcom.NewDocumentWithNodes([]gedcom.Node{
+		p1, p2, p3, p4, p5, p6, p7, p8,
+		f1, f2, f3, f4,
+	})
 }
 
 func TestIndividualNode_Parents(t *testing.T) {
@@ -424,7 +422,7 @@ func TestIndividualNode_Parents(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(gedcom.Pointer(test.node), func(t *testing.T) {
-			for _, n := range doc.Nodes {
+			for _, n := range doc.Nodes() {
 				n.SetDocument(doc)
 			}
 			assert.Equal(t, test.node.Parents(), test.parents)
@@ -432,7 +430,8 @@ func TestIndividualNode_Parents(t *testing.T) {
 	}
 }
 
-func TestIndividualNode_SpouseChildren(t *testing.T) {
+func
+TestIndividualNode_SpouseChildren(t *testing.T) {
 	doc := getDocument()
 
 	var tests = []struct {
@@ -503,7 +502,7 @@ func TestIndividualNode_SpouseChildren(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(gedcom.Pointer(test.node), func(t *testing.T) {
-			for _, n := range doc.Nodes {
+			for _, n := range doc.Nodes() {
 				n.SetDocument(doc)
 			}
 			assert.Equal(t, test.expected, test.node.SpouseChildren())
@@ -511,7 +510,8 @@ func TestIndividualNode_SpouseChildren(t *testing.T) {
 	}
 }
 
-func TestIndividualNode_LDSBaptisms(t *testing.T) {
+func
+TestIndividualNode_LDSBaptisms(t *testing.T) {
 	var tests = []struct {
 		node     *gedcom.IndividualNode
 		baptisms []gedcom.Node
@@ -571,7 +571,8 @@ func TestIndividualNode_LDSBaptisms(t *testing.T) {
 	}
 }
 
-func TestIndividualNode_EstimatedBirthDate(t *testing.T) {
+func
+TestIndividualNode_EstimatedBirthDate(t *testing.T) {
 	var tests = []struct {
 		node     *gedcom.IndividualNode
 		expected *gedcom.DateNode
@@ -681,7 +682,8 @@ func TestIndividualNode_EstimatedBirthDate(t *testing.T) {
 	}
 }
 
-func TestIndividualNode_EstimatedDeathDate(t *testing.T) {
+func
+TestIndividualNode_EstimatedDeathDate(t *testing.T) {
 	var tests = []struct {
 		node     *gedcom.IndividualNode
 		expected *gedcom.DateNode
@@ -1030,17 +1032,18 @@ func TestIndividualNode_Similarity(t *testing.T) {
 	}
 }
 
-func TestIndividualNode_SurroundingSimilarity(t *testing.T) {
+func
+TestIndividualNode_SurroundingSimilarity(t *testing.T) {
 	var tests = []struct {
 		doc      *gedcom.Document
 		expected gedcom.SurroundingSimilarity
 	}{
 		// Empty individuals.
 		{
-			doc: document(
+			doc: gedcom.NewDocumentWithNodes([]gedcom.Node{
 				individual("P1", "", "", ""),
 				individual("P2", "", "", ""),
-			),
+			}),
 			expected: gedcom.SurroundingSimilarity{
 				ParentsSimilarity:    0.5,
 				IndividualSimilarity: 0.25,
@@ -1051,10 +1054,10 @@ func TestIndividualNode_SurroundingSimilarity(t *testing.T) {
 
 		// Only matching individuals, but they are exact matches.
 		{
-			doc: document(
+			doc: gedcom.NewDocumentWithNodes([]gedcom.Node{
 				individual("P1", "Elliot /Chance/", "4 Jan 1843", "17 Mar 1907"),
 				individual("P2", "Elliot /Chance/", "4 Jan 1843", "17 Mar 1907"),
-			),
+			}),
 			expected: gedcom.SurroundingSimilarity{
 				ParentsSimilarity:    0.5,
 				IndividualSimilarity: 1.0,
@@ -1065,10 +1068,10 @@ func TestIndividualNode_SurroundingSimilarity(t *testing.T) {
 
 		// Only matching individuals, but they are similar matches.
 		{
-			doc: document(
+			doc: gedcom.NewDocumentWithNodes([]gedcom.Node{
 				individual("P1", "Elliot /Chance/", "4 Jan 1843", "17 Mar 1907"),
 				individual("P2", "Elliot /Chance/", "Abt. 1843", "Abt. 1910"),
-			),
+			}),
 			expected: gedcom.SurroundingSimilarity{
 				ParentsSimilarity:    0.5,
 				IndividualSimilarity: 0.7433558199873285,
@@ -1079,10 +1082,10 @@ func TestIndividualNode_SurroundingSimilarity(t *testing.T) {
 
 		// Only matching individuals and they are way off.
 		{
-			doc: document(
+			doc: gedcom.NewDocumentWithNodes([]gedcom.Node{
 				individual("P1", "Elliot /Chance/", "4 Jan 1843", "17 Mar 1907"),
 				individual("P2", "Joe /Bloggs/", "1945", "2000"),
-			),
+			}),
 			expected: gedcom.SurroundingSimilarity{
 				ParentsSimilarity:    0.5,
 				IndividualSimilarity: 0.20128205128205132,
@@ -1093,7 +1096,7 @@ func TestIndividualNode_SurroundingSimilarity(t *testing.T) {
 
 		// Parents and individuals match exactly.
 		{
-			doc: document(
+			doc: gedcom.NewDocumentWithNodes([]gedcom.Node{
 				individual("P1", "Elliot /Chance/", "4 Jan 1843", "17 Mar 1907"),
 				individual("P2", "Elliot /Chance/", "4 Jan 1843", "17 Mar 1907"),
 				individual("P3", "John /Smith/", "4 Jan 1803", "17 Mar 1877"),
@@ -1102,7 +1105,7 @@ func TestIndividualNode_SurroundingSimilarity(t *testing.T) {
 				individual("P6", "Jane /Doe/", "3 Mar 1803", "14 June 1877"),
 				family("F1", "P3", "P4", "P1"),
 				family("F2", "P5", "P6", "P2"),
-			),
+			}),
 			expected: gedcom.SurroundingSimilarity{
 				ParentsSimilarity:    1.0,
 				IndividualSimilarity: 1.0,
@@ -1113,7 +1116,7 @@ func TestIndividualNode_SurroundingSimilarity(t *testing.T) {
 
 		// Parents and individuals are very similar.
 		{
-			doc: document(
+			doc: gedcom.NewDocumentWithNodes([]gedcom.Node{
 				individual("P1", "Elliot /Chance/", "4 Jan 1843", "17 Mar 1907"),
 				individual("P2", "Elliot /Chaunce/", "4 Jan 1843", "17 Mar 1907"),
 				individual("P3", "John /Smith/", "4 Jan 1803", "17 Mar 1877"),
@@ -1122,7 +1125,7 @@ func TestIndividualNode_SurroundingSimilarity(t *testing.T) {
 				individual("P6", "Jane /Doe/", "3 Mar 1803", "14 June 1877"),
 				family("F1", "P3", "P4", "P1"),
 				family("F2", "P5", "P6", "P2"),
-			),
+			}),
 			expected: gedcom.SurroundingSimilarity{
 				ParentsSimilarity:    0.9981481481481481,
 				IndividualSimilarity: 0.9950549450549451,
@@ -1133,7 +1136,7 @@ func TestIndividualNode_SurroundingSimilarity(t *testing.T) {
 
 		// One parent is missing, otherwise exactly the same.
 		{
-			doc: document(
+			doc: gedcom.NewDocumentWithNodes([]gedcom.Node{
 				individual("P1", "Elliot /Chance/", "4 Jan 1843", "17 Mar 1907"),
 				individual("P2", "Elliot /Chaunce/", "4 Jan 1843", "17 Mar 1907"),
 				individual("P3", "John /Smith/", "4 Jan 1803", "17 Mar 1877"),
@@ -1142,7 +1145,7 @@ func TestIndividualNode_SurroundingSimilarity(t *testing.T) {
 				individual("P6", "Jane /Doe/", "3 Mar 1803", "14 June 1877"),
 				family("F1", "P3", "", "P1"),
 				family("F2", "P5", "P6", "P2"),
-			),
+			}),
 			expected: gedcom.SurroundingSimilarity{
 				ParentsSimilarity:    0.75,
 				IndividualSimilarity: 0.9950549450549451,
@@ -1153,7 +1156,7 @@ func TestIndividualNode_SurroundingSimilarity(t *testing.T) {
 
 		// Both parents are missing on one side, otherwise exactly the same.
 		{
-			doc: document(
+			doc: gedcom.NewDocumentWithNodes([]gedcom.Node{
 				individual("P1", "Elliot /Chance/", "4 Jan 1843", "17 Mar 1907"),
 				individual("P2", "Elliot /Chaunce/", "4 Jan 1843", "17 Mar 1907"),
 				individual("P3", "John /Smith/", "4 Jan 1803", "17 Mar 1877"),
@@ -1162,7 +1165,7 @@ func TestIndividualNode_SurroundingSimilarity(t *testing.T) {
 				individual("P6", "Jane /Doe/", "3 Mar 1803", "14 June 1877"),
 				family("F1", "", "", "P1"),
 				family("F2", "P5", "P6", "P2"),
-			),
+			}),
 			expected: gedcom.SurroundingSimilarity{
 				ParentsSimilarity:    0.5,
 				IndividualSimilarity: 0.9950549450549451,
@@ -1173,7 +1176,7 @@ func TestIndividualNode_SurroundingSimilarity(t *testing.T) {
 
 		// Parents, individual and spouses match exactly.
 		{
-			doc: document(
+			doc: gedcom.NewDocumentWithNodes([]gedcom.Node{
 				individual("P1", "Elliot /Chance/", "4 Jan 1843", "17 Mar 1907"),
 				individual("P2", "Elliot /Chance/", "4 Jan 1843", "17 Mar 1907"),
 				individual("P3", "John /Smith/", "4 Jan 1803", "17 Mar 1877"),
@@ -1186,7 +1189,7 @@ func TestIndividualNode_SurroundingSimilarity(t *testing.T) {
 				family("F2", "P5", "P6", "P2"),
 				family("F3", "P1", "P7"),
 				family("F4", "P2", "P8"),
-			),
+			}),
 			expected: gedcom.SurroundingSimilarity{
 				ParentsSimilarity:    1.0,
 				IndividualSimilarity: 1.0,
@@ -1199,7 +1202,7 @@ func TestIndividualNode_SurroundingSimilarity(t *testing.T) {
 	options := gedcom.NewSimilarityOptions()
 	for _, test := range tests {
 		t.Run("", func(t *testing.T) {
-			for _, n := range test.doc.Nodes {
+			for _, n := range test.doc.Nodes() {
 				n.SetDocument(test.doc)
 			}
 
@@ -1251,43 +1254,43 @@ func family(pointer, husband, wife string, children ...string) *gedcom.FamilyNod
 	return gedcom.NewFamilyNode(nil, pointer, nodes)
 }
 
-func document(nodes ...gedcom.Node) *gedcom.Document {
-	return &gedcom.Document{
-		Nodes: nodes,
-	}
-}
-
-func TestIndividualNode_Name(t *testing.T) {
+func
+TestIndividualNode_Name(t *testing.T) {
 	Name := tf.Function(t, (*gedcom.IndividualNode).Name)
 
 	Name((*gedcom.IndividualNode)(nil)).Returns((*gedcom.NameNode)(nil))
 }
 
-func TestIndividualNode_Spouses(t *testing.T) {
+func
+TestIndividualNode_Spouses(t *testing.T) {
 	Spouses := tf.Function(t, (*gedcom.IndividualNode).Spouses)
 
 	Spouses((*gedcom.IndividualNode)(nil)).Returns((gedcom.IndividualNodes)(nil))
 }
 
-func TestIndividualNode_Families(t *testing.T) {
+func
+TestIndividualNode_Families(t *testing.T) {
 	Families := tf.Function(t, (*gedcom.IndividualNode).Families)
 
 	Families((*gedcom.IndividualNode)(nil)).Returns(([]*gedcom.FamilyNode)(nil))
 }
 
-func TestIndividualNode_FamilyWithSpouse(t *testing.T) {
+func
+TestIndividualNode_FamilyWithSpouse(t *testing.T) {
 	FamilyWithSpouse := tf.Function(t, (*gedcom.IndividualNode).FamilyWithSpouse)
 
 	FamilyWithSpouse((*gedcom.IndividualNode)(nil), (*gedcom.IndividualNode)(nil)).Returns((*gedcom.FamilyNode)(nil))
 }
 
-func TestIndividualNode_FamilyWithUnknownSpouse(t *testing.T) {
+func
+TestIndividualNode_FamilyWithUnknownSpouse(t *testing.T) {
 	FamilyWithUnknownSpouse := tf.Function(t, (*gedcom.IndividualNode).FamilyWithUnknownSpouse)
 
 	FamilyWithUnknownSpouse((*gedcom.IndividualNode)(nil)).Returns((*gedcom.FamilyNode)(nil))
 }
 
-func TestIndividualNode_IsLiving(t *testing.T) {
+func
+TestIndividualNode_IsLiving(t *testing.T) {
 	IsLiving := tf.Function(t, (*gedcom.IndividualNode).IsLiving)
 
 	IsLiving(nil).Returns(false)
@@ -1332,13 +1335,15 @@ func TestIndividualNode_IsLiving(t *testing.T) {
 	})).Returns(true)
 }
 
-func TestIndividualNode_Children(t *testing.T) {
+func
+TestIndividualNode_Children(t *testing.T) {
 	Children := tf.Function(t, (*gedcom.IndividualNode).Children)
 
 	Children((*gedcom.IndividualNode)(nil)).Returns(gedcom.IndividualNodes{})
 }
 
-func TestIndividualNode_AllEvents(t *testing.T) {
+func
+TestIndividualNode_AllEvents(t *testing.T) {
 	var tests = []struct {
 		node   *gedcom.IndividualNode
 		events []gedcom.Node

--- a/individual_nodes_test.go
+++ b/individual_nodes_test.go
@@ -350,38 +350,38 @@ func TestIndividualNodes_Compare(t *testing.T) {
 		want       []gedcom.IndividualComparison
 	}{
 		{
-			doc1: document(),
-			doc2: document(),
+			doc1: gedcom.NewDocument(),
+			doc2: gedcom.NewDocument(),
 			min:  0.0,
 			want: []gedcom.IndividualComparison{},
 		},
 		{
-			doc1: document(elliot),
-			doc2: document(),
+			doc1: gedcom.NewDocumentWithNodes([]gedcom.Node{elliot}),
+			doc2: gedcom.NewDocument(),
 			min:  0.0,
 			want: []gedcom.IndividualComparison{
 				{elliot, nil, gedcom.SurroundingSimilarity{}},
 			},
 		},
 		{
-			doc1: document(),
-			doc2: document(elliot),
+			doc1: gedcom.NewDocument(),
+			doc2: gedcom.NewDocumentWithNodes([]gedcom.Node{elliot}),
 			min:  0.0,
 			want: []gedcom.IndividualComparison{
 				{nil, elliot, gedcom.SurroundingSimilarity{}},
 			},
 		},
 		{
-			doc1: document(elliot),
-			doc2: document(elliot),
+			doc1: gedcom.NewDocumentWithNodes([]gedcom.Node{elliot}),
+			doc2: gedcom.NewDocumentWithNodes([]gedcom.Node{elliot}),
 			min:  0.0,
 			want: []gedcom.IndividualComparison{
 				{elliot, elliot, gedcom.SurroundingSimilarity{0.5, 1.0, 1.0, 1.0}},
 			},
 		},
 		{
-			doc1: document(elliot, john, jane),
-			doc2: document(jane, elliot, john),
+			doc1: gedcom.NewDocumentWithNodes([]gedcom.Node{elliot, john, jane}),
+			doc2: gedcom.NewDocumentWithNodes([]gedcom.Node{jane, elliot, john}),
 			min:  0.0,
 			want: []gedcom.IndividualComparison{
 				{elliot, elliot, gedcom.SurroundingSimilarity{0.5, 1.0, 1.0, 1.0}},
@@ -390,8 +390,8 @@ func TestIndividualNodes_Compare(t *testing.T) {
 			},
 		},
 		{
-			doc1: document(elliot, jane),
-			doc2: document(jane, john),
+			doc1: gedcom.NewDocumentWithNodes([]gedcom.Node{elliot, jane}),
+			doc2: gedcom.NewDocumentWithNodes([]gedcom.Node{jane, john}),
 			min:  0.0,
 			want: []gedcom.IndividualComparison{
 				// elliot and john match because the minimumSimilarity is so
@@ -401,8 +401,8 @@ func TestIndividualNodes_Compare(t *testing.T) {
 			},
 		},
 		{
-			doc1: document(elliot, jane),
-			doc2: document(jane, john),
+			doc1: gedcom.NewDocumentWithNodes([]gedcom.Node{elliot, jane}),
+			doc2: gedcom.NewDocumentWithNodes([]gedcom.Node{jane, john}),
 			min:  0.75,
 			want: []gedcom.IndividualComparison{
 				{jane, jane, gedcom.SurroundingSimilarity{0.5, 1.0, 1.0, 1.0}},
@@ -411,8 +411,8 @@ func TestIndividualNodes_Compare(t *testing.T) {
 			},
 		},
 		{
-			doc1: document(elliot, jane),
-			doc2: document(bob, john),
+			doc1: gedcom.NewDocumentWithNodes([]gedcom.Node{elliot, jane}),
+			doc2: gedcom.NewDocumentWithNodes([]gedcom.Node{bob, john}),
 			min:  0.9,
 			want: []gedcom.IndividualComparison{
 				{elliot, nil, gedcom.SurroundingSimilarity{}},
@@ -425,10 +425,10 @@ func TestIndividualNodes_Compare(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run("", func(t *testing.T) {
-			for _, n := range test.doc1.Nodes {
+			for _, n := range test.doc1.Nodes() {
 				n.SetDocument(test.doc1)
 			}
-			for _, n := range test.doc2.Nodes {
+			for _, n := range test.doc2.Nodes() {
 				n.SetDocument(test.doc2)
 			}
 

--- a/node.go
+++ b/node.go
@@ -73,8 +73,7 @@ func NodeGedcom(node Node) string {
 		return ""
 	}
 
-	document := NewDocument()
-	document.Nodes = []Node{node}
+	document := NewDocumentWithNodes([]Node{node})
 
 	return document.String()
 }

--- a/node_diff_test.go
+++ b/node_diff_test.go
@@ -14,7 +14,7 @@ func parse(s ...string) []gedcom.Node {
 		panic(err)
 	}
 
-	return doc.Nodes
+	return doc.Nodes()
 }
 
 func TestCompareNodes(t *testing.T) {


### PR DESCRIPTION
Document.Nodes is no longer publically accessible and added a NewDocumentWithNodes() constructor.

Instead there are new methods Nodes() and AddNode() on the Document. These are required to make sure the proper cache mechanisms now and in the future can be triggered when the document changes.

It was stated before that you should never instantiate Document manually. However, all of the tests that did this have now been updated to use one of the constructors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/gedcom/162)
<!-- Reviewable:end -->
