### PR TITLE
gedcomdiff options for minimum similarity

### DIFF
--- a/gedcomdiff/main.go
+++ b/gedcomdiff/main.go
@@ -9,16 +9,19 @@ import (
 	"github.com/elliotchance/gedcom/util"
 	"log"
 	"os"
+	"strings"
 )
 
 var (
-	optionLeftGedcomFile    string
-	optionRightGedcomFile   string
-	optionOutputFile        string
-	optionSubset            bool
-	optionGoogleAnalyticsID string
-	optionProgress          bool
-	optionJobs              int
+	optionLeftGedcomFile            string
+	optionRightGedcomFile           string
+	optionOutputFile                string
+	optionSubset                    bool
+	optionGoogleAnalyticsID         string
+	optionProgress                  bool
+	optionJobs                      int
+	optionMinimumSimilarity         float64
+	optionMinimumWeightedSimilarity float64
 )
 
 var filterFlags = &util.FilterFlags{}
@@ -46,8 +49,13 @@ func main() {
 	}
 
 	var comparisons []gedcom.IndividualComparison
+
+	similarityOptions := gedcom.NewSimilarityOptions()
+	similarityOptions.MinimumWeightedSimilarity = optionMinimumWeightedSimilarity
+	similarityOptions.MinimumSimilarity = optionMinimumSimilarity
+
 	compareOptions := &gedcom.IndividualNodesCompareOptions{
-		SimilarityOptions: gedcom.NewSimilarityOptions(),
+		SimilarityOptions: similarityOptions,
 		Notifier:          make(chan gedcom.CompareProgress),
 		NotifierStep:      100,
 		Jobs:              optionJobs,
@@ -82,19 +90,92 @@ func main() {
 
 func parseCLIFlags() {
 	// Input files. Must be provided.
-	flag.StringVar(&optionLeftGedcomFile, "left-gedcom", "", "Left GEDCOM file.")
-	flag.StringVar(&optionRightGedcomFile, "right-gedcom", "", "Right GEDCOM file.")
+	flag.StringVar(&optionLeftGedcomFile, "left-gedcom", "",
+		"Required. Left GEDCOM file.")
+
+	flag.StringVar(&optionRightGedcomFile, "right-gedcom", "",
+		"Required. Right GEDCOM file.")
+
 	flag.StringVar(&optionOutputFile, "output", "", "Output file.")
-	flag.BoolVar(&optionSubset, "subset", false, "When -subset is enabled the "+
-		"right side will be considered a smaller part of the larger left "+
-		"side. This means that individuals that entirely exist on the left "+
-		"side will not be included.")
+
+	flag.BoolVar(&optionSubset, "subset", false, CLIDescription(`When -subset is
+		enabled the right side will be considered a smaller part of the larger
+		left side. This means that individuals that entirely exist on the left
+		side will not be included.`))
+
 	flag.StringVar(&optionGoogleAnalyticsID, "google-analytics-id", "",
 		"The Google Analytics ID, like 'UA-78454410-2'.")
+
 	flag.BoolVar(&optionProgress, "progress", false, "Show progress bar.")
-	flag.IntVar(&optionJobs, "jobs", 1, "Number of jobs to run in parallel.")
+
+	flag.IntVar(&optionJobs, "jobs", 1, CLIDescription(`Number of jobs to run in
+		parallel. If you are comparing large trees this will make the process
+		faster but will consume more CPU.`))
+
+	flag.Float64Var(&optionMinimumWeightedSimilarity,
+		"minimum-weighted-similarity", gedcom.DefaultMinimumSimilarity,
+		CLIDescription(`The weighted minimum similarity is the threshold for
+			whether two individuals should be the seen as the same person when
+			the surrounding immediate family is taken into consideration.
+
+			This value must be between 0 and 1 and is the primary way to adjust
+			the sensitivity of matches. It is best to also set
+			"-minimum-similarity" to the same value.
+
+			A higher value means you will get less matches but they will be of
+			higher quality. If you are comparing trees that do not share many of
+			the same individuals you should consider raising this to prevent
+			false-positives.`))
+
+	flag.Float64Var(&optionMinimumSimilarity,
+		"minimum-similarity", gedcom.DefaultMinimumSimilarity,
+		CLIDescription(`The minimum similarity is the threshold for matching
+			individuals as the same person. This is used to compare only the
+			individual (not surrounding family) like spouses and children.
+
+			This value must be between 0 and 1 and should be set to the same
+			value as "minimum-weighted-similarity" if you are unsure.`))
 
 	filterFlags.SetupCLI()
 
 	flag.Parse()
+}
+
+func CLIDescription(s string) (r string) {
+	lines := strings.Split(s, "\n")
+
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			r += "\n\n"
+		} else {
+			r += strings.Replace(line, "\t", "", -1) + " "
+		}
+	}
+
+	return WrapToMargin(r, 80)
+}
+
+func WrapToMargin(s string, width int) (r string) {
+	lines := strings.Split(s, "\n")
+
+	for _, line := range lines {
+		words := strings.Split(line, " ")
+		newLine := ""
+
+		for _, word := range words {
+			if len(newLine)+len(word)+1 > width {
+				r += strings.TrimSpace(newLine) + "\n"
+				newLine = word
+			} else {
+				newLine += " " + word
+			}
+		}
+
+		r += strings.TrimSpace(newLine) + "\n"
+	}
+
+	// Remove last new line
+	r = r[:len(r)-1]
+
+	return
 }


### PR DESCRIPTION
The functional change of this patch is to add the "-minimum-weighted-similarity" and "-minimum-similarity" to gedcomdiff. These map directly to the comparions options of the same name.

There is also come cleanup of documentation and CLI docs on the gedcomdiff tool.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/gedcom/163)
<!-- Reviewable:end -->
