### PR TITLE
Show gedcomdiff similarities

### DIFF
--- a/gedcomdiff/individual_compare.go
+++ b/gedcomdiff/individual_compare.go
@@ -147,7 +147,20 @@ func (c *individualCompare) String() string {
 		}
 	}
 
+	leftAnchor := ""
+	rightAnchor := ""
+
+	if c.comparison.Left != nil {
+		leftAnchor = c.comparison.Left.Pointer()
+	}
+
+	if c.comparison.Right != nil {
+		rightAnchor = c.comparison.Right.Pointer()
+	}
+
 	return html.NewComponents(
+		html.NewAnchor(leftAnchor),
+		html.NewAnchor(rightAnchor),
 		html.NewBigTitle(1, name),
 		html.NewSpace(),
 		html.NewTable("", tableRows...),

--- a/gedcomdiff/main.go
+++ b/gedcomdiff/main.go
@@ -22,6 +22,7 @@ var (
 	optionJobs                      int
 	optionMinimumSimilarity         float64
 	optionMinimumWeightedSimilarity float64
+	optionSortSimilarities          bool
 )
 
 var filterFlags = &util.FilterFlags{}
@@ -137,6 +138,10 @@ func parseCLIFlags() {
 
 			This value must be between 0 and 1 and should be set to the same
 			value as "minimum-weighted-similarity" if you are unsure.`))
+
+	flag.BoolVar(&optionSortSimilarities, "sort-similarities", false,
+		CLIDescription(`Sort the individuals by similarity (highest first)
+			rather than by name.`))
 
 	filterFlags.SetupCLI()
 

--- a/html/individual_name_and_dates.go
+++ b/html/individual_name_and_dates.go
@@ -22,7 +22,7 @@ func (c *IndividualNameAndDates) String() string {
 	name := NewIndividualName(c.individual, c.showLiving, c.unknownText).String()
 	dates := NewIndividualDates(c.individual, c.showLiving).String()
 
-	if name == c.unknownText || dates == "()" {
+	if name == c.unknownText || dates == "" {
 		return name
 	}
 

--- a/html/individual_name_and_dates_link.go
+++ b/html/individual_name_and_dates_link.go
@@ -1,0 +1,31 @@
+package html
+
+import (
+	"github.com/elliotchance/gedcom"
+	"fmt"
+)
+
+type IndividualNameAndDatesLink struct {
+	individual  *gedcom.IndividualNode
+	showLiving  bool
+	unknownText string
+}
+
+func NewIndividualNameAndDatesLink(individual *gedcom.IndividualNode, showLiving bool, unknownText string) *IndividualNameAndDatesLink {
+	return &IndividualNameAndDatesLink{
+		individual:  individual,
+		showLiving:  showLiving,
+		unknownText: unknownText,
+	}
+}
+
+func (c *IndividualNameAndDatesLink) String() string {
+	if c.individual == nil {
+		return ""
+	}
+
+	text := NewIndividualNameAndDates(c.individual, c.showLiving, c.unknownText).String()
+	link := fmt.Sprintf("#%s", c.individual.Pointer())
+
+	return NewLink(text, link).Style("color: black").String()
+}

--- a/html/link.go
+++ b/html/link.go
@@ -3,8 +3,9 @@ package html
 import "fmt"
 
 type Link struct {
-	text string
-	dest string
+	text  string
+	dest  string
+	style string
 }
 
 func NewLink(text, dest string) *Link {
@@ -14,6 +15,17 @@ func NewLink(text, dest string) *Link {
 	}
 }
 
+func (c *Link) Style(style string) *Link {
+	c.style = style
+
+	return c
+}
+
 func (c *Link) String() string {
-	return fmt.Sprintf(`<a href="%s">%s</a>`, c.dest, c.text)
+	attributes := ""
+	if c.style != "" {
+		attributes += fmt.Sprintf(` style="%s"`, c.style)
+	}
+
+	return fmt.Sprintf(`<a href="%s"%s>%s</a>`, c.dest, attributes, c.text)
 }


### PR DESCRIPTION
- Added "-sort-similarities" to sort the individuals by similarity (highest first) rather than by name.
- It now shows the similarity metric for indviduals that match.
- The individiual index now has links to the individuals below.
- Fixed a minor bug where individuals with missing dates would show "()".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/gedcom/164)
<!-- Reviewable:end -->
