### PR TITLE
Changes to "-show" and "-sort" for gedcomdiff

### DIFF
--- a/html/individual_name_and_dates_link.go
+++ b/html/individual_name_and_dates_link.go
@@ -1,8 +1,8 @@
 package html
 
 import (
-	"github.com/elliotchance/gedcom"
 	"fmt"
+	"github.com/elliotchance/gedcom"
 )
 
 type IndividualNameAndDatesLink struct {


### PR DESCRIPTION
- "-subset" has been renamed to "-match subset".
- "-sort-similarity" has been renamed to "-sort highest-similarity"
- Added new option "-show only-matches" to show individuals that only match in both files.