### PR TITLE
Introducing gedcomq

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /vendor
 /gh-md-toc
 /coverage.txt
+/gedcomq/gedcomq

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ zip:
 	go build -o bin/gedcom2json ./gedcom2json
 	go build -o bin/gedcom2text ./gedcom2text
 	go build -o bin/gedcomdiff ./gedcomdiff
+	go build -o bin/gedcomq ./gedcomq
 	go build -o bin/gedcomtune ./gedcomtune
 	zip gedcom-$(GOOS)-$(GOARCH).zip -r bin
 

--- a/gedcomq/accessor.go
+++ b/gedcomq/accessor.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// Accessor is used to fetch the value of a property or to invoke a method.
+//
+// The simplest form is ".Foo" where Foo could be a property or method.
+//
+// When an accessor is used on a slice the accessor is performed on each
+// element, generating a new slice of that returned type.
+type Accessor struct {
+	Query string
+}
+
+// Evaluate  will automatically handle conversions between pointer and
+// non-pointers to find the property or method and return the value. However, if
+// it is a method it must not take any arguments.
+//
+// It will return an error if a property or method could not be found by that
+// name.
+func (e *Accessor) Evaluate(input interface{}) (interface{}, error) {
+	in := reflect.ValueOf(input)
+	accessor := e.Query[1:]
+
+	// If it is a slice we need to Evaluate each one.
+	if in.Kind() == reflect.Slice {
+		t := TypeOfSliceElement(input)
+		if t.Kind() == reflect.Ptr {
+			t = t.Elem()
+		}
+		returnType := e.getReturnType(accessor, reflect.New(t).Interface())
+
+		results := reflect.MakeSlice(reflect.SliceOf(returnType), 0, 0)
+
+		for i := 0; i < in.Len(); i++ {
+			result, err := e.Evaluate(in.Index(i).Interface())
+			if err != nil {
+				return nil, err
+			}
+
+			results = reflect.Append(results, reflect.ValueOf(result))
+		}
+
+		return results.Interface(), nil
+	}
+
+	var err error
+	input, err = e.evaluateAccessor(accessor, input)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return input, nil
+}
+
+func (e *Accessor) evaluateAccessor(accessor string, input interface{}) (r interface{}, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("cannot use .%s on %s", accessor, getType(input))
+		}
+	}()
+
+	method, field := e.getMethodOrField(accessor, input)
+
+	switch {
+	case method != nil:
+		return callMethod(*method)
+
+	case field != nil:
+		return field.Interface(), nil
+	}
+
+	return nil, fmt.Errorf(`%s does not have a method or property named "%s"`,
+		getType(input), accessor)
+}
+
+func (e *Accessor) getReturnType(accessor string, input interface{}) reflect.Type {
+	method, field := e.getMethodOrField(accessor, input)
+
+	switch {
+	case method != nil:
+		return (*method).Type().Out(0)
+
+	case field != nil:
+		return field.Type()
+	}
+
+	return nil
+}
+
+func (e *Accessor) getMethodOrField(accessor string, input interface{}) (*reflect.Value, *reflect.Value) {
+	method := e.getMethod(accessor, input)
+
+	if method != nil {
+		return method, nil
+	}
+
+	field := e.getField(accessor, input)
+
+	return nil, field
+}
+
+func (e *Accessor) getMethod(accessor string, input interface{}) *reflect.Value {
+	defer func() {
+		// The nil return value will be handled higher up.
+		recover()
+	}()
+
+	in := ValueToPointer(reflect.ValueOf(input))
+
+	s := in.String()
+	s += ""
+
+	// Try the method on the pointer.
+	methodByName := in.MethodByName(accessor)
+	if methodByName.IsValid() {
+		return &methodByName
+	}
+
+	// If that doesn't work, try calling it on the dereferenced value.
+	methodByName = in.Elem().MethodByName(accessor)
+	if methodByName.IsValid() {
+		return &methodByName
+	}
+
+	return nil
+}
+
+func (e *Accessor) getField(accessor string, input interface{}) *reflect.Value {
+	defer func() {
+		// The nil return value will be handled higher up.
+		recover()
+	}()
+
+	in := ValueToPointer(reflect.ValueOf(input))
+
+	// Try the property on the pointer.
+	fieldByName := in.Elem().FieldByName(accessor)
+	if fieldByName.IsValid() {
+		return &fieldByName
+	}
+
+	// Try the property on the struct.
+	if in.Kind() == reflect.Struct {
+		fieldByName = in.FieldByName(accessor)
+		if fieldByName.IsValid() {
+			return &fieldByName
+		}
+	}
+
+	return nil
+}
+
+func callMethod(methodByName reflect.Value) (interface{}, error) {
+	result := methodByName.Call([]reflect.Value{})
+
+	return result[0].Interface(), nil
+}

--- a/gedcomq/accessor_test.go
+++ b/gedcomq/accessor_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"github.com/elliotchance/tf"
+	"testing"
+)
+
+type MyStruct struct {
+	Property int
+}
+
+func (ms *MyStruct) Foo() string {
+	return "bar"
+}
+
+func (ms MyStruct) Baz() []string {
+	return []string{"qux", "quux"}
+}
+
+func TestAccessor_Evaluate(t *testing.T) {
+	Evaluate := tf.NamedFunction(t, "Accessor_Evaluate", (*Accessor).Evaluate)
+
+	ms1 := &MyStruct{Property: 123}
+	ms2 := MyStruct{Property: 456}
+
+	Evaluate(&Accessor{Query: ".Foo"}, ms1).Returns("bar", nil)
+	Evaluate(&Accessor{Query: ".Foo"}, ms2).Returns("bar", nil)
+
+	Evaluate(&Accessor{Query: ".Baz"}, ms1).Returns([]string{"qux", "quux"}, nil)
+	Evaluate(&Accessor{Query: ".Baz"}, ms2).Returns([]string{"qux", "quux"}, nil)
+
+	Evaluate(&Accessor{Query: ".Property"}, ms1).Returns(123, nil)
+	Evaluate(&Accessor{Query: ".Property"}, ms2).Returns(456, nil)
+
+	Evaluate(&Accessor{Query: ".Missing"}, ms1).
+		Errors(`MyStruct does not have a method or property named "Missing"`)
+	Evaluate(&Accessor{Query: ".Missing"}, ms2).
+		Errors(`MyStruct does not have a method or property named "Missing"`)
+}

--- a/gedcomq/doc.go
+++ b/gedcomq/doc.go
@@ -1,0 +1,114 @@
+// Package gedcomq is a command line tool and query language for GEDCOM files.
+// It is heavily inspired by jq, in name and syntax.
+//
+// The basic syntax of the tool is:
+//
+//   gedcomq -gedcom file.ged '.Individuals | .Name'
+//
+// Language Basics
+//
+// The query is split into expressions. The pipe (|) indicates that the result
+// of one expression is the input into the next expression.
+//
+// The starting expression is the gedcom.Document itself that is passed into the
+// first expression (".Individuals" in the example above).
+//
+// ".Individuals" is called an "accessor", denoted by the "." prefix. An
+// accessor will try to find a property or method of that name, returning the
+// value of the property or the result of invoking the method. The above example
+// would return a slice ([]*IndividualNode).
+//
+// The next expression, ".Name" receives that slice. Since it is a slice the
+// ".Name" accessor is performed on each of the individual slice members,
+// creating a new slice with the results. In this case IndividualNode has a
+// method called Name that returns a *NameNode. That means that result of the
+// processing the slice will be []*NameNode.
+//
+// After all of the expressions have been evaluated the result is encoded into
+// JSON and output.
+//
+// It's important to note that some structures implement the json.Marshaller
+// interface which controls how the structure is represented in JSON. Many
+// structures also implement fmt.Stringer (the String method) which can be
+// helpful for seeing more simple representations of values.
+//
+// With the example ".Individuals | .Name" on a document that contains two
+// individuals:
+//
+//   [
+//     {
+//       "Nodes": [
+//         {
+//           "Tag": "GIVN",
+//           "Value": "Lucy Alcott"
+//         },
+//         {
+//           "Tag": "SURN",
+//           "Value": "Chauncey"
+//         }
+//       ],
+//       "Tag": "NAME",
+//       "Value": "Lucy Alcott /Chauncey/"
+//     },
+//     {
+//       "Nodes": [
+//         {
+//           "Tag": "GIVN",
+//           "Value": "Sarah"
+//         },
+//         {
+//           "Tag": "SURN",
+//           "Value": "Taylor"
+//         }
+//       ],
+//       "Tag": "NAME",
+//       "Value": "Sarah /Taylor/"
+//     }
+//   ]
+//
+// If this is too verbose for you, here is the same output using
+// ".Individuals | .Name | .String":
+//
+//   [
+//     "Lucy Alcott Chauncey",
+//     "Sarah Taylor"
+//   ]
+//
+// Functions
+//
+// Some functions are provided as part of the gedcomq language that exist
+// outside of the gedcom package:
+//
+// Length -- Returns an integer with the number of items in the slice. This
+// value will be 0 or more. If the input is not a slice then 1 will always be
+// returned.
+//
+// Here is an example of counting all individuals in a document:
+//
+//   .Individuals | Length
+//
+// The Question Mark
+//
+// "?" is a special function that can be used to show all of the possible next
+// functions and accessors. This is useful when exploring data by creating the
+// query interactively.
+//
+// For example the following query:
+//
+//   .Individuals | ?
+//
+// Returns (most items removed for brevity):
+//
+//   [
+//     ".AddNode",
+//     ".Age",
+//     ".AgeAt",
+//     ...
+//     ".SurroundingSimilarity",
+//     ".Tag",
+//     ".Value",
+//     "?",
+//     "Length"
+//   ]
+//
+package main

--- a/gedcomq/engine.go
+++ b/gedcomq/engine.go
@@ -1,0 +1,27 @@
+package main
+
+import "github.com/elliotchance/gedcom"
+
+// Engine is the compiled query. It is able to evaluate the entire query.
+type Engine struct {
+	// Expressions are separated by pipes. The result of each evaluated
+	// expressions is used as the input to the next expressions. The input value
+	// for the first expression is the gedcom.Document.
+	Expressions []Expression
+}
+
+// Evaluate executes all of the expressions and returns the final result.
+func (e *Engine) Evaluate(document *gedcom.Document) (interface{}, error) {
+	var result interface{} = document
+	var err error
+
+	for _, expression := range e.Expressions {
+		result, err = expression.Evaluate(result)
+
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return result, nil
+}

--- a/gedcomq/engine_test.go
+++ b/gedcomq/engine_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/elliotchance/gedcom"
+	"github.com/elliotchance/tf"
+)
+
+func TestEngine_Start(t *testing.T) {
+	Start := tf.Function(t, (*Engine).Evaluate)
+
+	parser := NewParser()
+	emptyEngine := parser.ParseString("")
+	individualsEngine := parser.ParseString(".Individuals")
+	individualNameEngine := parser.ParseString(".Individuals | .Name")
+	individualNameStringEngine := parser.ParseString(".Individuals | .Name | .String")
+
+	document := gedcom.NewDocumentWithNodes([]gedcom.Node{
+		gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
+			gedcom.NewNameNode(nil, "Elliot /Chance/", "", nil),
+		}),
+		gedcom.NewIndividualNode(nil, "", "P2", []gedcom.Node{
+			gedcom.NewNameNode(nil, "Dina /Wyche/", "", nil),
+		}),
+	})
+
+	Start(emptyEngine, document).Returns(document, nil)
+
+	Start(individualsEngine, document).Returns(gedcom.IndividualNodes{
+		gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
+			gedcom.NewNameNode(nil, "Elliot /Chance/", "", nil),
+		}),
+		gedcom.NewIndividualNode(nil, "", "P2", []gedcom.Node{
+			gedcom.NewNameNode(nil, "Dina /Wyche/", "", nil),
+		}),
+	}, nil)
+
+	Start(individualNameEngine, document).Returns([]*gedcom.NameNode{
+		gedcom.NewNameNode(nil, "Elliot /Chance/", "", nil),
+		gedcom.NewNameNode(nil, "Dina /Wyche/", "", nil),
+	}, nil)
+
+	Start(individualNameStringEngine, document).Returns([]string{
+		"Elliot Chance",
+		"Dina Wyche",
+	}, nil)
+}

--- a/gedcomq/expression.go
+++ b/gedcomq/expression.go
@@ -1,0 +1,10 @@
+package main
+
+// Expression is a single operation. Expressions can be chained together with a
+// pipe (|) in the query.
+type Expression interface {
+	// Evaluate should only be run once and is likely to alter the value of
+	// input. This means expressions can only be safely run once and previous
+	// input values cannot be reused.
+	Evaluate(input interface{}) (interface{}, error)
+}

--- a/gedcomq/functions.go
+++ b/gedcomq/functions.go
@@ -1,0 +1,9 @@
+package main
+
+// Functions is a map of available functions.
+//
+// See "Functions" in the package documentation for usage and examples.
+var Functions = map[string]Expression{
+	"?":      &QuestionMark{},
+	"Length": &Length{},
+}

--- a/gedcomq/length.go
+++ b/gedcomq/length.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"reflect"
+)
+
+// Length is a function. See Evaluate.
+type Length struct{}
+
+// Evaluate returns an integer with the number of items in the slice. This value
+// will be 0 or more. If the input is not a slice then 1 will always be
+// returned.
+func (e *Length) Evaluate(input interface{}) (interface{}, error) {
+	in := reflect.ValueOf(input)
+
+	if in.Kind() == reflect.Slice {
+		return in.Len(), nil
+	}
+
+	return 1, nil
+}

--- a/gedcomq/length_test.go
+++ b/gedcomq/length_test.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"github.com/elliotchance/tf"
+	"testing"
+)
+
+func TestLength_Evaluate(t *testing.T) {
+	Evaluate := tf.Function(t, (*Length).Evaluate)
+
+	Evaluate(&Length{}, nil).Returns(1, nil)
+	Evaluate(&Length{}, []int{1, 2, 3}).Returns(3, nil)
+	Evaluate(&Length{}, "foo bar").Returns(1, nil)
+}

--- a/gedcomq/main.go
+++ b/gedcomq/main.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"github.com/elliotchance/gedcom"
+	"log"
+)
+
+var (
+	optionGedcomFile string
+)
+
+func main() {
+	parseCLIFlags()
+
+	parser := NewParser()
+	engine := parser.ParseString(flag.Arg(0))
+
+	doc, err := gedcom.NewDocumentFromGEDCOMFile(optionGedcomFile)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	result, err := engine.Evaluate(doc)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println(string(data))
+}
+
+func parseCLIFlags() {
+	flag.StringVar(&optionGedcomFile, "gedcom", "", "GEDCOM file.")
+
+	flag.Parse()
+}

--- a/gedcomq/parser.go
+++ b/gedcomq/parser.go
@@ -1,0 +1,40 @@
+package main
+
+import "strings"
+
+// Parser converts the query string into an Engine that can be evaluated.
+type Parser struct{}
+
+// NewParser creates a new parser.
+func NewParser() *Parser {
+	return &Parser{}
+}
+
+// ParseString returns a new Engine by parsing the query string.
+func (p *Parser) ParseString(q string) *Engine {
+	engine := &Engine{}
+
+	if q == "" {
+		return engine
+	}
+
+	for _, e := range strings.Split(q, "|") {
+		expression := getExpression(e)
+
+		engine.Expressions = append(engine.Expressions, expression)
+	}
+
+	return engine
+}
+
+func getExpression(e string) Expression {
+	q := strings.TrimSpace(e)
+
+	if q[0] == '.' {
+		return &Accessor{
+			Query: q,
+		}
+	}
+
+	return Functions[q]
+}

--- a/gedcomq/parser_test.go
+++ b/gedcomq/parser_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/elliotchance/tf"
+)
+
+func TestNewParser(t *testing.T) {
+	NewParser := tf.Function(t, NewParser)
+
+	NewParser().Returns(&Parser{})
+}
+
+func TestParser_ParseString(t *testing.T) {
+	ParseString := tf.Function(t, (*Parser).ParseString)
+	parser := NewParser()
+
+	ParseString(parser, "").Returns(&Engine{})
+
+	ParseString(parser, ".Individuals").Returns(&Engine{
+		Expressions: []Expression{
+			&Accessor{Query: ".Individuals"},
+		},
+	})
+
+	ParseString(parser, ".Individuals | .Name").Returns(&Engine{
+		Expressions: []Expression{
+			&Accessor{Query: ".Individuals"},
+			&Accessor{Query: ".Name"},
+		},
+	})
+}

--- a/gedcomq/question_mark.go
+++ b/gedcomq/question_mark.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"reflect"
+	"sort"
+)
+
+// QuestionMark ("?") is a special function. See Evaluate.
+type QuestionMark struct{}
+
+// "?" is a special function that can be used to show all of the possible next
+// functions and accessors. This is useful when exploring data by creating the
+// query interactively.
+//
+// For example the following query:
+//
+//   .Individuals | ?
+//
+// Returns (most items removed for brevity):
+//
+//   [
+//     ".AddNode",
+//     ".Age",
+//     ".AgeAt",
+//     ...
+//     ".SurroundingSimilarity",
+//     ".Tag",
+//     ".Value",
+//     "?",
+//     "Length"
+//   ]
+//
+func (e *QuestionMark) Evaluate(input interface{}) (interface{}, error) {
+	in := reflect.TypeOf(input)
+
+	if in.Kind() == reflect.Slice {
+		return e.Evaluate(reflect.Zero(TypeOfSliceElement(input)).Interface())
+	}
+
+	if in.Kind() != reflect.Ptr {
+		in = reflect.New(in).Type()
+	}
+
+	options := []string{}
+	for i := 0; i < in.NumMethod(); i++ {
+		methodName := "." + in.Method(i).Name
+		options = append(options, methodName)
+	}
+
+	for function := range Functions {
+		options = append(options, function)
+	}
+
+	sort.Strings(options)
+
+	return options, nil
+}

--- a/gedcomq/question_mark_test.go
+++ b/gedcomq/question_mark_test.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"github.com/elliotchance/tf"
+	"testing"
+)
+
+func TestQuestionMark_Evaluate(t *testing.T) {
+	Evaluate := tf.NamedFunction(t, "QuestionMark_Evaluate", (*QuestionMark).Evaluate)
+
+	expected := []string{".Baz", ".Foo", "?", "Length"}
+
+	Evaluate(&QuestionMark{}, &MyStruct{}).Returns(expected, nil)
+	Evaluate(&QuestionMark{}, MyStruct{}).Returns(expected, nil)
+	Evaluate(&QuestionMark{}, []*MyStruct{{}, {}}).Returns(expected, nil)
+	Evaluate(&QuestionMark{}, []*MyStruct{}).Returns(expected, nil)
+}

--- a/gedcomq/util.go
+++ b/gedcomq/util.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"reflect"
+)
+
+func getType(v interface{}) string {
+	t := reflect.TypeOf(v)
+
+	if t.Kind() == reflect.Ptr {
+		return t.Elem().Name()
+	}
+
+	return t.Name()
+}
+
+// TypeOfSliceElement returns the type of element from a slice. The input should
+// not be a reflect.Value, but an actual value.
+//
+// If v is not a slice then nil is returned.
+func TypeOfSliceElement(v interface{}) reflect.Type {
+	vType := reflect.TypeOf(v)
+
+	if vType.Kind() != reflect.Slice {
+		return nil
+	}
+
+	e := vType.Elem()
+	if e.String() == "interface {}" {
+		return nil
+	}
+
+	return e
+}
+
+// ValueToPointer converts a value to a pointer. If the value is already a
+// pointer then it is passed through.
+func ValueToPointer(v reflect.Value) reflect.Value {
+	if v.Kind() != reflect.Ptr {
+		vp := reflect.New(v.Type())
+		vp.Elem().Set(v)
+
+		return vp
+	}
+
+	return v
+}

--- a/gedcomq/util_test.go
+++ b/gedcomq/util_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"github.com/elliotchance/gedcom"
+	"github.com/elliotchance/tf"
+	"github.com/stretchr/testify/assert"
+	"reflect"
+	"testing"
+)
+
+func TestTypeOfSliceElement(t *testing.T) {
+	TypeOfSliceElement := tf.Function(t, TypeOfSliceElement)
+
+	TypeOfSliceElement([]string{"foo", "bar"}).Returns(reflect.TypeOf(""))
+	TypeOfSliceElement([]int{1, 2, 3}).Returns(reflect.TypeOf(0))
+	TypeOfSliceElement([]int{}).Returns(reflect.TypeOf(0))
+	TypeOfSliceElement([]interface{}{12.3, "bar"}).Returns(reflect.TypeOf(nil))
+	TypeOfSliceElement(123).Returns(nil)
+	TypeOfSliceElement(gedcom.IndividualNode{}).Returns(nil)
+	TypeOfSliceElement(&gedcom.IndividualNode{}).Returns(nil)
+	TypeOfSliceElement(gedcom.IndividualNodes{}).Returns(reflect.TypeOf(&gedcom.IndividualNode{}))
+}
+
+func TestValueToPointer(t *testing.T) {
+	actual := ValueToPointer(reflect.ValueOf(3.5))
+	assert.Equal(t, *actual.Interface().(*float64), 3.5)
+
+	actual = ValueToPointer(reflect.ValueOf(123))
+	assert.Equal(t, *actual.Interface().(*int), 123)
+
+	a := "foo"
+	actual = ValueToPointer(reflect.ValueOf(&a))
+	assert.Equal(t, *actual.Interface().(*string), "foo")
+}

--- a/simple_node.go
+++ b/simple_node.go
@@ -1,5 +1,7 @@
 package gedcom
 
+import "encoding/json"
+
 // SimpleNode is used as the default node type when there is no more appropriate
 // or specific type to use.
 type SimpleNode struct {
@@ -124,4 +126,24 @@ func (node *SimpleNode) String() string {
 	}
 
 	return node.value
+}
+
+func (node *SimpleNode) MarshalJSON() ([]byte, error) {
+	m := map[string]interface{}{
+		"Tag": node.Tag().Tag(),
+	}
+
+	if node.Value() != "" {
+		m["Value"] = node.Value()
+	}
+
+	if node.Pointer() != "" {
+		m["Pointer"] = node.Pointer()
+	}
+
+	if len(node.Nodes()) > 0 {
+		m["Nodes"] = node.Nodes()
+	}
+
+	return json.Marshal(m)
 }


### PR DESCRIPTION
Package gedcomq is a command line tool and query language for GEDCOM files. It is heavily inspired by jq, in name and syntax. The basic syntax of the tool is:

    gedcomq -gedcom file.ged '.Individuals | .Name'

The functions are automatically discovered through the gedom package.

This initial version is quite rudimentary and does not handle errors gracefully. However, it does demonstrate what the most basic queries look like.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/gedcom/170)
<!-- Reviewable:end -->
