### PR TITLE
Added binary operators to gedcomq

### DIFF
--- a/q/accessor_expr.go
+++ b/q/accessor_expr.go
@@ -21,7 +21,7 @@ type AccessorExpr struct {
 //
 // It will return an error if a property or method could not be found by that
 // name.
-func (e *AccessorExpr) Evaluate(engine *Engine, input interface{}, args []interface{}) (interface{}, error) {
+func (e *AccessorExpr) Evaluate(engine *Engine, input interface{}, args []*Statement) (interface{}, error) {
 	in := reflect.ValueOf(input)
 	accessor := e.Query[1:]
 

--- a/q/binary_expr.go
+++ b/q/binary_expr.go
@@ -1,0 +1,190 @@
+package q
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+)
+
+// BinaryExpr evaluates a binary operator expression.
+type BinaryExpr struct {
+	Left, Right Expression
+	Operator    string
+}
+
+// Operators contains the tokens and functions for all operators.
+//
+// It is important that the operators are ordered so that the operators with
+// most tokens are read first. This prevents it from consuming operators that
+// are subsets of others.
+var Operators = []struct {
+	Name     string
+	Tokens   []TokenKind
+	Function func(left, right interface{}) (bool, error)
+}{
+	{"!=", []TokenKind{TokenNot, TokenEqual}, notEqual},
+	{">=", []TokenKind{TokenGreaterThan, TokenEqual}, greaterThanEqual},
+	{"<=", []TokenKind{TokenLessThan, TokenEqual}, lessThanEqual},
+	{"=", []TokenKind{TokenEqual}, equal},
+	{">", []TokenKind{TokenGreaterThan}, greaterThan},
+	{"<", []TokenKind{TokenLessThan}, lessThan},
+}
+
+func (e *BinaryExpr) Evaluate(engine *Engine, input interface{}, args []*Statement) (interface{}, error) {
+	in := reflect.ValueOf(input)
+
+	// If it is a slice we need to Evaluate each one.
+	if in.Kind() == reflect.Slice {
+		results := reflect.MakeSlice(reflect.SliceOf(reflect.TypeOf(true)), 0, in.Len())
+
+		for i := 0; i < in.Len(); i++ {
+			result, err := e.Evaluate(engine, in.Index(i).Interface(), args)
+			if err != nil {
+				return nil, err
+			}
+
+			results = reflect.Append(results, reflect.ValueOf(result))
+		}
+
+		return results.Interface(), nil
+	}
+
+	left, err := e.Left.Evaluate(engine, input, args)
+	if err != nil {
+		return nil, err
+	}
+
+	right, err := e.Right.Evaluate(engine, input, args)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, operator := range Operators {
+		if operator.Name == e.Operator {
+			return operator.Function(left, right)
+		}
+	}
+
+	return nil, fmt.Errorf("no such operator: %s", e.Operator)
+}
+
+func binaryFloats(left, right string) (float64, float64, bool) {
+	floatLeft, errLeft := strconv.ParseFloat(left, 64)
+	floatRight, errRight := strconv.ParseFloat(right, 64)
+
+	// Compare as numbers.
+	if errLeft == nil && errRight == nil {
+		return floatLeft, floatRight, true
+	}
+
+	return 0, 0, false
+}
+
+func binaryStrings(left, right interface{}) (sLeft string, sRight string) {
+	if s, ok := left.(string); ok {
+		sLeft = s
+	} else {
+		sLeft = fmt.Sprintf("%v", left)
+	}
+
+	if s, ok := right.(string); ok {
+		sRight = s
+	} else {
+		sRight = fmt.Sprintf("%v", right)
+	}
+
+	return
+}
+
+func compareStrings(s, t string, op func(string, string) bool) bool {
+	// This is not the most ideal way to do comparisons because it doesn't
+	// handle more complex characters as nicely as strings.EqualFold.
+
+	s = strings.TrimSpace(strings.ToLower(s))
+	t = strings.TrimSpace(strings.ToLower(t))
+
+	return op(s, t)
+}
+
+func equal(left, right interface{}) (bool, error) {
+	sLeft, sRight := binaryStrings(left, right)
+
+	// Compare as numbers.
+	if floatLeft, floatRight, ok := binaryFloats(sLeft, sRight); ok {
+		return floatLeft == floatRight, nil
+	}
+
+	compare := func(s, t string) bool {
+		return s == t
+	}
+
+	// At least one side could not be converted to a float, so compare them as
+	// strings.
+	return compareStrings(sLeft, sRight, compare), nil
+}
+
+func notEqual(left, right interface{}) (bool, error) {
+	result, err := equal(left, right)
+	if err != nil {
+		return false, err
+	}
+
+	return !result, nil
+}
+
+func greaterThan(left, right interface{}) (bool, error) {
+	sLeft, sRight := binaryStrings(left, right)
+
+	if floatLeft, floatRight, ok := binaryFloats(sLeft, sRight); ok {
+		return floatLeft > floatRight, nil
+	}
+
+	compare := func(s, t string) bool {
+		return s > t
+	}
+
+	return compareStrings(sLeft, sRight, compare), nil
+}
+
+func greaterThanEqual(left, right interface{}) (bool, error) {
+	sLeft, sRight := binaryStrings(left, right)
+
+	if floatLeft, floatRight, ok := binaryFloats(sLeft, sRight); ok {
+		return floatLeft >= floatRight, nil
+	}
+
+	compare := func(s, t string) bool {
+		return s >= t
+	}
+
+	return compareStrings(sLeft, sRight, compare), nil
+}
+
+func lessThan(left, right interface{}) (bool, error) {
+	sLeft, sRight := binaryStrings(left, right)
+
+	if floatLeft, floatRight, ok := binaryFloats(sLeft, sRight); ok {
+		return floatLeft < floatRight, nil
+	}
+
+	compare := func(s, t string) bool {
+		return s < t
+	}
+
+	return compareStrings(sLeft, sRight, compare), nil
+}
+
+func lessThanEqual(left, right interface{}) (bool, error) {
+	sLeft, sRight := binaryStrings(left, right)
+
+	if floatLeft, floatRight, ok := binaryFloats(sLeft, sRight); ok {
+		return floatLeft <= floatRight, nil
+	}
+
+	compare := func(s, t string) bool {
+		return s <= t
+	}
+
+	return compareStrings(sLeft, sRight, compare), nil
+}

--- a/q/binary_expr_test.go
+++ b/q/binary_expr_test.go
@@ -1,0 +1,84 @@
+package q_test
+
+import (
+	"github.com/elliotchance/gedcom/q"
+	"github.com/elliotchance/tf"
+	"testing"
+)
+
+func TestBinaryExpr_Evaluate(t *testing.T) {
+	Evaluate := tf.NamedFunction(t, "BinaryExpr_Evaluate", (*q.BinaryExpr).Evaluate)
+	engine := &q.Engine{}
+
+	for _, test := range []struct {
+		left     q.Expression
+		op       string
+		right    q.Expression
+		expected bool
+	}{
+		{&q.ConstantExpr{"0"}, "=", &q.ConstantExpr{""}, false},
+		{&q.ConstantExpr{"1.50"}, "=", &q.ConstantExpr{"1.5"}, true},
+		{&q.ConstantExpr{"1.6"}, "=", &q.ConstantExpr{"1.601"}, false},
+		{&q.ConstantExpr{"foo"}, "=", &q.ConstantExpr{"foo"}, true},
+		{&q.ConstantExpr{"foo"}, "=", &q.ConstantExpr{"Foo"}, true},
+		{&q.ConstantExpr{"\nfoo "}, "=", &q.ConstantExpr{" Foo\t"}, true},
+		{&q.ConstantExpr{"foo"}, "=", &q.ConstantExpr{"bar"}, false},
+
+		{&q.ConstantExpr{"0"}, "!=", &q.ConstantExpr{""}, true},
+		{&q.ConstantExpr{"1.50"}, "!=", &q.ConstantExpr{"1.5"}, false},
+		{&q.ConstantExpr{"1.6"}, "!=", &q.ConstantExpr{"1.601"}, true},
+		{&q.ConstantExpr{"foo"}, "!=", &q.ConstantExpr{"foo"}, false},
+		{&q.ConstantExpr{"foo"}, "!=", &q.ConstantExpr{"Foo"}, false},
+		{&q.ConstantExpr{"\nfoo "}, "!=", &q.ConstantExpr{" Foo\t"}, false},
+		{&q.ConstantExpr{"foo"}, "!=", &q.ConstantExpr{"bar"}, true},
+
+		{&q.ConstantExpr{"0"}, ">", &q.ConstantExpr{""}, true},
+		{&q.ConstantExpr{"1.50"}, ">", &q.ConstantExpr{"1.5"}, false},
+		{&q.ConstantExpr{"1.6"}, ">", &q.ConstantExpr{"1.601"}, false},
+		{&q.ConstantExpr{"foo"}, ">", &q.ConstantExpr{"foo"}, false},
+		{&q.ConstantExpr{"foo"}, ">", &q.ConstantExpr{"Foo"}, false},
+		{&q.ConstantExpr{"\nfoo "}, ">", &q.ConstantExpr{" Foo\t"}, false},
+		{&q.ConstantExpr{"foo"}, ">", &q.ConstantExpr{"bar"}, true},
+
+		{&q.ConstantExpr{"0"}, ">=", &q.ConstantExpr{""}, true},
+		{&q.ConstantExpr{"1.50"}, ">=", &q.ConstantExpr{"1.5"}, true},
+		{&q.ConstantExpr{"1.6"}, ">=", &q.ConstantExpr{"1.601"}, false},
+		{&q.ConstantExpr{"foo"}, ">=", &q.ConstantExpr{"foo"}, true},
+		{&q.ConstantExpr{"foo"}, ">=", &q.ConstantExpr{"Foo"}, true},
+		{&q.ConstantExpr{"\nfoo "}, ">=", &q.ConstantExpr{" Foo\t"}, true},
+		{&q.ConstantExpr{"foo"}, ">=", &q.ConstantExpr{"bar"}, true},
+
+		{&q.ConstantExpr{"0"}, "<", &q.ConstantExpr{""}, false},
+		{&q.ConstantExpr{"1.50"}, "<", &q.ConstantExpr{"1.5"}, false},
+		{&q.ConstantExpr{"1.6"}, "<", &q.ConstantExpr{"1.601"}, true},
+		{&q.ConstantExpr{"foo"}, "<", &q.ConstantExpr{"foo"}, false},
+		{&q.ConstantExpr{"foo"}, "<", &q.ConstantExpr{"Foo"}, false},
+		{&q.ConstantExpr{"\nfoo "}, "<", &q.ConstantExpr{" Foo\t"}, false},
+		{&q.ConstantExpr{"foo"}, "<", &q.ConstantExpr{"bar"}, false},
+
+		{&q.ConstantExpr{"0"}, "<=", &q.ConstantExpr{""}, false},
+		{&q.ConstantExpr{"1.50"}, "<=", &q.ConstantExpr{"1.5"}, true},
+		{&q.ConstantExpr{"1.6"}, "<=", &q.ConstantExpr{"1.601"}, true},
+		{&q.ConstantExpr{"foo"}, "<=", &q.ConstantExpr{"foo"}, true},
+		{&q.ConstantExpr{"foo"}, "<=", &q.ConstantExpr{"Foo"}, true},
+		{&q.ConstantExpr{"\nfoo "}, "<=", &q.ConstantExpr{" Foo\t"}, true},
+		{&q.ConstantExpr{"foo"}, "<=", &q.ConstantExpr{"bar"}, false},
+
+		// TODO: Some ideas?
+		//
+		// >> ends with
+		// !>>
+		// << starts with
+		// !<<
+		// >< contains
+		// !><
+		// ~ match regexp
+		// !~
+	} {
+		Evaluate(&q.BinaryExpr{
+			Left:     test.left,
+			Operator: test.op,
+			Right:    test.right,
+		}, engine, nil, nil).Returns(test.expected, nil)
+	}
+}

--- a/q/call_expr.go
+++ b/q/call_expr.go
@@ -3,9 +3,9 @@ package q
 // CallExpr calls a function.
 type CallExpr struct {
 	Function Expression
-	Args     []interface{}
+	Args     []*Statement
 }
 
-func (e *CallExpr) Evaluate(engine *Engine, input interface{}, args []interface{}) (interface{}, error) {
+func (e *CallExpr) Evaluate(engine *Engine, input interface{}, args []*Statement) (interface{}, error) {
 	return e.Function.Evaluate(engine, input, e.Args)
 }

--- a/q/call_expr_test.go
+++ b/q/call_expr_test.go
@@ -10,6 +10,8 @@ func TestCallExpr_Evaluate(t *testing.T) {
 	Evaluate := tf.NamedFunction(t, "CallExpr_Evaluate", (*q.CallExpr).Evaluate)
 	engine := &q.Engine{}
 
-	Evaluate(&q.CallExpr{&q.LengthExpr{}, []interface{}{123}}, engine, []int{1, 2, 3}, nil).
+	args := []*q.Statement{{Expressions: []q.Expression{&q.ConstantExpr{Value: "123"}}}}
+
+	Evaluate(&q.CallExpr{&q.LengthExpr{}, args}, engine, []int{1, 2, 3}, nil).
 		Returns(3, nil)
 }

--- a/q/constant_expr.go
+++ b/q/constant_expr.go
@@ -1,0 +1,10 @@
+package q
+
+// ConstantExpr represents a floating-point number or string.
+type ConstantExpr struct {
+	Value string
+}
+
+func (e *ConstantExpr) Evaluate(engine *Engine, input interface{}, args []*Statement) (interface{}, error) {
+	return e.Value, nil
+}

--- a/q/constant_expr_test.go
+++ b/q/constant_expr_test.go
@@ -1,0 +1,16 @@
+package q_test
+
+import (
+	"github.com/elliotchance/gedcom/q"
+	"github.com/elliotchance/tf"
+	"testing"
+)
+
+func TestConstantExpr_Evaluate(t *testing.T) {
+	Evaluate := tf.NamedFunction(t, "ConstantExpr_Evaluate", (*q.ConstantExpr).Evaluate)
+	engine := &q.Engine{}
+
+	Evaluate(&q.ConstantExpr{Value: "0"}, engine, nil, nil).Returns("0", nil)
+	Evaluate(&q.ConstantExpr{Value: "12.3"}, engine, nil, nil).Returns("12.3", nil)
+	Evaluate(&q.ConstantExpr{Value: "foo bar"}, engine, nil, nil).Returns("foo bar", nil)
+}

--- a/q/doc.go
+++ b/q/doc.go
@@ -105,6 +105,13 @@
 // This value will be 0 or more. If the input is not a slice then 1 will always
 // be returned.
 //
+//   Only(condition)
+//
+// The Only function returns a new slice that only contains the entities that
+// have returned true from the condition. For example:
+//
+//   .Individuals | Only(.Age > 100)
+//
 // The Question Mark
 //
 // "?" is a special function that can be used to show all of the possible next
@@ -162,7 +169,73 @@
 // Available variables will be shown as options with the special Question Mark
 // function.
 //
-// Objects
+// Data Types
+//
+// gedcomq does not define strict data types. Instead it will perform an
+// operation as best it can under the conditions provided.
+//
+// To help simplify things here are general descriptions of how certain data
+// types are handled:
+//
+// - Numbers can be actual whole of floating-point numbers, or they can also be
+// represented as a string. For example 1.23 and "1.230" are considered equal
+// because they both represent the same numerical value, even though they are in
+// different forms.
+//
+// - Strings are text of any length (including zero characters). If it's value
+// represents a number, such as "123" or "4.56" it will change the behaviour of
+// the operator used on it because they will be treated as numbers rather than
+// text. It's also very important to note that strings are compared internally
+// without case-sensitivity and whitespace that exists at the start or end of
+// the string will be ignore. For example "John Smith" is considered to be equal
+// to "  john SMITH ".
+//
+// - Slices are an ordered set of items, often also called an "array". The name
+// was chosen as "slice" rather than "array" because it is more inline with the
+// description of types in Go. A slice may contain zero elements but if it does
+// have items they will almost certainly be of the same type. Such as a slice of
+// individuals.
+//
+// - Objects (sometimes referred to as a "map" or "dictionary") consists as a
+// zero or more key-value pairs. The values may be of any type, but the keys are
+// always strings and always unique in that object. Objects may be generic, or
+// they may be a specific type from the gedcom package. If they are a specific
+// type, such as an IndividualNode they may also have methods available which
+// can be accessed just like properties.
+//
+// Operators
+//
+// gedcomq supports several binary operators that can be used for comparison of
+// values. All operators will return a boolean (true/false) result:
+//
+//   =  (equal)
+//   != (not equal)
+//
+// If the left and right both represent numeric values then the values are
+// compared numerically. That is to say 1.23 and "1.2300" are equal.
+//
+// If either the left or right is not a number then the values are compared
+// without case and any whitespace at the start or end is ignore. This means
+// that "John Smith" is considered to be equal to "  john SMITH ", but not equal
+// to "John  Smith".
+//
+// Not equal works exactly opposite.
+//
+//   >  (greater than)
+//   >= (greater than or equal)
+//   <  (less than)
+//   >= (less than or equal)
+//
+// If the left and right both represent numeric values then the values are
+// compared numerically. That is to say 1.2301 is greater than "1.23".
+//
+// If the left or right does not represent a numeric value then the values are
+// compared as strings using the same case-insensitive rules as "=".
+//
+// One string is greater than another string by comparing each of the
+// characters. So "Jon" is greater than "John" because "n" is greater than "h".
+//
+// Creating Objects
 //
 // Custom objects can be constructed on one more items. For example:
 //
@@ -238,6 +311,39 @@
 //       "born": "1408",
 //       "died": "7 May 1479",
 //       "name": "John Chauncy Esq."
+//     },
+//   ]
+//
+// Retrieve the names of individuals that have a given name (first name) of
+// "John".
+//
+//   .Individuals | .Name | Only(.GivenName = "John") | .String
+//
+// result:
+//
+//   [
+//     "John Chaunce",
+//     "John Chaunce",
+//     "John Chance",
+//     "John Unett",
+//     "John Chance",
+//     "John de Chauncy",
+//   ]
+//
+// Find all of the living people with their current age:
+//
+//   .Individuals | Only(.IsLiving) | { name: .Name | .String, age: .Age | .String}
+//
+// result:
+//
+//   [
+//     {
+//       "age": "82y 6m",
+//       "name": "Robert Walter Chance"
+//     },
+//     {
+//       "age": "~ 90y 10m",
+//       "name": "Sir Robert Temple Armstrong"
 //     },
 //   ]
 //

--- a/q/engine_test.go
+++ b/q/engine_test.go
@@ -91,6 +91,7 @@ func TestEngine_Start(t *testing.T) {
 			"First",
 			"Last",
 			"Length",
+			"Only",
 		}, nil)
 	}
 
@@ -110,6 +111,7 @@ func TestEngine_Start(t *testing.T) {
 			"Last",
 			"Length",
 			"Names",
+			"Only",
 		}, nil)
 	}
 
@@ -128,6 +130,7 @@ func TestEngine_Start(t *testing.T) {
 			"First",
 			"Last",
 			"Length",
+			"Only",
 		}, nil)
 	}
 

--- a/q/expression.go
+++ b/q/expression.go
@@ -6,5 +6,5 @@ type Expression interface {
 	// Evaluate should only be run once and is likely to alter the value of
 	// input. This means expressions can only be safely run once and previous
 	// input values cannot be reused.
-	Evaluate(engine *Engine, input interface{}, args []interface{}) (interface{}, error)
+	Evaluate(engine *Engine, input interface{}, args []*Statement) (interface{}, error)
 }

--- a/q/first_expr.go
+++ b/q/first_expr.go
@@ -3,6 +3,7 @@ package q
 import (
 	"fmt"
 	"reflect"
+	"strconv"
 )
 
 // FirstExpr is a function. See Evaluate.
@@ -17,7 +18,7 @@ type FirstExpr struct{}
 //
 // There must be exactly one argument and it must be 0 or greater. If the number
 // is greater than the length of the slice all elements are returned.
-func (e *FirstExpr) Evaluate(engine *Engine, input interface{}, args []interface{}) (interface{}, error) {
+func (e *FirstExpr) Evaluate(engine *Engine, input interface{}, args []*Statement) (interface{}, error) {
 	in := reflect.ValueOf(input)
 
 	if len(args) != 1 {
@@ -39,7 +40,16 @@ func (e *FirstExpr) Evaluate(engine *Engine, input interface{}, args []interface
 		return nil, nil
 	}
 
-	max := args[0].(int)
+	result, err := args[0].Evaluate(engine, input)
+	if err != nil {
+		return nil, err
+	}
+
+	max, err := strconv.Atoi(fmt.Sprintf("%v", result))
+	if err != nil {
+		return nil, err
+	}
+
 	if len := in.Len(); max >= len {
 		max = len
 	}

--- a/q/first_expr_test.go
+++ b/q/first_expr_test.go
@@ -13,33 +13,39 @@ func TestFirstExpr_Evaluate(t *testing.T) {
 
 	err := errors.New("function First() must take a single argument")
 
-	Evaluate(&q.FirstExpr{}, engine, nil, []interface{}{0}).Returns(nil, nil)
-	Evaluate(&q.FirstExpr{}, engine, nil, []interface{}{1}).Returns(nil, nil)
-	Evaluate(&q.FirstExpr{}, engine, nil, []interface{}{5}).Returns(nil, nil)
-	Evaluate(&q.FirstExpr{}, engine, nil, []interface{}{}).Returns(nil, err)
+	argNil := []*q.Statement{}
+	arg0 := []*q.Statement{{Expressions: []q.Expression{&q.ConstantExpr{Value: "0"}}}}
+	arg1 := []*q.Statement{{Expressions: []q.Expression{&q.ConstantExpr{Value: "1"}}}}
+	arg2 := []*q.Statement{{Expressions: []q.Expression{&q.ConstantExpr{Value: "2"}}}}
+	arg5 := []*q.Statement{{Expressions: []q.Expression{&q.ConstantExpr{Value: "5"}}}}
 
-	Evaluate(&q.FirstExpr{}, engine, ([]int)(nil), []interface{}{0}).Returns(nil, nil)
-	Evaluate(&q.FirstExpr{}, engine, ([]string)(nil), []interface{}{1}).Returns(nil, nil)
-	Evaluate(&q.FirstExpr{}, engine, ([]MyStruct)(nil), []interface{}{5}).Returns(nil, nil)
-	Evaluate(&q.FirstExpr{}, engine, ([]string)(nil), []interface{}{}).Returns(nil, err)
+	Evaluate(&q.FirstExpr{}, engine, nil, arg0).Returns(nil, nil)
+	Evaluate(&q.FirstExpr{}, engine, nil, arg1).Returns(nil, nil)
+	Evaluate(&q.FirstExpr{}, engine, nil, arg5).Returns(nil, nil)
+	Evaluate(&q.FirstExpr{}, engine, nil, argNil).Returns(nil, err)
 
-	Evaluate(&q.FirstExpr{}, engine, []int{1, 2, 3}, []interface{}{0}).
+	Evaluate(&q.FirstExpr{}, engine, ([]int)(nil), arg0).Returns(nil, nil)
+	Evaluate(&q.FirstExpr{}, engine, ([]string)(nil), arg1).Returns(nil, nil)
+	Evaluate(&q.FirstExpr{}, engine, ([]MyStruct)(nil), arg5).Returns(nil, nil)
+	Evaluate(&q.FirstExpr{}, engine, ([]string)(nil), argNil).Returns(nil, err)
+
+	Evaluate(&q.FirstExpr{}, engine, []int{1, 2, 3}, arg0).
 		Returns([]int{}, nil)
-	Evaluate(&q.FirstExpr{}, engine, []int{1, 2, 3}, []interface{}{1}).
+	Evaluate(&q.FirstExpr{}, engine, []int{1, 2, 3}, arg1).
 		Returns([]int{1}, nil)
-	Evaluate(&q.FirstExpr{}, engine, []int{1, 2, 3}, []interface{}{2}).
+	Evaluate(&q.FirstExpr{}, engine, []int{1, 2, 3}, arg2).
 		Returns([]int{1, 2}, nil)
-	Evaluate(&q.FirstExpr{}, engine, []int{1, 2, 3}, []interface{}{5}).
+	Evaluate(&q.FirstExpr{}, engine, []int{1, 2, 3}, arg5).
 		Returns([]int{1, 2, 3}, nil)
-	Evaluate(&q.FirstExpr{}, engine, []int{1, 2, 3}, []interface{}{}).
+	Evaluate(&q.FirstExpr{}, engine, []int{1, 2, 3}, argNil).
 		Returns(nil, err)
 
-	Evaluate(&q.LengthExpr{}, engine, "foo bar", []interface{}{0}).
+	Evaluate(&q.LengthExpr{}, engine, "foo bar", arg0).
 		Returns([]string{}, nil)
-	Evaluate(&q.LengthExpr{}, engine, "foo bar", []interface{}{1}).
+	Evaluate(&q.LengthExpr{}, engine, "foo bar", arg1).
 		Returns([]string{"foo bar"}, nil)
-	Evaluate(&q.LengthExpr{}, engine, "foo bar", []interface{}{5}).
+	Evaluate(&q.LengthExpr{}, engine, "foo bar", arg5).
 		Returns([]string{"foo bar"}, nil)
-	Evaluate(&q.LengthExpr{}, engine, "foo bar", []interface{}{}).
+	Evaluate(&q.LengthExpr{}, engine, "foo bar", argNil).
 		Returns(nil, err)
 }

--- a/q/formatter.go
+++ b/q/formatter.go
@@ -27,7 +27,7 @@ func (f *JSONFormatter) Write(result interface{}) error {
 		return err
 	}
 
-	_, err = f.Writer.Write(data)
+	_, err = f.Writer.Write(append(data, '\n'))
 
 	return err
 }
@@ -42,7 +42,7 @@ func (f *PrettyJSONFormatter) Write(result interface{}) error {
 		return err
 	}
 
-	_, err = f.Writer.Write(data)
+	_, err = f.Writer.Write(append(data, '\n'))
 
 	return err
 }

--- a/q/formatter_test.go
+++ b/q/formatter_test.go
@@ -19,8 +19,8 @@ var formatterTests = []struct {
 }{
 	{
 		result:       nil,
-		asJSON:       []byte("null"),
-		asPrettyJSON: []byte("null"),
+		asJSON:       []byte("null\n"),
+		asPrettyJSON: []byte("null\n"),
 		asCSV:        []byte(nil),
 		csvHeader:    nil,
 		csvError:     errors.New("not a slice"),
@@ -30,7 +30,8 @@ var formatterTests = []struct {
 			gedcom.NewNameNode(nil, "Elliot /Chance/", "", nil),
 			gedcom.NewNameNode(nil, "Dina /Wyche/", "", nil),
 		},
-		asJSON: []byte(`[{"Tag":"NAME","Value":"Elliot /Chance/"},{"Tag":"NAME","Value":"Dina /Wyche/"}]`),
+		asJSON: []byte(`[{"Tag":"NAME","Value":"Elliot /Chance/"},{"Tag":"NAME","Value":"Dina /Wyche/"}]
+`),
 		asPrettyJSON: []byte(`[
   {
     "Tag": "NAME",
@@ -40,7 +41,8 @@ var formatterTests = []struct {
     "Tag": "NAME",
     "Value": "Dina /Wyche/"
   }
-]`),
+]
+`),
 		asCSV: []byte(`Tag,Value
 NAME,Elliot /Chance/
 NAME,Dina /Wyche/
@@ -53,7 +55,8 @@ NAME,Dina /Wyche/
 			{"foo": "bar,", "baz": 123},
 			{"foo": 4.56, "baz": `q"ux`},
 		},
-		asJSON: []byte(`[{"baz":123,"foo":"bar,"},{"baz":"q\"ux","foo":4.56}]`),
+		asJSON: []byte(`[{"baz":123,"foo":"bar,"},{"baz":"q\"ux","foo":4.56}]
+`),
 		asPrettyJSON: []byte(`[
   {
     "baz": 123,
@@ -63,7 +66,8 @@ NAME,Dina /Wyche/
     "baz": "q\"ux",
     "foo": 4.56
   }
-]`),
+]
+`),
 		asCSV: []byte(`baz,foo
 123,"bar,"
 "q""ux",4.56

--- a/q/functions.go
+++ b/q/functions.go
@@ -8,4 +8,5 @@ var Functions = map[string]Expression{
 	"First":  &FirstExpr{},
 	"Last":   &LastExpr{},
 	"Length": &LengthExpr{},
+	"Only":   &OnlyExpr{},
 }

--- a/q/last_expr.go
+++ b/q/last_expr.go
@@ -2,7 +2,9 @@ package q
 
 import (
 	"errors"
+	"fmt"
 	"reflect"
+	"strconv"
 )
 
 // LastExpr is a function. See Evaluate.
@@ -17,7 +19,7 @@ type LastExpr struct{}
 //
 // There must be exactly one argument and it must be 0 or greater. If the number
 // is greater than the length of the slice all elements are returned.
-func (e *LastExpr) Evaluate(engine *Engine, input interface{}, args []interface{}) (interface{}, error) {
+func (e *LastExpr) Evaluate(engine *Engine, input interface{}, args []*Statement) (interface{}, error) {
 	in := reflect.ValueOf(input)
 
 	if len(args) != 1 {
@@ -39,12 +41,22 @@ func (e *LastExpr) Evaluate(engine *Engine, input interface{}, args []interface{
 		return nil, nil
 	}
 
-	if args[0].(int) == 0 {
+	result, err := args[0].Evaluate(engine, input)
+	if err != nil {
+		return nil, err
+	}
+
+	x, err := strconv.Atoi(fmt.Sprintf("%v", result))
+	if err != nil {
+		return nil, err
+	}
+
+	if x == 0 {
 		return in.Slice(0, 0).Interface(), nil
 	}
 
 	l := in.Len()
-	start := l - args[0].(int)
+	start := l - x
 
 	if start < 0 {
 		start = 0

--- a/q/last_expr_test.go
+++ b/q/last_expr_test.go
@@ -13,39 +13,46 @@ func TestLastExpr_Evaluate(t *testing.T) {
 
 	err := errors.New("function Last() must take a single argument")
 
-	Evaluate(&q.LastExpr{}, engine, nil, []interface{}{0}).Returns(nil, nil)
-	Evaluate(&q.LastExpr{}, engine, nil, []interface{}{1}).Returns(nil, nil)
-	Evaluate(&q.LastExpr{}, engine, nil, []interface{}{5}).Returns(nil, nil)
-	Evaluate(&q.LastExpr{}, engine, nil, []interface{}{}).Returns(nil, err)
+	argNil := []*q.Statement{}
+	arg0 := []*q.Statement{{Expressions: []q.Expression{&q.ConstantExpr{Value: "0"}}}}
+	arg1 := []*q.Statement{{Expressions: []q.Expression{&q.ConstantExpr{Value: "1"}}}}
+	arg2 := []*q.Statement{{Expressions: []q.Expression{&q.ConstantExpr{Value: "2"}}}}
+	arg3 := []*q.Statement{{Expressions: []q.Expression{&q.ConstantExpr{Value: "3"}}}}
+	arg5 := []*q.Statement{{Expressions: []q.Expression{&q.ConstantExpr{Value: "5"}}}}
 
-	Evaluate(&q.LastExpr{}, engine, ([]int)(nil), []interface{}{0}).
+	Evaluate(&q.LastExpr{}, engine, nil, arg0).Returns(nil, nil)
+	Evaluate(&q.LastExpr{}, engine, nil, arg1).Returns(nil, nil)
+	Evaluate(&q.LastExpr{}, engine, nil, arg5).Returns(nil, nil)
+	Evaluate(&q.LastExpr{}, engine, nil, argNil).Returns(nil, err)
+
+	Evaluate(&q.LastExpr{}, engine, ([]int)(nil), arg0).
 		Returns(nil, nil)
-	Evaluate(&q.LastExpr{}, engine, ([]string)(nil), []interface{}{1}).
+	Evaluate(&q.LastExpr{}, engine, ([]string)(nil), arg1).
 		Returns(nil, nil)
-	Evaluate(&q.LastExpr{}, engine, ([]MyStruct)(nil), []interface{}{5}).
+	Evaluate(&q.LastExpr{}, engine, ([]MyStruct)(nil), arg5).
 		Returns(nil, nil)
-	Evaluate(&q.LastExpr{}, engine, ([]MyStruct)(nil), []interface{}{}).
+	Evaluate(&q.LastExpr{}, engine, ([]MyStruct)(nil), argNil).
 		Returns(nil, err)
 
-	Evaluate(&q.LastExpr{}, engine, []int{1, 2, 3}, []interface{}{0}).
+	Evaluate(&q.LastExpr{}, engine, []int{1, 2, 3}, arg0).
 		Returns([]int{}, nil)
-	Evaluate(&q.LastExpr{}, engine, []int{1, 2, 3}, []interface{}{1}).
+	Evaluate(&q.LastExpr{}, engine, []int{1, 2, 3}, arg1).
 		Returns([]int{3}, nil)
-	Evaluate(&q.LastExpr{}, engine, []int{1, 2, 3}, []interface{}{2}).
+	Evaluate(&q.LastExpr{}, engine, []int{1, 2, 3}, arg2).
 		Returns([]int{2, 3}, nil)
-	Evaluate(&q.LastExpr{}, engine, []int{1, 2, 3}, []interface{}{3}).
+	Evaluate(&q.LastExpr{}, engine, []int{1, 2, 3}, arg3).
 		Returns([]int{1, 2, 3}, nil)
-	Evaluate(&q.LastExpr{}, engine, []int{1, 2, 3}, []interface{}{5}).
+	Evaluate(&q.LastExpr{}, engine, []int{1, 2, 3}, arg5).
 		Returns([]int{1, 2, 3}, nil)
-	Evaluate(&q.LastExpr{}, engine, []int{1, 2, 3}, []interface{}{}).
+	Evaluate(&q.LastExpr{}, engine, []int{1, 2, 3}, argNil).
 		Returns(nil, err)
 
-	Evaluate(&q.LengthExpr{}, engine, "foo bar", []interface{}{0}).
+	Evaluate(&q.LengthExpr{}, engine, "foo bar", arg0).
 		Returns([]string{}, nil)
-	Evaluate(&q.LengthExpr{}, engine, "foo bar", []interface{}{1}).
+	Evaluate(&q.LengthExpr{}, engine, "foo bar", arg1).
 		Returns([]string{"foo bar"}, nil)
-	Evaluate(&q.LengthExpr{}, engine, "foo bar", []interface{}{5}).
+	Evaluate(&q.LengthExpr{}, engine, "foo bar", arg5).
 		Returns([]string{"foo bar"}, nil)
-	Evaluate(&q.LengthExpr{}, engine, "foo bar", []interface{}{}).
+	Evaluate(&q.LengthExpr{}, engine, "foo bar", argNil).
 		Returns(nil, err)
 }

--- a/q/length_expr.go
+++ b/q/length_expr.go
@@ -10,7 +10,7 @@ type LengthExpr struct{}
 // Evaluate returns an integer with the number of items in the slice. This value
 // will be 0 or more. If the input is not a slice then 1 will always be
 // returned.
-func (e *LengthExpr) Evaluate(engine *Engine, input interface{}, args []interface{}) (interface{}, error) {
+func (e *LengthExpr) Evaluate(engine *Engine, input interface{}, args []*Statement) (interface{}, error) {
 	in := reflect.ValueOf(input)
 
 	if in.Kind() == reflect.Slice {

--- a/q/object_expr.go
+++ b/q/object_expr.go
@@ -7,7 +7,7 @@ type ObjectExpr struct {
 	Data map[string]*Statement
 }
 
-func (e *ObjectExpr) Evaluate(engine *Engine, input interface{}, args []interface{}) (interface{}, error) {
+func (e *ObjectExpr) Evaluate(engine *Engine, input interface{}, args []*Statement) (interface{}, error) {
 	in := reflect.ValueOf(input)
 
 	// If it is a slice we need to Evaluate each one.

--- a/q/only_expr.go
+++ b/q/only_expr.go
@@ -1,0 +1,39 @@
+package q
+
+import (
+	"errors"
+	"reflect"
+)
+
+// OnlyExpr is a function. See Evaluate.
+type OnlyExpr struct{}
+
+// Evaluate returns a new slice that only contains the entities that have
+// returned true from the condition.
+func (e *OnlyExpr) Evaluate(engine *Engine, input interface{}, args []*Statement) (interface{}, error) {
+	in := reflect.ValueOf(input)
+
+	if len(args) != 1 {
+		return nil, errors.New("function Only() must take a single argument")
+	}
+
+	if in.Kind() != reflect.Slice {
+		return nil, nil
+	}
+
+	results := reflect.MakeSlice(reflect.SliceOf(TypeOfSliceElement(input)), 0, 0)
+
+	condition := args[0]
+	for i := 0; i < in.Len(); i++ {
+		result, err := condition.Evaluate(engine, in.Index(i).Interface())
+		if err != nil {
+			return nil, err
+		}
+
+		if shouldAppend, ok := result.(bool); ok && shouldAppend {
+			results = reflect.Append(results, in.Index(i))
+		}
+	}
+
+	return results.Interface(), nil
+}

--- a/q/only_expr_test.go
+++ b/q/only_expr_test.go
@@ -1,0 +1,39 @@
+package q_test
+
+import (
+	"errors"
+	"github.com/elliotchance/gedcom/q"
+	"github.com/elliotchance/tf"
+	"testing"
+)
+
+func TestOnlyExpr_Evaluate(t *testing.T) {
+	Evaluate := tf.NamedFunction(t, "OnlyExpr_Evaluate", (*q.OnlyExpr).Evaluate)
+	engine := &q.Engine{}
+
+	err := errors.New("function Only() must take a single argument")
+
+	argNil := []*q.Statement{}
+	argEq := []*q.Statement{{Expressions: []q.Expression{&q.BinaryExpr{
+		Left:     &q.AccessorExpr{".Property"},
+		Operator: "=",
+		Right:    &q.ConstantExpr{"52"},
+	}}}}
+	argBadComp := []*q.Statement{{Expressions: []q.Expression{
+		&q.ConstantExpr{Value: "foo"},
+	}}}
+
+	Evaluate(&q.OnlyExpr{}, engine, nil, argEq).Returns(nil, nil)
+	Evaluate(&q.OnlyExpr{}, engine, nil, argBadComp).Returns(nil, nil)
+	Evaluate(&q.OnlyExpr{}, engine, nil, argNil).Returns(nil, err)
+
+	Evaluate(&q.OnlyExpr{}, engine, MyStruct{Property: 52}, argEq).Returns(nil, nil)
+	Evaluate(&q.OnlyExpr{}, engine, MyStruct{Property: 52}, argBadComp).Returns(nil, nil)
+	Evaluate(&q.OnlyExpr{}, engine, MyStruct{Property: 13}, argEq).Returns(nil, nil)
+	Evaluate(&q.OnlyExpr{}, engine, MyStruct{}, argNil).Returns(nil, err)
+
+	Evaluate(&q.OnlyExpr{}, engine, []MyStruct{{Property: 52}}, argEq).Returns([]MyStruct{{Property: 52}}, nil)
+	Evaluate(&q.OnlyExpr{}, engine, []MyStruct{{Property: 52}}, argBadComp).Returns([]MyStruct{}, nil)
+	Evaluate(&q.OnlyExpr{}, engine, []MyStruct{{Property: 13}}, argEq).Returns([]MyStruct{}, nil)
+	Evaluate(&q.OnlyExpr{}, engine, []MyStruct{{}}, argNil).Returns(nil, err)
+}

--- a/q/question_mark_expr.go
+++ b/q/question_mark_expr.go
@@ -30,7 +30,7 @@ type QuestionMarkExpr struct{}
 //     "Length"
 //   ]
 //
-func (e *QuestionMarkExpr) Evaluate(engine *Engine, input interface{}, args []interface{}) (interface{}, error) {
+func (e *QuestionMarkExpr) Evaluate(engine *Engine, input interface{}, args []*Statement) (interface{}, error) {
 	in := reflect.TypeOf(input)
 
 	if in.Kind() == reflect.Slice {

--- a/q/question_mark_expr_test.go
+++ b/q/question_mark_expr_test.go
@@ -10,7 +10,7 @@ func TestQuestionMarkExpr_Evaluate(t *testing.T) {
 	Evaluate := tf.NamedFunction(t, "QuestionMarkExpr_Evaluate", (*q.QuestionMarkExpr).Evaluate)
 	engine := &q.Engine{}
 
-	expected := []string{".Baz", ".Foo", "?", "First", "Last", "Length"}
+	expected := []string{".Baz", ".Foo", "?", "First", "Last", "Length", "Only"}
 
 	Evaluate(&q.QuestionMarkExpr{}, engine, &MyStruct{}, nil).
 		Returns(expected, nil)

--- a/q/token_test.go
+++ b/q/token_test.go
@@ -48,6 +48,16 @@ func TestTokenizer_TokenizeString(t *testing.T) {
 		{q.TokenWord, "Foo"},
 		{q.TokenQuestionMark, "?"},
 	}})
+
+	for _, operator := range q.Operators {
+		expectedTokens := []q.Token{}
+		for _, token := range operator.Tokens {
+			expectedTokens = append(expectedTokens, q.Token{token, string(token)})
+		}
+
+		TokenizeString(tz, operator.Name).
+			Returns(&q.Tokens{Tokens: expectedTokens})
+	}
 }
 
 func TestTokens_Consume(t *testing.T) {

--- a/q/variable_expr.go
+++ b/q/variable_expr.go
@@ -4,7 +4,7 @@ type VariableExpr struct {
 	Name string
 }
 
-func (e *VariableExpr) Evaluate(engine *Engine, input interface{}, args []interface{}) (interface{}, error) {
+func (e *VariableExpr) Evaluate(engine *Engine, input interface{}, args []*Statement) (interface{}, error) {
 	v, err := engine.StatementByVariableName(e.Name)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The gedcomq syntax has been greatly improved with:

- Adding binary operators; "=", "!=", ">", ">=", "<" and "<=". These work for number and strings. All strings are treated as non case sensitve and automatically trim surrounding whitespace.
- Added a new function "Only". It can be used to filter slices based on an expression. This also means that functions can take a real evaluated argument instead of only a constant.
- Added number (1.23) and string constants ("foo") to the syntax.

Other improvements:

- Added a trailing newline for JSON and pretty JSON outputs so they are more friendly to the CLI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/gedcom/179)
<!-- Reviewable:end -->
