### PR TITLE
gedcomq can now output as GEDCOM

### DIFF
--- a/gedcomq/main.go
+++ b/gedcomq/main.go
@@ -56,6 +56,8 @@ func output(result interface{}) {
 		formatter = &q.PrettyJSONFormatter{os.Stdout}
 	case "csv":
 		formatter = &q.CSVFormatter{os.Stdout}
+	case "gedcom":
+		formatter = &q.GEDCOMFormatter{os.Stdout}
 	default:
 		log.Panicf("unsupported format: %s", optionFormat)
 	}
@@ -67,8 +69,8 @@ func parseCLIFlags() {
 	flag.StringVar(&optionGedcomFile, "gedcom", "", util.CLIDescription(`
 		Path to the GEDCOM file (required).`))
 	flag.StringVar(&optionFormat, "format", "json", util.CLIDescription(`
-		Output format, can be one of the following: "json", "pretty-json" or
-		"csv".`))
+		Output format, can be one of the following: "json", "pretty-json",
+		"gedcom" or "csv".`))
 
 	flag.Parse()
 }

--- a/q/formatter.go
+++ b/q/formatter.go
@@ -161,3 +161,34 @@ func (f *CSVFormatter) Header(result interface{}) ([]string, error) {
 
 	return s, nil
 }
+
+type GEDCOMFormatter struct {
+	Writer io.Writer
+}
+
+func (f *GEDCOMFormatter) Write(result interface{}) error {
+	// Nil should be treated as a blank document.
+	if gedcom.IsNil(result) {
+		return nil
+	}
+
+	t := reflect.ValueOf(result)
+	if t.Kind() == reflect.Slice {
+		for i := 0; i < t.Len(); i++ {
+			err := f.Write(t.Index(i).Interface())
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+
+	if x, ok := result.(gedcom.GEDCOMStringer); ok {
+		f.Writer.Write([]byte(x.GEDCOMString(0)))
+
+		return nil
+	}
+
+	return fmt.Errorf("%s does not implement gedcom.GEDCOMStringer", t.Type())
+}


### PR DESCRIPTION
A new formatter "-format gedcom" can be used to output any single entity or slice as GEDCOM if they implement gedcom.GEDCOMStringer.