### PR TITLE
gedcomq now supports multiple documents

### DIFF
--- a/gedcomq/main.go
+++ b/gedcomq/main.go
@@ -20,8 +20,8 @@ import (
 )
 
 var (
-	optionGedcomFile string
-	optionFormat     string
+	optionGedcomFiles util.CLIStringSlice
+	optionFormat      string
 )
 
 func main() {
@@ -33,12 +33,22 @@ func main() {
 		log.Fatal(err)
 	}
 
-	doc, err := gedcom.NewDocumentFromGEDCOMFile(optionGedcomFile)
-	if err != nil {
-		log.Fatal(err)
+	docs := []*gedcom.Document{}
+
+	for _, gedcomFile := range optionGedcomFiles {
+		doc, err := gedcom.NewDocumentFromGEDCOMFile(gedcomFile)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		docs = append(docs, doc)
 	}
 
-	result, err := engine.Evaluate(doc)
+	if len(docs) == 0 {
+		log.Fatal("you must provide at least one gedcom file")
+	}
+
+	result, err := engine.Evaluate(docs)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -66,8 +76,10 @@ func output(result interface{}) {
 }
 
 func parseCLIFlags() {
-	flag.StringVar(&optionGedcomFile, "gedcom", "", util.CLIDescription(`
-		Path to the GEDCOM file (required).`))
+	flag.Var(&optionGedcomFiles, "gedcom", util.CLIDescription(`
+		Path to the GEDCOM file. You may specify more than one document by
+		providing -gedcom with an argument multiple times. You must provide at
+		least one document.`))
 	flag.StringVar(&optionFormat, "format", "json", util.CLIDescription(`
 		Output format, can be one of the following: "json", "pretty-json",
 		"gedcom" or "csv".`))

--- a/node_set_test.go
+++ b/node_set_test.go
@@ -1,9 +1,9 @@
 package gedcom_test
 
 import (
-	"testing"
 	"github.com/elliotchance/gedcom"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func TestNodeSet_Add(t *testing.T) {

--- a/q/combine_expr.go
+++ b/q/combine_expr.go
@@ -1,0 +1,36 @@
+package q
+
+import (
+	"reflect"
+)
+
+// CombineExpr will combine multiple slices of the same type into a single
+// slice.
+//
+// If the slices are not the same type an error will be returned with a nil
+// value.
+type CombineExpr struct{}
+
+func (e *CombineExpr) Evaluate(engine *Engine, input interface{}, args []*Statement) (interface{}, error) {
+	if len(args) == 0 {
+		return nil, nil
+	}
+
+	// Build a new slice with all elements.
+	firstArg, err := args[0].Evaluate(engine, input)
+	if err != nil {
+		return nil, err
+	}
+
+	slice := reflect.MakeSlice(reflect.TypeOf(firstArg), 0, 0)
+	for _, arg := range args {
+		argValue, err := arg.Evaluate(engine, input)
+		if err != nil {
+			return nil, err
+		}
+
+		slice = reflect.AppendSlice(slice, reflect.ValueOf(argValue))
+	}
+
+	return slice.Interface(), nil
+}

--- a/q/combine_expr_test.go
+++ b/q/combine_expr_test.go
@@ -1,0 +1,27 @@
+package q_test
+
+import (
+	"github.com/elliotchance/gedcom/q"
+	"github.com/elliotchance/tf"
+	"testing"
+)
+
+func TestCombineExpr_Evaluate(t *testing.T) {
+	Evaluate := tf.NamedFunction(t, "CombineExpr_Evaluate",
+		(*q.CombineExpr).Evaluate)
+	engine := &q.Engine{}
+
+	slice1 := []int{3, 4, 5}
+	slice2 := []int{1, 2}
+
+	Evaluate(&q.CombineExpr{}, engine, nil, []*q.Statement{}).Returns(nil, nil)
+
+	Evaluate(&q.CombineExpr{}, engine, nil, []*q.Statement{
+		{Expressions: []q.Expression{&q.ValueExpr{slice2}}},
+	}).Returns([]int{1, 2}, nil)
+
+	Evaluate(&q.CombineExpr{}, engine, nil, []*q.Statement{
+		{Expressions: []q.Expression{&q.ValueExpr{slice1}}},
+		{Expressions: []q.Expression{&q.ValueExpr{slice2}}},
+	}).Returns([]int{3, 4, 5, 1, 2}, nil)
+}

--- a/q/doc.go
+++ b/q/doc.go
@@ -74,6 +74,10 @@
 // Some functions are provided as part of the gedcomq language that exist
 // outside of the gedcom package:
 //
+//   Combine(Slices...)
+//
+// Combine will combine multiple slices of the same type into a single slice.
+//
 //   First(number)
 //
 // First returns up to the number of elements in a slice.

--- a/q/engine.go
+++ b/q/engine.go
@@ -11,9 +11,27 @@ type Engine struct {
 }
 
 // Evaluate executes all of the expressions and returns the final result.
-func (e *Engine) Evaluate(document *gedcom.Document) (interface{}, error) {
+//
+// Evaluate expects that there is at least one document provided.
+func (e *Engine) Evaluate(documents []*gedcom.Document) (interface{}, error) {
+	// Before we begin we will setup the Document variables. Each document, in
+	// order will be given Document1, Document2, ...
+	for i, document := range documents {
+		// Always prepend. The order of these variables does not matter, but we
+		// need to make sure they do not land on the end where they will attempt
+		// to be evaluated as the result.
+		e.Statements = append([]*Statement{{
+			VariableName: fmt.Sprintf("Document%d", i+1),
+			Expressions: []Expression{
+				&ValueExpr{Value: document},
+			},
+		}}, e.Statements...)
+	}
+
+	firstDocument := documents[0]
+
 	for _, statement := range e.Statements {
-		_, err := statement.Evaluate(e, document)
+		_, err := statement.Evaluate(e, firstDocument)
 
 		if err != nil {
 			return nil, err
@@ -22,7 +40,7 @@ func (e *Engine) Evaluate(document *gedcom.Document) (interface{}, error) {
 
 	lastStatement := e.Statements[len(e.Statements)-1]
 
-	return lastStatement.Evaluate(e, document)
+	return lastStatement.Evaluate(e, firstDocument)
 }
 
 func (e *Engine) StatementByVariableName(name string) (*Statement, error) {

--- a/q/functions.go
+++ b/q/functions.go
@@ -4,9 +4,10 @@ package q
 //
 // See "Functions" in the package documentation for usage and examples.
 var Functions = map[string]Expression{
-	"?":      &QuestionMarkExpr{},
-	"First":  &FirstExpr{},
-	"Last":   &LastExpr{},
-	"Length": &LengthExpr{},
-	"Only":   &OnlyExpr{},
+	"?":       &QuestionMarkExpr{},
+	"Combine": &CombineExpr{},
+	"First":   &FirstExpr{},
+	"Last":    &LastExpr{},
+	"Length":  &LengthExpr{},
+	"Only":    &OnlyExpr{},
 }

--- a/q/parser_test.go
+++ b/q/parser_test.go
@@ -183,4 +183,54 @@ func TestParser_ParseString(t *testing.T) {
 			},
 		},
 	}, nil)
+
+	ParseString(parser, `Combine(.Individuals, .Individuals)`).Returns(&q.Engine{
+		Statements: []*q.Statement{
+			{
+				Expressions: []q.Expression{
+					&q.CallExpr{
+						Function: &q.CombineExpr{},
+						Args: []*q.Statement{
+							{
+								Expressions: []q.Expression{
+									&q.AccessorExpr{Query: ".Individuals"},
+								},
+							},
+							{
+								Expressions: []q.Expression{
+									&q.AccessorExpr{Query: ".Individuals"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}, nil)
+
+	ParseString(parser, `Combine(.Individuals | .Names, .Individuals | .Names)`).Returns(&q.Engine{
+		Statements: []*q.Statement{
+			{
+				Expressions: []q.Expression{
+					&q.CallExpr{
+						Function: &q.CombineExpr{},
+						Args: []*q.Statement{
+							{
+								Expressions: []q.Expression{
+									&q.AccessorExpr{Query: ".Individuals"},
+									&q.AccessorExpr{Query: ".Names"},
+								},
+							},
+							{
+								Expressions: []q.Expression{
+									&q.AccessorExpr{Query: ".Individuals"},
+									&q.AccessorExpr{Query: ".Names"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}, nil)
 }

--- a/q/question_mark_expr_test.go
+++ b/q/question_mark_expr_test.go
@@ -6,11 +6,33 @@ import (
 	"testing"
 )
 
+var documentChoices = []string{
+	".AddNode",
+	".Families",
+	".GEDCOMString",
+	".Individuals",
+	".NodeByPointer",
+	".Nodes",
+	".Places",
+	".Sources",
+	".String",
+}
+
+var functionAndVariableChoices = []string{
+	"?",
+	"Combine",
+	"First",
+	"Last",
+	"Length",
+	"Only",
+}
+
 func TestQuestionMarkExpr_Evaluate(t *testing.T) {
-	Evaluate := tf.NamedFunction(t, "QuestionMarkExpr_Evaluate", (*q.QuestionMarkExpr).Evaluate)
+	Evaluate := tf.NamedFunction(t, "QuestionMarkExpr_Evaluate",
+		(*q.QuestionMarkExpr).Evaluate)
 	engine := &q.Engine{}
 
-	expected := []string{".Baz", ".Foo", "?", "First", "Last", "Length", "Only"}
+	expected := append([]string{".Baz", ".Foo"}, functionAndVariableChoices...)
 
 	Evaluate(&q.QuestionMarkExpr{}, engine, &MyStruct{}, nil).
 		Returns(expected, nil)

--- a/q/value_expr.go
+++ b/q/value_expr.go
@@ -1,0 +1,13 @@
+package q
+
+// ValueExpr holds a single value.
+//
+// It is different from ConstantExpr because it cannot be instantiated from the
+// q language, but acts as a placeholder for prepared values.
+type ValueExpr struct {
+	Value interface{}
+}
+
+func (e *ValueExpr) Evaluate(engine *Engine, input interface{}, args []*Statement) (interface{}, error) {
+	return e.Value, nil
+}

--- a/util/cli.go
+++ b/util/cli.go
@@ -1,6 +1,8 @@
 package util
 
-import "strings"
+import (
+	"strings"
+)
 
 func CLIDescription(s string) (r string) {
 	lines := strings.Split(s, "\n")
@@ -39,4 +41,25 @@ func WrapToMargin(s string, width int) (r string) {
 	r = r[:len(r)-1]
 
 	return
+}
+
+// CLIStringSlice is used to accept multiple values from a CLI argument like:
+//
+//   -foo value1 -foo value2
+//
+// Usage:
+//
+//   var foos CLIStringSlice
+//   flag.Var(&foos, "foo", "Some description for this param.")
+//
+type CLIStringSlice []string
+
+func (i *CLIStringSlice) String() string {
+	return strings.Join(*i, ";")
+}
+
+func (i *CLIStringSlice) Set(value string) error {
+	*i = append(*i, value)
+
+	return nil
 }


### PR DESCRIPTION
Multiple documents can be provided by supplying "-gedcom" several times. New variables Document1, Document2, etc can be used to access these files.

Also added a Combine() function which creates a single slice out of multiple slices of the same type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/gedcom/185)
<!-- Reviewable:end -->
