### PR TITLE
Heavily improved merging and much more

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -20,6 +20,18 @@
   version = "v1.5.0"
 
 [[projects]]
+  name = "github.com/google/go-cmp"
+  packages = [
+    "cmp",
+    "cmp/cmpopts",
+    "cmp/internal/diff",
+    "cmp/internal/function",
+    "cmp/internal/value"
+  ]
+  revision = "3af367b6b30c263d47e8895973edcca9a49cf029"
+  version = "v0.2.0"
+
+[[projects]]
   name = "github.com/mattn/go-colorable"
   packages = ["."]
   revision = "167de6bfdfba052fa6b2d3664c8f5272e23c9072"
@@ -107,6 +119,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "852a181d3fa5af228f4a53f8d631383680f324c42e674626a3444de4ce8ee941"
+  inputs-digest = "b844fa460f371cc3bcdbf207fb6eda3540007d00d8f6b3bc4dd6e6936a898635"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -17,3 +17,7 @@
 [[constraint]]
   name = "github.com/cheggaaa/pb"
   version = "2.0.6"
+
+[[constraint]]
+  name = "github.com/google/go-cmp"
+  version = "0.2.0"

--- a/copy_test.go
+++ b/copy_test.go
@@ -1,0 +1,61 @@
+package gedcom_test
+
+import (
+	"github.com/elliotchance/gedcom"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestDeepCopy(t *testing.T) {
+	dateNode1 := gedcom.NewDateNode(nil, "1851", "", nil)
+	dateNode2 := gedcom.NewDateNode(nil, "1856", "", nil)
+	birthNode := gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
+		dateNode1,
+	})
+	deathNode := gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
+		dateNode1,
+		dateNode2,
+	})
+	individualNode := gedcom.NewIndividualNode(nil, "", "P221", []gedcom.Node{
+		birthNode,
+		deathNode,
+	})
+
+	t.Run("Nil", func(t *testing.T) {
+		actual := gedcom.DeepCopy(nil)
+
+		assert.Nil(t, actual)
+	})
+
+	t.Run("NoChildren", func(t *testing.T) {
+		actual := gedcom.DeepCopy(dateNode1)
+
+		assert.True(t, actual != dateNode1)
+	})
+
+	t.Run("Birth", func(t *testing.T) {
+		actual := gedcom.DeepCopy(birthNode)
+
+		assert.True(t, actual != birthNode)
+		assert.True(t, actual.Nodes()[0] != dateNode1)
+	})
+
+	t.Run("Death", func(t *testing.T) {
+		actual := gedcom.DeepCopy(deathNode)
+
+		assert.True(t, actual != deathNode)
+		assert.True(t, actual.Nodes()[0] != dateNode1)
+		assert.True(t, actual.Nodes()[1] != dateNode2)
+	})
+
+	t.Run("Individual", func(t *testing.T) {
+		actual := gedcom.DeepCopy(individualNode)
+
+		assert.True(t, actual != individualNode)
+		assert.True(t, actual.Nodes()[0] != birthNode)
+		assert.True(t, actual.Nodes()[0].Nodes()[0] != dateNode1)
+		assert.True(t, actual.Nodes()[1] != deathNode)
+		assert.True(t, actual.Nodes()[1].Nodes()[0] != dateNode1)
+		assert.True(t, actual.Nodes()[1].Nodes()[1] != dateNode2)
+	})
+}

--- a/document.go
+++ b/document.go
@@ -184,7 +184,7 @@ func (doc *Document) Sources() []*SourceNode {
 //
 // If the node already exists it will be added again. This will cause problems
 // with duplicate references.
-func (doc *Document) AddNode(node Node) *Document {
+func (doc *Document) AddNode(node Node) {
 	if !IsNil(node) {
 		doc.nodes = append(doc.nodes, node)
 
@@ -195,8 +195,6 @@ func (doc *Document) AddNode(node Node) *Document {
 			doc.pointerCache.Store(pointer, node)
 		}
 	}
-
-	return doc
 }
 
 // Nodes returns the root nodes for the document.
@@ -246,4 +244,36 @@ func NewDocumentWithNodes(nodes []Node) *Document {
 	document.buildPointerCache()
 
 	return document
+}
+
+func (doc *Document) nonIndividuals() []Node {
+	nodes := []Node{}
+
+	for _, node := range doc.Nodes() {
+		if _, ok := node.(*IndividualNode); !ok {
+			nodes = append(nodes, node)
+		}
+	}
+
+	return nodes
+}
+
+func (doc *Document) SetNodes(nodes []Node) {
+	doc.nodes = nodes
+}
+
+func individuals(doc *Document) IndividualNodes {
+	if doc == nil {
+		return nil
+	}
+
+	return doc.Individuals()
+}
+
+func nonIndividuals(doc *Document) []Node {
+	if doc == nil {
+		return nil
+	}
+
+	return doc.nonIndividuals()
 }

--- a/flatten.go
+++ b/flatten.go
@@ -1,0 +1,50 @@
+package gedcom
+
+// Flatten returns a slice of nodes from a tree structure.
+//
+// The original nodes will not be modified, but they will also not be copied.
+// Any changes to the result nodes will directly affect the original tree
+// structure. This also means that the nodes returned will have the references
+// to their children as before.
+//
+// Flatten makes no guarantees about the same node appearing more than once if
+// it also appears more then once in the original structure. Be careful not to
+// pass in structures that have circular references between nodes.
+//
+// If the input is nil then the result will also be nil.
+//
+// If you would like a completely new copy of the data you can use:
+//
+//   Flatten(DeepCopy(node))
+//
+func Flatten(node Node) []Node {
+	if IsNil(node) {
+		return nil
+	}
+
+	result := []Node{}
+
+	Filter(node, func(node Node) (newNode Node, traverseChildren bool) {
+		result = append(result, node)
+
+		return node, true
+	})
+
+	return result
+}
+
+// FlattenAll works as Flatten with multiple inputs that are returned as a
+// single slice.
+//
+// If any of the nodes are nil they will be ignored.
+func FlattenAll(nodes []Node) (result []Node) {
+	for _, node := range nodes {
+		if IsNil(node) {
+			continue
+		}
+
+		result = append(result, Flatten(node)...)
+	}
+
+	return
+}

--- a/flatten_test.go
+++ b/flatten_test.go
@@ -1,0 +1,82 @@
+package gedcom_test
+
+import (
+	"github.com/elliotchance/gedcom"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestFlatten(t *testing.T) {
+	dateNode1 := gedcom.NewDateNode(nil, "1851", "", nil)
+	dateNode2 := gedcom.NewDateNode(nil, "1856", "", nil)
+	birthNode := gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
+		dateNode1,
+	})
+	deathNode := gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
+		dateNode1,
+		dateNode2,
+	})
+	individualNode := gedcom.NewIndividualNode(nil, "", "P221", []gedcom.Node{
+		birthNode,
+		deathNode,
+	})
+
+	t.Run("Nil", func(t *testing.T) {
+		actual := gedcom.Flatten(nil)
+
+		assert.Nil(t, actual)
+	})
+
+	t.Run("NoChildren", func(t *testing.T) {
+		actual := gedcom.Flatten(dateNode1)
+
+		if assert.Len(t, actual, 1) {
+			assert.True(t, actual[0] == dateNode1)
+		}
+	})
+
+	t.Run("Birth", func(t *testing.T) {
+		actual := gedcom.Flatten(birthNode)
+
+		if assert.Len(t, actual, 2) {
+			assert.True(t, actual[0] == birthNode)
+			assert.True(t, actual[1] == dateNode1)
+		}
+	})
+
+	t.Run("Death", func(t *testing.T) {
+		actual := gedcom.Flatten(deathNode)
+
+		if assert.Len(t, actual, 3) {
+			assert.True(t, actual[0] == deathNode)
+			assert.True(t, actual[1] == dateNode1)
+			assert.True(t, actual[2] == dateNode2)
+		}
+	})
+
+	t.Run("Individual", func(t *testing.T) {
+		actual := gedcom.Flatten(individualNode)
+
+		if assert.Len(t, actual, 6) {
+			assert.True(t, actual[0] == individualNode)
+			assert.True(t, actual[1] == birthNode)
+			assert.True(t, actual[2] == dateNode1)
+			assert.True(t, actual[3] == deathNode)
+			assert.True(t, actual[4] == dateNode1)
+			assert.True(t, actual[5] == dateNode2)
+		}
+	})
+
+	t.Run("DeepCopy", func(t *testing.T) {
+		actual := gedcom.Flatten(gedcom.DeepCopy(individualNode))
+
+		if assert.Len(t, actual, 6) {
+			assert.True(t, actual[0] != individualNode)
+			assert.True(t, actual[1] != birthNode)
+			assert.True(t, actual[2] != dateNode1)
+			assert.True(t, actual[3] != deathNode)
+			assert.True(t, actual[4] != dateNode1)
+			assert.True(t, actual[5] != dateNode2)
+		}
+	})
+}

--- a/gedcomdiff/diff_page.go
+++ b/gedcomdiff/diff_page.go
@@ -9,13 +9,13 @@ import (
 )
 
 type diffPage struct {
-	comparisons       []gedcom.IndividualComparison
+	comparisons       gedcom.IndividualComparisons
 	options           *gedcom.SimilarityOptions
 	filterFlags       *util.FilterFlags
 	googleAnalyticsID string
 }
 
-func newDiffPage(comparisons []gedcom.IndividualComparison, options *gedcom.SimilarityOptions, filterFlags *util.FilterFlags, googleAnalyticsID string) *diffPage {
+func newDiffPage(comparisons gedcom.IndividualComparisons, options *gedcom.SimilarityOptions, filterFlags *util.FilterFlags, googleAnalyticsID string) *diffPage {
 	return &diffPage{
 		comparisons:       comparisons,
 		options:           options,
@@ -40,8 +40,8 @@ func (c *diffPage) sortByWrittenName(i, j int) bool {
 }
 
 func (c *diffPage) sortByHighestSimilarity(i, j int) bool {
-	a := c.comparisons[i].Similarity.WeightedSimilarity(c.options)
-	b := c.comparisons[j].Similarity.WeightedSimilarity(c.options)
+	a := c.comparisons[i].Similarity.WeightedSimilarity()
+	b := c.comparisons[j].Similarity.WeightedSimilarity()
 
 	if a != b {
 		// Greater than because we want the highest matches up the top.
@@ -74,7 +74,7 @@ func (c *diffPage) String() string {
 			continue
 		}
 
-		weightedSimilarity := comparison.Similarity.WeightedSimilarity(c.options)
+		weightedSimilarity := comparison.Similarity.WeightedSimilarity()
 
 		leftClass := ""
 		rightClass := ""
@@ -134,7 +134,7 @@ func (c *diffPage) String() string {
 	).String()
 }
 
-func shouldSkip(comparison gedcom.IndividualComparison) bool {
+func shouldSkip(comparison *gedcom.IndividualComparison) bool {
 	switch optionShow {
 	case optionShowAll:
 		// Do nothing, we want to show all.

--- a/gedcomdiff/individual_compare.go
+++ b/gedcomdiff/individual_compare.go
@@ -8,11 +8,11 @@ import (
 )
 
 type individualCompare struct {
-	comparison  gedcom.IndividualComparison
+	comparison  *gedcom.IndividualComparison
 	filterFlags *util.FilterFlags
 }
 
-func newIndividualCompare(comparison gedcom.IndividualComparison, filterFlags *util.FilterFlags) *individualCompare {
+func newIndividualCompare(comparison *gedcom.IndividualComparison, filterFlags *util.FilterFlags) *individualCompare {
 	return &individualCompare{
 		comparison:  comparison,
 		filterFlags: filterFlags,
@@ -83,10 +83,7 @@ func (c *individualCompare) String() string {
 		}
 	}
 
-	options := gedcom.NewSimilarityOptions()
-	compareOptions := &gedcom.IndividualNodesCompareOptions{
-		SimilarityOptions: options,
-	}
+	compareOptions := gedcom.NewIndividualNodesCompareOptions()
 	for _, parents := range leftParents.Compare(rightParents, compareOptions) {
 		var row *diffRow
 		name := "Parent"

--- a/gedcomdiff/main.go
+++ b/gedcomdiff/main.go
@@ -71,18 +71,17 @@ func main() {
 	out, err := os.Create(optionOutputFile)
 	check(err)
 
-	var comparisons []gedcom.IndividualComparison
+	var comparisons gedcom.IndividualComparisons
 
 	similarityOptions := gedcom.NewSimilarityOptions()
 	similarityOptions.MinimumWeightedSimilarity = optionMinimumWeightedSimilarity
 	similarityOptions.MinimumSimilarity = optionMinimumSimilarity
 
-	compareOptions := &gedcom.IndividualNodesCompareOptions{
-		SimilarityOptions: similarityOptions,
-		Notifier:          make(chan gedcom.CompareProgress),
-		NotifierStep:      100,
-		Jobs:              optionJobs,
-	}
+	compareOptions := gedcom.NewIndividualNodesCompareOptions()
+	compareOptions.SimilarityOptions = similarityOptions
+	compareOptions.Notifier = make(chan gedcom.CompareProgress)
+	compareOptions.NotifierStep = 100
+	compareOptions.Jobs = optionJobs
 
 	if optionProgress {
 		go func() {

--- a/gedcomtune/main.go
+++ b/gedcomtune/main.go
@@ -253,9 +253,10 @@ func startCPUProfiler() {
 }
 
 func run(gedcom1, gedcom2 *gedcom.Document, idealScore int, options *gedcom.SimilarityOptions) {
-	comparisons := gedcom1.Individuals().Compare(gedcom2.Individuals(), &gedcom.IndividualNodesCompareOptions{
-		SimilarityOptions: options,
-	})
+	compareOptions := gedcom.NewIndividualNodesCompareOptions()
+	compareOptions.SimilarityOptions = options
+
+	comparisons := gedcom1.Individuals().Compare(gedcom2.Individuals(), compareOptions)
 
 	score := 0.0
 	for _, comparison := range comparisons {

--- a/individual_node_test.go
+++ b/individual_node_test.go
@@ -1041,7 +1041,7 @@ func TestIndividualNode_SurroundingSimilarity(t *testing.T) {
 	// ghost:ignore
 	var tests = []struct {
 		doc      *gedcom.Document
-		expected gedcom.SurroundingSimilarity
+		expected *gedcom.SurroundingSimilarity
 	}{
 		// Empty individuals.
 		{
@@ -1049,11 +1049,12 @@ func TestIndividualNode_SurroundingSimilarity(t *testing.T) {
 				individual("P1", "", "", ""),
 				individual("P2", "", "", ""),
 			}),
-			expected: gedcom.SurroundingSimilarity{
+			expected: &gedcom.SurroundingSimilarity{
 				ParentsSimilarity:    0.5,
 				IndividualSimilarity: 0.25,
 				SpousesSimilarity:    1.0,
 				ChildrenSimilarity:   1.0,
+				Options:              gedcom.NewSimilarityOptions(),
 			},
 		},
 
@@ -1063,11 +1064,12 @@ func TestIndividualNode_SurroundingSimilarity(t *testing.T) {
 				individual("P1", "Elliot /Chance/", "4 Jan 1843", "17 Mar 1907"),
 				individual("P2", "Elliot /Chance/", "4 Jan 1843", "17 Mar 1907"),
 			}),
-			expected: gedcom.SurroundingSimilarity{
+			expected: &gedcom.SurroundingSimilarity{
 				ParentsSimilarity:    0.5,
 				IndividualSimilarity: 1.0,
 				SpousesSimilarity:    1.0,
 				ChildrenSimilarity:   1.0,
+				Options:              gedcom.NewSimilarityOptions(),
 			},
 		},
 
@@ -1077,11 +1079,12 @@ func TestIndividualNode_SurroundingSimilarity(t *testing.T) {
 				individual("P1", "Elliot /Chance/", "4 Jan 1843", "17 Mar 1907"),
 				individual("P2", "Elliot /Chance/", "Abt. 1843", "Abt. 1910"),
 			}),
-			expected: gedcom.SurroundingSimilarity{
+			expected: &gedcom.SurroundingSimilarity{
 				ParentsSimilarity:    0.5,
 				IndividualSimilarity: 0.7433558199873285,
 				SpousesSimilarity:    1.0,
 				ChildrenSimilarity:   1.0,
+				Options:              gedcom.NewSimilarityOptions(),
 			},
 		},
 
@@ -1091,11 +1094,12 @@ func TestIndividualNode_SurroundingSimilarity(t *testing.T) {
 				individual("P1", "Elliot /Chance/", "4 Jan 1843", "17 Mar 1907"),
 				individual("P2", "Joe /Bloggs/", "1945", "2000"),
 			}),
-			expected: gedcom.SurroundingSimilarity{
+			expected: &gedcom.SurroundingSimilarity{
 				ParentsSimilarity:    0.5,
 				IndividualSimilarity: 0.20128205128205132,
 				SpousesSimilarity:    1.0,
 				ChildrenSimilarity:   1.0,
+				Options:              gedcom.NewSimilarityOptions(),
 			},
 		},
 
@@ -1111,11 +1115,12 @@ func TestIndividualNode_SurroundingSimilarity(t *testing.T) {
 				family("F1", "P3", "P4", "P1"),
 				family("F2", "P5", "P6", "P2"),
 			}),
-			expected: gedcom.SurroundingSimilarity{
+			expected: &gedcom.SurroundingSimilarity{
 				ParentsSimilarity:    1.0,
 				IndividualSimilarity: 1.0,
 				SpousesSimilarity:    1.0,
 				ChildrenSimilarity:   1.0,
+				Options:              gedcom.NewSimilarityOptions(),
 			},
 		},
 
@@ -1131,11 +1136,12 @@ func TestIndividualNode_SurroundingSimilarity(t *testing.T) {
 				family("F1", "P3", "P4", "P1"),
 				family("F2", "P5", "P6", "P2"),
 			}),
-			expected: gedcom.SurroundingSimilarity{
+			expected: &gedcom.SurroundingSimilarity{
 				ParentsSimilarity:    0.9981481481481481,
 				IndividualSimilarity: 0.9950549450549451,
 				SpousesSimilarity:    1.0,
 				ChildrenSimilarity:   1.0,
+				Options:              gedcom.NewSimilarityOptions(),
 			},
 		},
 
@@ -1151,11 +1157,12 @@ func TestIndividualNode_SurroundingSimilarity(t *testing.T) {
 				family("F1", "P3", "", "P1"),
 				family("F2", "P5", "P6", "P2"),
 			}),
-			expected: gedcom.SurroundingSimilarity{
+			expected: &gedcom.SurroundingSimilarity{
 				ParentsSimilarity:    0.75,
 				IndividualSimilarity: 0.9950549450549451,
 				SpousesSimilarity:    1.0,
 				ChildrenSimilarity:   1.0,
+				Options:              gedcom.NewSimilarityOptions(),
 			},
 		},
 
@@ -1171,11 +1178,12 @@ func TestIndividualNode_SurroundingSimilarity(t *testing.T) {
 				family("F1", "", "", "P1"),
 				family("F2", "P5", "P6", "P2"),
 			}),
-			expected: gedcom.SurroundingSimilarity{
+			expected: &gedcom.SurroundingSimilarity{
 				ParentsSimilarity:    0.5,
 				IndividualSimilarity: 0.9950549450549451,
 				SpousesSimilarity:    1.0,
 				ChildrenSimilarity:   1.0,
+				Options:              gedcom.NewSimilarityOptions(),
 			},
 		},
 
@@ -1195,11 +1203,12 @@ func TestIndividualNode_SurroundingSimilarity(t *testing.T) {
 				family("F3", "P1", "P7"),
 				family("F4", "P2", "P8"),
 			}),
-			expected: gedcom.SurroundingSimilarity{
+			expected: &gedcom.SurroundingSimilarity{
 				ParentsSimilarity:    1.0,
 				IndividualSimilarity: 1.0,
 				SpousesSimilarity:    1.0,
 				ChildrenSimilarity:   1.0,
+				Options:              gedcom.NewSimilarityOptions(),
 			},
 		},
 	}
@@ -1632,4 +1641,113 @@ func parseAgeYears(s string) (years float64, isEstimate, isKnown bool) {
 	fmt.Sscanf(value, "%f", &years)
 
 	return
+}
+
+func TestIndividualNode_String(t *testing.T) {
+	String := tf.NamedFunction(t, "IndividualNode_String", (*gedcom.IndividualNode).String)
+
+	String(gedcom.NewIndividualNode(nil, "", "", nil)).
+		Returns("(no name)")
+
+	String(gedcom.NewIndividualNode(nil, "", "", []gedcom.Node{
+		gedcom.NewNameNode(nil, "", "", nil),
+	})).Returns("(no name)")
+
+	String(gedcom.NewIndividualNode(nil, "", "", []gedcom.Node{
+		gedcom.NewNameNode(nil, "Elliot /Chance/", "", nil),
+	})).Returns("Elliot Chance")
+
+	String(gedcom.NewIndividualNode(nil, "", "", []gedcom.Node{
+		gedcom.NewNameNode(nil, "Elliot /Chance/", "", nil),
+		gedcom.NewBirthNode(nil, "", "", nil),
+	})).Returns("Elliot Chance")
+
+	String(gedcom.NewIndividualNode(nil, "", "", []gedcom.Node{
+		gedcom.NewNameNode(nil, "Elliot /Chance/", "", nil),
+		gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
+			gedcom.NewDateNode(nil, "3 Apr 1983", "", nil),
+		}),
+	})).Returns("Elliot Chance (b. 3 Apr 1983)")
+
+	String(gedcom.NewIndividualNode(nil, "", "", []gedcom.Node{
+		gedcom.NewNameNode(nil, "Elliot /Chance/", "", nil),
+		gedcom.NewDeathNode(nil, "", "", nil),
+	})).Returns("Elliot Chance")
+
+	String(gedcom.NewIndividualNode(nil, "", "", []gedcom.Node{
+		gedcom.NewNameNode(nil, "Elliot /Chance/", "", nil),
+		gedcom.NewDeathNode(nil, "", "", []gedcom.Node{
+			gedcom.NewDateNode(nil, "19 Nov 2007", "", nil),
+		}),
+	})).Returns("Elliot Chance (d. 19 Nov 2007)")
+
+	String(gedcom.NewIndividualNode(nil, "", "", []gedcom.Node{
+		gedcom.NewNameNode(nil, "John /Smith/", "", nil),
+		gedcom.NewDeathNode(nil, "", "", nil),
+		gedcom.NewBirthNode(nil, "", "", nil),
+	})).Returns("John Smith")
+
+	String(gedcom.NewIndividualNode(nil, "", "", []gedcom.Node{
+		gedcom.NewNameNode(nil, "John /Smith/", "", nil),
+		gedcom.NewDeathNode(nil, "", "", []gedcom.Node{
+			gedcom.NewDateNode(nil, "19 Nov 2007", "", nil),
+		}),
+		gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
+			gedcom.NewDateNode(nil, "7 Aug 1971", "", nil),
+		}),
+	})).Returns("John Smith (b. 7 Aug 1971, d. 19 Nov 2007)")
+
+	String(gedcom.NewIndividualNode(nil, "", "", []gedcom.Node{
+		gedcom.NewNameNode(nil, "Jane /Doe/", "", nil),
+		gedcom.NewBaptismNode(nil, "", "", []gedcom.Node{
+			gedcom.NewDateNode(nil, "14 Jun 2007", "", nil),
+		}),
+	})).Returns("Jane Doe (bap. 14 Jun 2007)")
+
+	String(gedcom.NewIndividualNode(nil, "", "", []gedcom.Node{
+		gedcom.NewNameNode(nil, "Jane /Doe/", "", nil),
+		gedcom.NewBaptismNode(nil, "", "", []gedcom.Node{
+			gedcom.NewDateNode(nil, "14 Jun 2007", "", nil),
+		}),
+		gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
+			gedcom.NewDateNode(nil, "7 Jun 2007", "", nil),
+		}),
+	})).Returns("Jane Doe (b. 7 Jun 2007)")
+
+	String(gedcom.NewIndividualNode(nil, "", "", []gedcom.Node{
+		gedcom.NewNameNode(nil, "Jane /Doe/", "", nil),
+		gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
+			gedcom.NewDateNode(nil, "7 Jun 2007", "", nil),
+		}),
+		gedcom.NewBaptismNode(nil, "", "", []gedcom.Node{
+			gedcom.NewDateNode(nil, "14 Jun 2007", "", nil),
+		}),
+	})).Returns("Jane Doe (b. 7 Jun 2007)")
+
+	String(gedcom.NewIndividualNode(nil, "", "", []gedcom.Node{
+		gedcom.NewNameNode(nil, "Jane /Doe/", "", nil),
+		gedcom.NewBurialNode(nil, "", "", []gedcom.Node{
+			gedcom.NewDateNode(nil, "14 Jun 2007", "", nil),
+		}),
+	})).Returns("Jane Doe (bur. 14 Jun 2007)")
+
+	String(gedcom.NewIndividualNode(nil, "", "", []gedcom.Node{
+		gedcom.NewNameNode(nil, "Jane /Doe/", "", nil),
+		gedcom.NewBurialNode(nil, "", "", []gedcom.Node{
+			gedcom.NewDateNode(nil, "14 Jun 2007", "", nil),
+		}),
+		gedcom.NewDeathNode(nil, "", "", []gedcom.Node{
+			gedcom.NewDateNode(nil, "7 Jun 2007", "", nil),
+		}),
+	})).Returns("Jane Doe (d. 7 Jun 2007)")
+
+	String(gedcom.NewIndividualNode(nil, "", "", []gedcom.Node{
+		gedcom.NewNameNode(nil, "Jane /Doe/", "", nil),
+		gedcom.NewDeathNode(nil, "", "", []gedcom.Node{
+			gedcom.NewDateNode(nil, "7 Jun 2007", "", nil),
+		}),
+		gedcom.NewBurialNode(nil, "", "", []gedcom.Node{
+			gedcom.NewDateNode(nil, "14 Jun 2007", "", nil),
+		}),
+	})).Returns("Jane Doe (d. 7 Jun 2007)")
 }

--- a/individual_nodes_test.go
+++ b/individual_nodes_test.go
@@ -4,8 +4,138 @@ import (
 	"testing"
 
 	"github.com/elliotchance/gedcom"
+	"github.com/elliotchance/tf"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
 )
+
+var (
+	elliot = individual("P1", "Elliot /Chance/", "4 Jan 1843", "17 Mar 1907")
+	john   = individual("P2", "John /Smith/", "4 Jan 1803", "17 Mar 1877")
+	jane   = individual("P3", "Jane /Doe/", "3 Mar 1803", "14 June 1877")
+	bob    = individual("P4", "Bob /Jones/", "1749", "1810")
+)
+
+var individualNodesTests = map[string]struct {
+	doc1, doc2  *gedcom.Document
+	min         float64
+	wantCompare gedcom.IndividualComparisons
+	wantMerge   gedcom.IndividualNodes
+}{
+	"BothDocumentsEmpty": {
+		doc1:        gedcom.NewDocument(),
+		doc2:        gedcom.NewDocument(),
+		min:         0.0,
+		wantCompare: gedcom.IndividualComparisons{},
+	},
+	"Doc2Empty": {
+		doc1: gedcom.NewDocumentWithNodes([]gedcom.Node{elliot}),
+		doc2: gedcom.NewDocument(),
+		min:  0.0,
+		wantCompare: gedcom.IndividualComparisons{
+			{elliot, nil, nil},
+		},
+		wantMerge: gedcom.IndividualNodes{
+			elliot,
+		},
+	},
+	"Doc1Empty": {
+		doc1: gedcom.NewDocument(),
+		doc2: gedcom.NewDocumentWithNodes([]gedcom.Node{elliot}),
+		min:  0.0,
+		wantCompare: gedcom.IndividualComparisons{
+			{nil, elliot, nil},
+		},
+		wantMerge: gedcom.IndividualNodes{
+			elliot,
+		},
+	},
+	"SameIndividualInBothDocuments": {
+		doc1: gedcom.NewDocumentWithNodes([]gedcom.Node{elliot}),
+		doc2: gedcom.NewDocumentWithNodes([]gedcom.Node{elliot}),
+		min:  0.0,
+		wantCompare: gedcom.IndividualComparisons{
+			{elliot, elliot, gedcom.NewSurroundingSimilarity(0.5, 1.0, 1.0, 1.0)},
+		},
+		wantMerge: gedcom.IndividualNodes{
+			elliot,
+		},
+	},
+	"SameIndividualsInDifferentOrder": {
+		doc1: gedcom.NewDocumentWithNodes([]gedcom.Node{elliot, john, jane}),
+		doc2: gedcom.NewDocumentWithNodes([]gedcom.Node{jane, elliot, john}),
+		min:  0.0,
+		wantCompare: gedcom.IndividualComparisons{
+			{elliot, elliot, gedcom.NewSurroundingSimilarity(0.5, 1.0, 1.0, 1.0)},
+			{john, john, gedcom.NewSurroundingSimilarity(0.5, 1.0, 1.0, 1.0)},
+			{jane, jane, gedcom.NewSurroundingSimilarity(0.5, 1.0, 1.0, 1.0)},
+		},
+		wantMerge: gedcom.IndividualNodes{
+			elliot,
+			john,
+			jane,
+		},
+	},
+	"ZeroMinimumSimilarity": {
+		doc1: gedcom.NewDocumentWithNodes([]gedcom.Node{elliot, jane}),
+		doc2: gedcom.NewDocumentWithNodes([]gedcom.Node{jane, john}),
+		min:  0.0,
+		wantCompare: gedcom.IndividualComparisons{
+			// elliot and john match because the minimumSimilarity is so
+			// low.
+			{jane, jane, gedcom.NewSurroundingSimilarity(0.5, 1, 1.0, 1.0)},
+			{elliot, john, gedcom.NewSurroundingSimilarity(0.5, 0.24743589743589745, 1.0, 1.0)},
+		},
+		wantMerge: gedcom.IndividualNodes{
+			jane,
+			gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
+				gedcom.NewNameNode(nil, "Elliot /Chance/", "", nil),
+				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
+					gedcom.NewDateNode(nil, "4 Jan 1803", "", nil), // john
+					gedcom.NewDateNode(nil, "4 Jan 1843", "", nil), // elliot
+				}),
+				gedcom.NewDeathNode(nil, "", "", []gedcom.Node{
+					gedcom.NewDateNode(nil, "17 Mar 1877", "", nil), // john
+					gedcom.NewDateNode(nil, "17 Mar 1907", "", nil), // elliot
+				}),
+				gedcom.NewNameNode(nil, "John /Smith/", "", nil),
+			}),
+		},
+	},
+	"OneMatch": {
+		doc1: gedcom.NewDocumentWithNodes([]gedcom.Node{elliot, jane}),
+		doc2: gedcom.NewDocumentWithNodes([]gedcom.Node{jane, john}),
+		min:  0.75,
+		wantCompare: gedcom.IndividualComparisons{
+			{jane, jane, gedcom.NewSurroundingSimilarity(0.5, 1.0, 1.0, 1.0)},
+			{elliot, nil, nil},
+			{nil, john, nil},
+		},
+		wantMerge: gedcom.IndividualNodes{
+			jane,
+			elliot,
+			john,
+		},
+	},
+	"NoMatches": {
+		doc1: gedcom.NewDocumentWithNodes([]gedcom.Node{elliot, jane}),
+		doc2: gedcom.NewDocumentWithNodes([]gedcom.Node{bob, john}),
+		min:  0.9,
+		wantCompare: gedcom.IndividualComparisons{
+			{elliot, nil, nil},
+			{jane, nil, nil},
+			{nil, bob, nil},
+			{nil, john, nil},
+		},
+		wantMerge: gedcom.IndividualNodes{
+			elliot,
+			jane,
+			bob,
+			john,
+		},
+	},
+}
 
 func TestIndividualNodes_Similarity(t *testing.T) {
 	// ghost:ignore
@@ -340,93 +470,8 @@ func TestIndividualNodes_Similarity(t *testing.T) {
 }
 
 func TestIndividualNodes_Compare(t *testing.T) {
-	elliot := individual("P1", "Elliot /Chance/", "4 Jan 1843", "17 Mar 1907")
-	john := individual("P2", "John /Smith/", "4 Jan 1803", "17 Mar 1877")
-	jane := individual("P3", "Jane /Doe/", "3 Mar 1803", "14 June 1877")
-	bob := individual("P4", "Bob /Jones/", "1749", "1810")
-
-	// ghost:ignore
-	tests := []struct {
-		doc1, doc2 *gedcom.Document
-		min        float64
-		want       []gedcom.IndividualComparison
-	}{
-		{
-			doc1: gedcom.NewDocument(),
-			doc2: gedcom.NewDocument(),
-			min:  0.0,
-			want: []gedcom.IndividualComparison{},
-		},
-		{
-			doc1: gedcom.NewDocumentWithNodes([]gedcom.Node{elliot}),
-			doc2: gedcom.NewDocument(),
-			min:  0.0,
-			want: []gedcom.IndividualComparison{
-				{elliot, nil, gedcom.SurroundingSimilarity{}},
-			},
-		},
-		{
-			doc1: gedcom.NewDocument(),
-			doc2: gedcom.NewDocumentWithNodes([]gedcom.Node{elliot}),
-			min:  0.0,
-			want: []gedcom.IndividualComparison{
-				{nil, elliot, gedcom.SurroundingSimilarity{}},
-			},
-		},
-		{
-			doc1: gedcom.NewDocumentWithNodes([]gedcom.Node{elliot}),
-			doc2: gedcom.NewDocumentWithNodes([]gedcom.Node{elliot}),
-			min:  0.0,
-			want: []gedcom.IndividualComparison{
-				{elliot, elliot, gedcom.SurroundingSimilarity{0.5, 1.0, 1.0, 1.0}},
-			},
-		},
-		{
-			doc1: gedcom.NewDocumentWithNodes([]gedcom.Node{elliot, john, jane}),
-			doc2: gedcom.NewDocumentWithNodes([]gedcom.Node{jane, elliot, john}),
-			min:  0.0,
-			want: []gedcom.IndividualComparison{
-				{elliot, elliot, gedcom.SurroundingSimilarity{0.5, 1.0, 1.0, 1.0}},
-				{john, john, gedcom.SurroundingSimilarity{0.5, 1.0, 1.0, 1.0}},
-				{jane, jane, gedcom.SurroundingSimilarity{0.5, 1.0, 1.0, 1.0}},
-			},
-		},
-		{
-			doc1: gedcom.NewDocumentWithNodes([]gedcom.Node{elliot, jane}),
-			doc2: gedcom.NewDocumentWithNodes([]gedcom.Node{jane, john}),
-			min:  0.0,
-			want: []gedcom.IndividualComparison{
-				// elliot and john match because the minimumSimilarity is so
-				// low.
-				{jane, jane, gedcom.SurroundingSimilarity{0.5, 1, 1.0, 1.0}},
-				{elliot, john, gedcom.SurroundingSimilarity{0.5, 0.24743589743589745, 1.0, 1.0}},
-			},
-		},
-		{
-			doc1: gedcom.NewDocumentWithNodes([]gedcom.Node{elliot, jane}),
-			doc2: gedcom.NewDocumentWithNodes([]gedcom.Node{jane, john}),
-			min:  0.75,
-			want: []gedcom.IndividualComparison{
-				{jane, jane, gedcom.SurroundingSimilarity{0.5, 1.0, 1.0, 1.0}},
-				{elliot, nil, gedcom.SurroundingSimilarity{}},
-				{nil, john, gedcom.SurroundingSimilarity{}},
-			},
-		},
-		{
-			doc1: gedcom.NewDocumentWithNodes([]gedcom.Node{elliot, jane}),
-			doc2: gedcom.NewDocumentWithNodes([]gedcom.Node{bob, john}),
-			min:  0.9,
-			want: []gedcom.IndividualComparison{
-				{elliot, nil, gedcom.SurroundingSimilarity{}},
-				{jane, nil, gedcom.SurroundingSimilarity{}},
-				{nil, bob, gedcom.SurroundingSimilarity{}},
-				{nil, john, gedcom.SurroundingSimilarity{}},
-			},
-		},
-	}
-
-	for _, test := range tests {
-		t.Run("", func(t *testing.T) {
+	for testName, test := range individualNodesTests {
+		t.Run(testName, func(t *testing.T) {
 			for _, n := range test.doc1.Nodes() {
 				n.SetDocument(test.doc1)
 			}
@@ -437,14 +482,81 @@ func TestIndividualNodes_Compare(t *testing.T) {
 			options := gedcom.NewSimilarityOptions()
 			options.MinimumWeightedSimilarity = test.min
 
+			compareOptions := gedcom.NewIndividualNodesCompareOptions()
+			compareOptions.SimilarityOptions = options
+
 			individuals1 := test.doc1.Individuals()
 			individuals2 := test.doc2.Individuals()
-			got := individuals1.Compare(individuals2,
-				&gedcom.IndividualNodesCompareOptions{
-					SimilarityOptions: options,
-				})
+			got := individuals1.Compare(individuals2, compareOptions)
 
-			assert.Equal(t, test.want, got)
+			// The comparison results (got) will include the options from above.
+			// However, the fixture for this test does not provide the
+			// compareOptions as it would make the fixture verbose and
+			// confusing. Instead we set the test.min on each of the comparison
+			// results so that the deep equal passes.
+			for _, x := range test.wantCompare {
+				if x.Similarity != nil {
+					x.Similarity.Options.MinimumWeightedSimilarity = test.min
+				}
+			}
+
+			assertEqual(t, test.wantCompare, got)
 		})
 	}
+}
+
+func assertEqual(t *testing.T, expected, actual interface{}) bool {
+	diff := cmp.Diff(expected, actual, cmpopts.IgnoreUnexported(gedcom.SimpleNode{}, gedcom.IndividualNode{}))
+	if diff != "" {
+		assert.Fail(t, diff)
+	}
+
+	return diff == ""
+}
+
+func TestNewIndividualNodesCompareOptions(t *testing.T) {
+	actual := gedcom.NewIndividualNodesCompareOptions()
+
+	assert.Equal(t, actual.SimilarityOptions, gedcom.NewSimilarityOptions())
+}
+
+func TestIndividualNodes_Nodes(t *testing.T) {
+	Nodes := tf.Function(t, gedcom.IndividualNodes.Nodes)
+
+	i1 := individual("P1", "Elliot /Chance/", "", "")
+	i2 := individual("P2", "Joe /Bloggs/", "", "")
+
+	Nodes(nil).Returns(nil)
+	Nodes(gedcom.IndividualNodes{}).Returns(nil)
+	Nodes(gedcom.IndividualNodes{i1, i2}).Returns([]gedcom.Node{i1, i2})
+}
+
+func TestIndividualNodes_Merge(t *testing.T) {
+	for testName, test := range individualNodesTests {
+		t.Run(testName, func(t *testing.T) {
+			for _, n := range test.doc1.Nodes() {
+				n.SetDocument(test.doc1)
+			}
+			for _, n := range test.doc2.Nodes() {
+				n.SetDocument(test.doc2)
+			}
+
+			options := gedcom.NewSimilarityOptions()
+			options.MinimumWeightedSimilarity = test.min
+
+			compareOptions := gedcom.NewIndividualNodesCompareOptions()
+			compareOptions.SimilarityOptions = options
+
+			individuals1 := test.doc1.Individuals()
+			individuals2 := test.doc2.Individuals()
+			got, err := individuals1.Merge(individuals2, compareOptions)
+
+			assert.NoError(t, err)
+			assertIndividualNodes(t, test.wantMerge, got)
+		})
+	}
+}
+
+func assertIndividualNodes(t *testing.T, expected, actual gedcom.IndividualNodes) {
+	assert.Equal(t, expected.GEDCOMString(0), actual.GEDCOMString(0))
 }

--- a/node.go
+++ b/node.go
@@ -32,16 +32,6 @@ type Node interface {
 	Document() *Document
 	SetDocument(document *Document)
 
-	// AddNode will add a child to this node.
-	//
-	// There is no restriction on whether a node is not allow to have children
-	// so you can expect that no error can occur.
-	//
-	// AddNode will always append the child at the end, even if there is is an
-	// exact child that already exists. However, the order of node in a GEDCOM
-	// file is almost always irrelevant.
-	AddNode(node Node)
-
 	// Equals performs a shallow comparison between two nodes.
 	//
 	// The implementation is different depending on the types of nodes being

--- a/node_set.go
+++ b/node_set.go
@@ -16,7 +16,7 @@ func (ns NodeSet) Add(node Node) {
 	ns[node] = true
 }
 
-// Has returned true if a node exists in the set.
+// Has returns true if a node exists in the set.
 func (ns NodeSet) Has(node Node) bool {
 	_, ok := ns[node]
 

--- a/nodes.go
+++ b/nodes.go
@@ -9,6 +9,19 @@ import (
 type Noder interface {
 	// Nodes returns any child nodes.
 	Nodes() []Node
+
+	// AddNode will add a child to this node.
+	//
+	// There is no restriction on whether a node is not allow to have children
+	// so you can expect that no error can occur.
+	//
+	// AddNode will always append the child at the end, even if there is is an
+	// exact child that already exists. However, the order of node in a GEDCOM
+	// file is almost always irrelevant.
+	AddNode(node Node)
+
+	// SetNodes replaces all of the child nodes.
+	SetNodes(nodes []Node)
 }
 
 // nodeCache is used by NodesWithTag. Even though the lookup of child tags are

--- a/q/question_mark_expr_test.go
+++ b/q/question_mark_expr_test.go
@@ -14,6 +14,7 @@ var documentChoices = []string{
 	".NodeByPointer",
 	".Nodes",
 	".Places",
+	".SetNodes",
 	".Sources",
 	".String",
 }

--- a/simple_node.go
+++ b/simple_node.go
@@ -217,3 +217,10 @@ func (node *SimpleNode) GEDCOMLine(indent int) string {
 
 	return buf.String()
 }
+
+// SetNodes replaces all of the child nodes.
+//
+// You can use SetNodes(nil) to remove all child nodes.
+func (node *SimpleNode) SetNodes(nodes []Node) {
+	node.children = nodes
+}

--- a/simple_node_test.go
+++ b/simple_node_test.go
@@ -134,3 +134,18 @@ func TestSimpleNode_GEDCOMLine(t *testing.T) {
 	GEDCOMLine(gedcom.NewBirthNode(nil, "foo", "72", nil).SimpleNode, -1).
 		Returns("@72@ BIRT foo")
 }
+
+func TestSimpleNode_SetNodes(t *testing.T) {
+	birth := gedcom.NewBirthNode(nil, "foo", "72", nil)
+	assert.Nil(t, birth.Nodes())
+
+	birth.SetNodes([]gedcom.Node{
+		gedcom.NewDateNode(nil, "3 SEP 1945", "", nil),
+	})
+	assert.Equal(t, []gedcom.Node{
+		gedcom.NewDateNode(nil, "3 SEP 1945", "", nil),
+	}, birth.Nodes())
+
+	birth.SetNodes(nil)
+	assert.Nil(t, birth.Nodes())
+}

--- a/surrounding_similarity.go
+++ b/surrounding_similarity.go
@@ -1,5 +1,7 @@
 package gedcom
 
+import "fmt"
+
 // SurroundingSimilarity describes different aspects of the similarity of an
 // individual by its immediate relationships; parents, spouses and children.
 type SurroundingSimilarity struct {
@@ -29,6 +31,23 @@ type SurroundingSimilarity struct {
 	// It is done this way as to not skew the results if any particular parent
 	// is unknown or the child is connected to a different spouse.
 	ChildrenSimilarity float64
+
+	// Options affects the weights and other aspects of the normalised
+	// similarity metrics.
+	Options *SimilarityOptions
+}
+
+// NewSurroundingSimilarity creates a surrounding similarity using default
+// similarity options. You can modify or replace the Options after
+// instantiation.
+func NewSurroundingSimilarity(parentsSimilarity, individualSimilarity, spousesSimilarity, childrenSimilarity float64) *SurroundingSimilarity {
+	return &SurroundingSimilarity{
+		ParentsSimilarity:    parentsSimilarity,
+		IndividualSimilarity: individualSimilarity,
+		SpousesSimilarity:    spousesSimilarity,
+		ChildrenSimilarity:   childrenSimilarity,
+		Options:              NewSimilarityOptions(),
+	}
 }
 
 // WeightedSimilarity calculates a single similarity from all of the similarity
@@ -39,11 +58,18 @@ type SurroundingSimilarity struct {
 //   SpousesSimilarity: ~6.7%
 //   ChildrenSimilarity: ~6.7%
 //
-func (s SurroundingSimilarity) WeightedSimilarity(options *SimilarityOptions) float64 {
-	individual := s.IndividualSimilarity * options.IndividualWeight
-	parents := s.ParentsSimilarity * options.ParentsWeight
-	spouses := s.SpousesSimilarity * options.SpousesWeight
-	children := s.ChildrenSimilarity * options.ChildrenWeight
+func (s SurroundingSimilarity) WeightedSimilarity() float64 {
+	individual := s.IndividualSimilarity * s.Options.IndividualWeight
+	parents := s.ParentsSimilarity * s.Options.ParentsWeight
+	spouses := s.SpousesSimilarity * s.Options.SpousesWeight
+	children := s.ChildrenSimilarity * s.Options.ChildrenWeight
 
 	return individual + parents + spouses + children
+}
+
+// String returns the WeightedSimilarity -- a number between 0.0 and 1.0.
+//
+// The WeightedSimilarity is affected by Options.
+func (s SurroundingSimilarity) String() string {
+	return fmt.Sprintf("%f", s.WeightedSimilarity())
 }

--- a/surrounding_similarity_test.go
+++ b/surrounding_similarity_test.go
@@ -7,16 +7,14 @@ import (
 )
 
 func TestSurroundingSimilarity_WeightedSimilarity(t *testing.T) {
-	WS := tf.Function(t, gedcom.SurroundingSimilarity.WeightedSimilarity)
-	options := gedcom.NewSimilarityOptions()
+	WS := tf.Function(t, (*gedcom.SurroundingSimilarity).WeightedSimilarity)
 
-	WS(gedcom.SurroundingSimilarity{}, options).Returns(0.0)
-	WS(gedcom.SurroundingSimilarity{0.0, 0.0, 0.0, 0.0}, options).Returns(0.0)
-	WS(gedcom.SurroundingSimilarity{1.0, 0.0, 0.0, 0.0}, options).Returns(0.06666666666666666)
-	WS(gedcom.SurroundingSimilarity{0.0, 1.0, 0.0, 0.0}, options).Returns(0.8)
-	WS(gedcom.SurroundingSimilarity{0.0, 0.0, 1.0, 0.0}, options).Returns(0.06666666666666666)
-	WS(gedcom.SurroundingSimilarity{0.0, 0.0, 0.0, 1.0}, options).Returns(0.06666666666666666)
-	WS(gedcom.SurroundingSimilarity{1.0, 0.5, 1.0, 1.0}, options).Returns(0.6)
-	WS(gedcom.SurroundingSimilarity{0.8, 0.8, 0.8, 0.8}, options).Returns(0.8000000000000002)
-	WS(gedcom.SurroundingSimilarity{1.0, 1.0, 1.0, 1.0}, options).Returns(1.0)
+	WS(gedcom.NewSurroundingSimilarity(0.0, 0.0, 0.0, 0.0)).Returns(0.0)
+	WS(gedcom.NewSurroundingSimilarity(1.0, 0.0, 0.0, 0.0)).Returns(0.06666666666666666)
+	WS(gedcom.NewSurroundingSimilarity(0.0, 1.0, 0.0, 0.0)).Returns(0.8)
+	WS(gedcom.NewSurroundingSimilarity(0.0, 0.0, 1.0, 0.0)).Returns(0.06666666666666666)
+	WS(gedcom.NewSurroundingSimilarity(0.0, 0.0, 0.0, 1.0)).Returns(0.06666666666666666)
+	WS(gedcom.NewSurroundingSimilarity(1.0, 0.5, 1.0, 1.0)).Returns(0.6)
+	WS(gedcom.NewSurroundingSimilarity(0.8, 0.8, 0.8, 0.8)).Returns(0.8000000000000002)
+	WS(gedcom.NewSurroundingSimilarity(1.0, 1.0, 1.0, 1.0)).Returns(1.0)
 }


### PR DESCRIPTION
- IndividualNodes.Merge() uses the expensive but more accurate Compare algorithm to determine the best way to merge two slices of individuals.
- Flatten() returns a slice of nodes from a tree structure.
- Node.SetNodes() can be used to replace or remove all child nodes.
- Fixed a bug where MergeNodes() may not correctly childen from two equal nodes.
- MergeDocumentsAndIndividuals() merges two documents while also merging similar individuals.
- github.com/google/go-cmp has been added to make comparing more complex structures easier through assertEquals().
- SurroundingSimilarity now includes the SimilarityOptions as a propety. This makes the interface more friendly and String more appropriate.
- Fixed a bug in MergeNodeSlices() where the right slice may get mangled.
- Added EqualityMergeFunction to be used with MergeSlice as one of the most common use cases.
- Added String() to several existing structures, including IndividualNode that returns a pretty description like "Jane Doe (b. 3 Apr 1923, bur. Abt. 1943)"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/gedcom/188)
<!-- Reviewable:end -->
