### PR TITLE
gedcomdiff: Fix required "-sort". Fixes #196

### DIFF
--- a/gedcomdiff/main.go
+++ b/gedcomdiff/main.go
@@ -148,18 +148,19 @@ func parseCLIFlags() {
 
 	flag.Float64Var(&optionMinimumSimilarity,
 		"minimum-similarity", gedcom.DefaultMinimumSimilarity,
-		util.CLIDescription(`The minimum similarity is the threshold for matching
-			individuals as the same person. This is used to compare only the
-			individual (not surrounding family) like spouses and children.
+		util.CLIDescription(`The minimum similarity is the threshold for
+			matching individuals as the same person. This is used to compare
+			only the individual (not surrounding family) like spouses and
+			children.
 
 			This value must be between 0 and 1 and should be set to the same
 			value as "minimum-weighted-similarity" if you are unsure.`))
 
-	flag.StringVar(&optionSort, "sort", optionSort, util.CLIDescription(`
+	flag.StringVar(&optionSort, "sort", html.DiffPageSortWrittenName,
+		util.CLIDescription(`
 			Controls how the individuals are sorted in the output:
 
-			"written-name": Default. Sort individuals by written their written
-			name.
+			"written-name": Sort individuals by written their written name.
 
 			"highest-similarity": Sort the individuals by their match
 			similarity. Highest matches will appear first.`))


### PR DESCRIPTION
This fixes a bug that lead to "-sort" being required. It is now correctly optional with a default value of "written-name" as originally documented.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/gedcom/198)
<!-- Reviewable:end -->
