### PR TITLE
compare: change DefaultMinimumSimilarity

### DIFF
--- a/individual_nodes.go
+++ b/individual_nodes.go
@@ -16,7 +16,7 @@ import (
 //
 // The value was chosen by running comparison experiments with gedcomtune, a
 // tool to try and find ideal values for constants like this.
-const DefaultMinimumSimilarity = 0.735
+const DefaultMinimumSimilarity = 0.733
 
 // IndividualNodes is a collection of individuals.
 type IndividualNodes []*IndividualNode

--- a/similarity_options_test.go
+++ b/similarity_options_test.go
@@ -8,11 +8,11 @@ import (
 )
 
 func TestSimilarityOptions_String(t *testing.T) {
-	String := tf.Function(t, gedcom.SimilarityOptions.String)
-	options := *gedcom.NewSimilarityOptions()
+	String := tf.NamedFunction(t, "SimilarityOptions_String", (*gedcom.SimilarityOptions).String)
+	options := gedcom.NewSimilarityOptions()
 
-	String(options).Returns("MinimumSimilarity:0.735, " +
-		"MinimumWeightedSimilarity:0.735, " +
+	String(options).Returns("MinimumSimilarity:0.733, " +
+		"MinimumWeightedSimilarity:0.733, " +
 		"MaxYears:3, " +
 		"IndividualWeight:0.8, " +
 		"ParentsWeight:0.06666666666666667, " +
@@ -26,8 +26,10 @@ func TestSimilarityOptions_String(t *testing.T) {
 func TestNewSimilarityOptions(t *testing.T) {
 	options := gedcom.NewSimilarityOptions()
 
-	shouldBeOne := options.IndividualWeight + options.ParentsWeight +
-		options.SpousesWeight + options.ChildrenWeight
+	t.Run("Weights", func(t *testing.T) {
+		shouldBeOne := options.IndividualWeight + options.ParentsWeight +
+			options.SpousesWeight + options.ChildrenWeight
 
-	assert.Equal(t, 1.0, shouldBeOne)
+		assert.Equal(t, 1.0, shouldBeOne)
+	})
 }


### PR DESCRIPTION
DefaultMinimumSimilarity has been changed to 0.733 (and all metrics that depend on this) because there seems to be a sweet spot around 0.733333 when comparing large trees that it should remain just under.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/gedcom/208)
<!-- Reviewable:end -->
