### PR TITLE
gedcom2html: "-living" option. Fixes #212

### DIFF
--- a/gedcomdiff/main.go
+++ b/gedcomdiff/main.go
@@ -113,7 +113,7 @@ func main() {
 	}
 
 	page := html.NewDiffPage(comparisons, filterFlags, optionGoogleAnalyticsID,
-		optionShow, optionSort)
+		optionShow, optionSort, html.LivingVisibilityShow)
 
 	_, err = page.WriteTo(out)
 	if err != nil {

--- a/html/all_parent_buttons.go
+++ b/html/all_parent_buttons.go
@@ -11,12 +11,14 @@ import (
 type AllParentButtons struct {
 	individual *gedcom.IndividualNode
 	document   *gedcom.Document
+	visibility LivingVisibility
 }
 
-func NewAllParentButtons(document *gedcom.Document, individual *gedcom.IndividualNode) *AllParentButtons {
+func NewAllParentButtons(document *gedcom.Document, individual *gedcom.IndividualNode, visibility LivingVisibility) *AllParentButtons {
 	return &AllParentButtons{
 		individual: individual,
 		document:   document,
+		visibility: visibility,
 	}
 }
 
@@ -32,14 +34,17 @@ func (c *AllParentButtons) WriteTo(w io.Writer) (int64, error) {
 			continue
 		}
 
-		components = append(components, NewParentButtons(c.document, family))
+		components = append(components,
+			NewParentButtons(c.document, family, c.visibility))
 	}
 
 	// If there are no families we still want to show an empty family. We just
 	// create a dummy family that has no child nodes.
 	if len(components) == 0 {
 		familyNode := gedcom.NewFamilyNode(nil, "", nil)
-		components = []Component{NewParentButtons(c.document, familyNode)}
+		components = []Component{
+			NewParentButtons(c.document, familyNode, c.visibility),
+		}
 	}
 
 	return NewComponents(components...).WriteTo(w)

--- a/html/components.go
+++ b/html/components.go
@@ -1,6 +1,7 @@
 package html
 
 import (
+	"github.com/elliotchance/gedcom"
 	"io"
 )
 
@@ -11,8 +12,16 @@ type Components struct {
 }
 
 func NewComponents(items ...Component) *Components {
+	nonNilItems := []Component{}
+
+	for _, item := range items {
+		if !gedcom.IsNil(item) {
+			nonNilItems = append(nonNilItems, item)
+		}
+	}
+
 	return &Components{
-		items: items,
+		items: nonNilItems,
 	}
 }
 

--- a/html/diff_page.go
+++ b/html/diff_page.go
@@ -29,15 +29,17 @@ type DiffPage struct {
 	googleAnalyticsID string
 	sort              string
 	show              string
+	visibility        LivingVisibility
 }
 
-func NewDiffPage(comparisons gedcom.IndividualComparisons, filterFlags *util.FilterFlags, googleAnalyticsID string, show, sort string) *DiffPage {
+func NewDiffPage(comparisons gedcom.IndividualComparisons, filterFlags *util.FilterFlags, googleAnalyticsID string, show, sort string, visibility LivingVisibility) *DiffPage {
 	return &DiffPage{
 		comparisons:       comparisons,
 		filterFlags:       filterFlags,
 		googleAnalyticsID: googleAnalyticsID,
 		show:              show,
 		sort:              sort,
+		visibility:        visibility,
 	}
 }
 
@@ -121,8 +123,8 @@ func (c *DiffPage) WriteTo(w io.Writer) (int64, error) {
 			continue
 		}
 
-		leftNameAndDates := NewIndividualNameAndDatesLink(comparison.Left, true, "")
-		rightNameAndDates := NewIndividualNameAndDatesLink(comparison.Right, true, "")
+		leftNameAndDates := NewIndividualNameAndDatesLink(comparison.Left, c.visibility, "")
+		rightNameAndDates := NewIndividualNameAndDatesLink(comparison.Right, c.visibility, "")
 
 		left := NewTableCell(leftNameAndDates).Class(leftClass)
 		right := NewTableCell(rightNameAndDates).Class(rightClass)
@@ -150,7 +152,7 @@ func (c *DiffPage) WriteTo(w io.Writer) (int64, error) {
 			continue
 		}
 
-		compare := NewIndividualCompare(comparison, c.filterFlags)
+		compare := NewIndividualCompare(comparison, c.filterFlags, c.visibility)
 		components = append(components, compare)
 	}
 

--- a/html/diff_page_test.go
+++ b/html/diff_page_test.go
@@ -65,7 +65,8 @@ func TestDiffPage_WriteTo(t *testing.T) {
 	googleAnalyticsID := ""
 
 	component := html.NewDiffPage(comparisons, filterFlags, googleAnalyticsID,
-		html.DiffPageShowAll, html.DiffPageSortHighestSimilarity)
+		html.DiffPageShowAll, html.DiffPageSortHighestSimilarity,
+		html.LivingVisibilityPlaceholder)
 
 	buf := bytes.NewBuffer(nil)
 	component.WriteTo(buf)

--- a/html/family_in_list.go
+++ b/html/family_in_list.go
@@ -6,14 +6,16 @@ import (
 )
 
 type FamilyInList struct {
-	document *gedcom.Document
-	family   *gedcom.FamilyNode
+	document   *gedcom.Document
+	family     *gedcom.FamilyNode
+	visibility LivingVisibility
 }
 
-func NewFamilyInList(document *gedcom.Document, family *gedcom.FamilyNode) *FamilyInList {
+func NewFamilyInList(document *gedcom.Document, family *gedcom.FamilyNode, visibility LivingVisibility) *FamilyInList {
 	return &FamilyInList{
-		document: document,
-		family:   family,
+		document:   document,
+		family:     family,
+		visibility: visibility,
 	}
 }
 
@@ -24,8 +26,8 @@ func (c *FamilyInList) WriteTo(w io.Writer) (int64, error) {
 		date = n.Value()
 	}
 
-	husband := NewIndividualLink(c.document, c.family.Husband())
-	wife := NewIndividualLink(c.document, c.family.Wife())
+	husband := NewIndividualLink(c.document, c.family.Husband(), c.visibility)
+	wife := NewIndividualLink(c.document, c.family.Wife(), c.visibility)
 
 	return NewTableRow(
 		NewTableCell(husband),

--- a/html/family_list_page.go
+++ b/html/family_list_page.go
@@ -9,13 +9,15 @@ type FamilyListPage struct {
 	document          *gedcom.Document
 	googleAnalyticsID string
 	options           PublishShowOptions
+	visibility        LivingVisibility
 }
 
-func NewFamilyListPage(document *gedcom.Document, googleAnalyticsID string, options PublishShowOptions) *FamilyListPage {
+func NewFamilyListPage(document *gedcom.Document, googleAnalyticsID string, options PublishShowOptions, visibility LivingVisibility) *FamilyListPage {
 	return &FamilyListPage{
 		document:          document,
 		googleAnalyticsID: googleAnalyticsID,
 		options:           options,
+		visibility:        visibility,
 	}
 }
 
@@ -25,7 +27,7 @@ func (c *FamilyListPage) WriteTo(w io.Writer) (int64, error) {
 	}
 
 	for _, family := range c.document.Families() {
-		familyInList := NewFamilyInList(c.document, family)
+		familyInList := NewFamilyInList(c.document, family, c.visibility)
 		table = append(table, familyInList)
 	}
 

--- a/html/individual_button_test.go
+++ b/html/individual_button_test.go
@@ -11,6 +11,6 @@ func TestIndividualButton_WriteTo(t *testing.T) {
 
 	doc := gedcom.NewDocumentWithNodes([]gedcom.Node{elliot})
 
-	c(html.NewIndividualButton(doc, elliot)).
+	c(html.NewIndividualButton(doc, elliot, html.LivingVisibilityPlaceholder)).
 		Returns("<button class=\"btn btn-outline-info btn-block\" onclick=\"location.href='elliot-chance.html'\" type=\"button\"><strong>Elliot Chance</strong><br/><em>b.</em> 4 Jan 1843&nbsp;&nbsp;&nbsp;<em>d.</em> 17 Mar 1907&nbsp;</button>")
 }

--- a/html/individual_compare.go
+++ b/html/individual_compare.go
@@ -9,12 +9,14 @@ import (
 type IndividualCompare struct {
 	comparison  *gedcom.IndividualComparison
 	filterFlags *util.FilterFlags
+	visibility  LivingVisibility
 }
 
-func NewIndividualCompare(comparison *gedcom.IndividualComparison, filterFlags *util.FilterFlags) *IndividualCompare {
+func NewIndividualCompare(comparison *gedcom.IndividualComparison, filterFlags *util.FilterFlags, visibility LivingVisibility) *IndividualCompare {
 	return &IndividualCompare{
 		comparison:  comparison,
 		filterFlags: filterFlags,
+		visibility:  visibility,
 	}
 }
 
@@ -38,11 +40,11 @@ func (c *IndividualCompare) WriteTo(w io.Writer) (int64, error) {
 	var name Component = nil
 
 	if n := left; n != nil {
-		name = NewIndividualNameAndDates(n, true, "")
+		name = NewIndividualNameAndDates(n, c.visibility, "")
 	}
 
 	if n := right; name == nil && n != nil {
-		name = NewIndividualNameAndDates(n, true, "")
+		name = NewIndividualNameAndDates(n, c.visibility, "")
 	}
 
 	if name == nil {

--- a/html/individual_dates.go
+++ b/html/individual_dates.go
@@ -7,13 +7,13 @@ import (
 
 type IndividualDates struct {
 	individual *gedcom.IndividualNode
-	showLiving bool
+	visibility LivingVisibility
 }
 
-func NewIndividualDates(individual *gedcom.IndividualNode, showLiving bool) *IndividualDates {
+func NewIndividualDates(individual *gedcom.IndividualNode, visibility LivingVisibility) *IndividualDates {
 	return &IndividualDates{
 		individual: individual,
-		showLiving: showLiving,
+		visibility: visibility,
 	}
 }
 
@@ -30,7 +30,13 @@ func (c *IndividualDates) IsBlank() bool {
 }
 
 func (c *IndividualDates) WriteTo(w io.Writer) (int64, error) {
-	if c.individual != nil && c.individual.IsLiving() && !c.showLiving {
+	isLiving := c.individual != nil && c.individual.IsLiving()
+
+	if isLiving && c.visibility == LivingVisibilityHide {
+		return writeNothing()
+	}
+
+	if isLiving && c.visibility == LivingVisibilityPlaceholder {
 		return NewText("living").WriteTo(w)
 	}
 

--- a/html/individual_dates_test.go
+++ b/html/individual_dates_test.go
@@ -8,6 +8,6 @@ import (
 func TestIndividualDates_WriteTo(t *testing.T) {
 	c := testComponent(t, "IndividualDates")
 
-	c(html.NewIndividualDates(elliot, true)).
+	c(html.NewIndividualDates(elliot, html.LivingVisibilityPlaceholder)).
 		Returns("<em>b.</em> 4 Jan 1843&nbsp;&nbsp;&nbsp;<em>d.</em> 17 Mar 1907")
 }

--- a/html/individual_events.go
+++ b/html/individual_events.go
@@ -11,12 +11,14 @@ import (
 type IndividualEvents struct {
 	document   *gedcom.Document
 	individual *gedcom.IndividualNode
+	visibility LivingVisibility
 }
 
-func newIndividualEvents(document *gedcom.Document, individual *gedcom.IndividualNode) *IndividualEvents {
+func newIndividualEvents(document *gedcom.Document, individual *gedcom.IndividualNode, visibility LivingVisibility) *IndividualEvents {
 	return &IndividualEvents{
 		document:   document,
 		individual: individual,
+		visibility: visibility,
 	}
 }
 
@@ -52,7 +54,7 @@ func (c *IndividualEvents) WriteTo(w io.Writer) (int64, error) {
 			description = NewHTML(UnknownEmphasis)
 
 			if wife := family.Wife(); wife != nil {
-				description = NewIndividualLink(c.document, wife)
+				description = NewIndividualLink(c.document, wife, c.visibility)
 			}
 		}
 
@@ -60,7 +62,7 @@ func (c *IndividualEvents) WriteTo(w io.Writer) (int64, error) {
 			description = NewHTML(UnknownEmphasis)
 
 			if husband := family.Husband(); husband != nil {
-				description = NewIndividualLink(c.document, husband)
+				description = NewIndividualLink(c.document, husband, c.visibility)
 			}
 		}
 

--- a/html/individual_in_list.go
+++ b/html/individual_in_list.go
@@ -10,12 +10,14 @@ import (
 type IndividualInList struct {
 	individual *gedcom.IndividualNode
 	document   *gedcom.Document
+	visibility LivingVisibility
 }
 
-func NewIndividualInList(document *gedcom.Document, individual *gedcom.IndividualNode) *IndividualInList {
+func NewIndividualInList(document *gedcom.Document, individual *gedcom.IndividualNode, visibility LivingVisibility) *IndividualInList {
 	return &IndividualInList{
 		individual: individual,
 		document:   document,
+		visibility: visibility,
 	}
 }
 
@@ -29,7 +31,7 @@ func (c *IndividualInList) WriteTo(w io.Writer) (int64, error) {
 	birthDateText := NewText(gedcom.String(birthDate))
 	deathDateText := NewText(gedcom.String(deathDate))
 
-	link := NewIndividualLink(c.document, c.individual)
+	link := NewIndividualLink(c.document, c.individual, c.visibility)
 	birthPlaceLink := NewPlaceLink(c.document, birthPlaceName)
 	deathPlaceLink := NewPlaceLink(c.document, deathPlaceName)
 	birthLines := NewLines(birthDateText, birthPlaceLink)

--- a/html/individual_name.go
+++ b/html/individual_name.go
@@ -13,14 +13,14 @@ const UnknownEmphasis = "<em>Unknown</em>"
 // individual.
 type IndividualName struct {
 	individual  *gedcom.IndividualNode
-	showLiving  bool
+	visibility  LivingVisibility
 	unknownHTML string
 }
 
-func NewIndividualName(individual *gedcom.IndividualNode, showLiving bool, unknownHTML string) *IndividualName {
+func NewIndividualName(individual *gedcom.IndividualNode, visibility LivingVisibility, unknownHTML string) *IndividualName {
 	return &IndividualName{
 		individual:  individual,
-		showLiving:  showLiving,
+		visibility:  visibility,
 		unknownHTML: unknownHTML,
 	}
 }
@@ -35,8 +35,17 @@ func (c *IndividualName) WriteTo(w io.Writer) (int64, error) {
 	}
 
 	isLiving := c.individual.IsLiving()
-	if isLiving && !c.showLiving {
-		return writeString(w, "<em>Hidden</em>")
+	if isLiving {
+		switch c.visibility {
+		case LivingVisibilityShow:
+			// Proceed.
+
+		case LivingVisibilityHide:
+			return writeNothing()
+
+		case LivingVisibilityPlaceholder:
+			return writeString(w, "<em>Hidden</em>")
+		}
 	}
 
 	names := c.individual.Names()

--- a/html/individual_name_and_dates.go
+++ b/html/individual_name_and_dates.go
@@ -7,21 +7,21 @@ import (
 
 type IndividualNameAndDates struct {
 	individual  *gedcom.IndividualNode
-	showLiving  bool
+	visibility  LivingVisibility
 	unknownText string
 }
 
-func NewIndividualNameAndDates(individual *gedcom.IndividualNode, showLiving bool, unknownText string) *IndividualNameAndDates {
+func NewIndividualNameAndDates(individual *gedcom.IndividualNode, visibility LivingVisibility, unknownText string) *IndividualNameAndDates {
 	return &IndividualNameAndDates{
 		individual:  individual,
-		showLiving:  showLiving,
+		visibility:  visibility,
 		unknownText: unknownText,
 	}
 }
 
 func (c *IndividualNameAndDates) WriteTo(w io.Writer) (int64, error) {
-	name := NewIndividualName(c.individual, c.showLiving, c.unknownText)
-	dates := NewIndividualDates(c.individual, c.showLiving)
+	name := NewIndividualName(c.individual, c.visibility, c.unknownText)
+	dates := NewIndividualDates(c.individual, c.visibility)
 
 	if name.IsUnknown() || dates.IsBlank() {
 		return name.WriteTo(w)

--- a/html/individual_name_and_dates_link.go
+++ b/html/individual_name_and_dates_link.go
@@ -8,14 +8,14 @@ import (
 
 type IndividualNameAndDatesLink struct {
 	individual  *gedcom.IndividualNode
-	showLiving  bool
+	visibility  LivingVisibility
 	unknownText string
 }
 
-func NewIndividualNameAndDatesLink(individual *gedcom.IndividualNode, showLiving bool, unknownText string) *IndividualNameAndDatesLink {
+func NewIndividualNameAndDatesLink(individual *gedcom.IndividualNode, visibility LivingVisibility, unknownText string) *IndividualNameAndDatesLink {
 	return &IndividualNameAndDatesLink{
 		individual:  individual,
-		showLiving:  showLiving,
+		visibility:  visibility,
 		unknownText: unknownText,
 	}
 }
@@ -25,7 +25,7 @@ func (c *IndividualNameAndDatesLink) WriteTo(w io.Writer) (int64, error) {
 		return writeNothing()
 	}
 
-	text := NewIndividualNameAndDates(c.individual, c.showLiving, c.unknownText)
+	text := NewIndividualNameAndDates(c.individual, c.visibility, c.unknownText)
 	link := fmt.Sprintf("#%s", c.individual.Pointer())
 
 	return NewLink(text, link).Style("color: black").WriteTo(w)

--- a/html/individual_page.go
+++ b/html/individual_page.go
@@ -12,29 +12,31 @@ type IndividualPage struct {
 	individual        *gedcom.IndividualNode
 	googleAnalyticsID string
 	options           PublishShowOptions
+	visibility        LivingVisibility
 }
 
-func NewIndividualPage(document *gedcom.Document, individual *gedcom.IndividualNode, googleAnalyticsID string, options PublishShowOptions) *IndividualPage {
+func NewIndividualPage(document *gedcom.Document, individual *gedcom.IndividualNode, googleAnalyticsID string, options PublishShowOptions, visibility LivingVisibility) *IndividualPage {
 	return &IndividualPage{
 		document:          document,
 		individual:        individual,
 		googleAnalyticsID: googleAnalyticsID,
 		options:           options,
+		visibility:        visibility,
 	}
 }
 
 func (c *IndividualPage) WriteTo(w io.Writer) (int64, error) {
 	name := c.individual.Names()[0]
 
-	individualName := NewIndividualName(c.individual, false,
+	individualName := NewIndividualName(c.individual, c.visibility,
 		UnknownEmphasis)
-	individualDates := NewIndividualDates(c.individual, false)
+	individualDates := NewIndividualDates(c.individual, c.visibility)
 
 	return NewPage(
 		name.String(),
 		NewComponents(
 			NewPublishHeader(c.document, name.String(), selectedExtraTab, c.options),
-			NewAllParentButtons(c.document, c.individual),
+			NewAllParentButtons(c.document, c.individual, c.visibility),
 			NewBigTitle(1, individualName),
 			NewBigTitle(3, individualDates),
 			NewHorizontalRuleRow(),
@@ -43,9 +45,9 @@ func (c *IndividualPage) WriteTo(w io.Writer) (int64, error) {
 				NewColumn(HalfRow, NewIndividualAdditionalNames(c.individual)),
 			),
 			NewSpace(),
-			newIndividualEvents(c.document, c.individual),
+			newIndividualEvents(c.document, c.individual, c.visibility),
 			NewSpace(),
-			NewPartnersAndChildren(c.document, c.individual),
+			NewPartnersAndChildren(c.document, c.individual, c.visibility),
 		),
 		c.googleAnalyticsID,
 	).WriteTo(w)

--- a/html/individual_statistics.go
+++ b/html/individual_statistics.go
@@ -6,12 +6,14 @@ import (
 )
 
 type IndividualStatistics struct {
-	document *gedcom.Document
+	document   *gedcom.Document
+	visibility LivingVisibility
 }
 
-func NewIndividualStatistics(document *gedcom.Document) *IndividualStatistics {
+func NewIndividualStatistics(document *gedcom.Document, visibility LivingVisibility) *IndividualStatistics {
 	return &IndividualStatistics{
-		document: document,
+		document:   document,
+		visibility: visibility,
 	}
 }
 
@@ -30,6 +32,18 @@ func (c *IndividualStatistics) WriteTo(w io.Writer) (int64, error) {
 	totalRow := NewKeyedTableRow("Total", NewNumber(total), true)
 	livingRow := NewKeyedTableRow("Living", NewNumber(living), true)
 	deadRow := NewKeyedTableRow("Dead", NewNumber(total-living), true)
+
+	switch c.visibility {
+	case LivingVisibilityShow, LivingVisibilityPlaceholder:
+		// Proceed.
+
+	case LivingVisibilityHide:
+		// We need to pretend like there were never any living individuals in
+		// the document at all.
+		totalRow = NewKeyedTableRow("Total", NewNumber(total-living), true)
+		livingRow = NewKeyedTableRow("Living", NewNumber(0), true)
+		deadRow = NewKeyedTableRow("Dead", NewNumber(total-living), true)
+	}
 
 	s := NewComponents(totalRow, livingRow, deadRow)
 

--- a/html/living_visibility.go
+++ b/html/living_visibility.go
@@ -1,0 +1,20 @@
+package html
+
+type LivingVisibility string
+
+const (
+	LivingVisibilityShow        = "show"
+	LivingVisibilityHide        = "hide"
+	LivingVisibilityPlaceholder = "placeholder"
+)
+
+func NewLivingVisibility(lv string) LivingVisibility {
+	switch LivingVisibility(lv) {
+	case LivingVisibilityShow,
+		LivingVisibilityHide,
+		LivingVisibilityPlaceholder:
+		return LivingVisibility(lv)
+	}
+
+	panic("invalid LivingVisibility: " + lv)
+}

--- a/html/living_visibility_test.go
+++ b/html/living_visibility_test.go
@@ -1,0 +1,20 @@
+package html_test
+
+import (
+	"github.com/elliotchance/gedcom/html"
+	"github.com/elliotchance/tf"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestNewLivingVisibility(t *testing.T) {
+	NewLivingVisibility := tf.Function(t, html.NewLivingVisibility)
+
+	NewLivingVisibility("show").Returns(html.LivingVisibilityShow)
+	NewLivingVisibility("hide").Returns(html.LivingVisibilityHide)
+	NewLivingVisibility("placeholder").Returns(html.LivingVisibilityPlaceholder)
+
+	assert.PanicsWithValue(t, "invalid LivingVisibility: foo", func() {
+		html.NewLivingVisibility("foo")
+	})
+}

--- a/html/parent_buttons.go
+++ b/html/parent_buttons.go
@@ -8,20 +8,22 @@ import (
 // ParentButtons show two buttons separated by a "T" to be placed above the
 // large individuals name.
 type ParentButtons struct {
-	family   *gedcom.FamilyNode
-	document *gedcom.Document
+	family     *gedcom.FamilyNode
+	document   *gedcom.Document
+	visibility LivingVisibility
 }
 
-func NewParentButtons(document *gedcom.Document, family *gedcom.FamilyNode) *ParentButtons {
+func NewParentButtons(document *gedcom.Document, family *gedcom.FamilyNode, visibility LivingVisibility) *ParentButtons {
 	return &ParentButtons{
-		family:   family,
-		document: document,
+		family:     family,
+		document:   document,
+		visibility: visibility,
 	}
 }
 
 func (c *ParentButtons) WriteTo(w io.Writer) (int64, error) {
-	husband := NewIndividualButton(c.document, c.family.Husband())
-	wife := NewIndividualButton(c.document, c.family.Wife())
+	husband := NewIndividualButton(c.document, c.family.Husband(), c.visibility)
+	wife := NewIndividualButton(c.document, c.family.Wife(), c.visibility)
 	svg := NewPlusSVG(false, true, true, true)
 	space := NewSpace()
 

--- a/html/place_page.go
+++ b/html/place_page.go
@@ -10,14 +10,16 @@ type PlacePage struct {
 	placeKey          string
 	googleAnalyticsID string
 	options           PublishShowOptions
+	visibility        LivingVisibility
 }
 
-func NewPlacePage(document *gedcom.Document, placeKey string, googleAnalyticsID string, options PublishShowOptions) *PlacePage {
+func NewPlacePage(document *gedcom.Document, placeKey string, googleAnalyticsID string, options PublishShowOptions, visibility LivingVisibility) *PlacePage {
 	return &PlacePage{
 		document:          document,
 		placeKey:          placeKey,
 		googleAnalyticsID: googleAnalyticsID,
 		options:           options,
+		visibility:        visibility,
 	}
 }
 
@@ -29,7 +31,7 @@ func (c *PlacePage) WriteTo(w io.Writer) (int64, error) {
 	}
 
 	for _, node := range place.nodes {
-		placeEvent := NewPlaceEvent(c.document, node)
+		placeEvent := NewPlaceEvent(c.document, node, c.visibility)
 		table = append(table, placeEvent)
 	}
 

--- a/html/statistics_page.go
+++ b/html/statistics_page.go
@@ -9,13 +9,15 @@ type StatisticsPage struct {
 	document          *gedcom.Document
 	googleAnalyticsID string
 	options           PublishShowOptions
+	visibility        LivingVisibility
 }
 
-func NewStatisticsPage(document *gedcom.Document, googleAnalyticsID string, options PublishShowOptions) *StatisticsPage {
+func NewStatisticsPage(document *gedcom.Document, googleAnalyticsID string, options PublishShowOptions, visibility LivingVisibility) *StatisticsPage {
 	return &StatisticsPage{
 		document:          document,
 		googleAnalyticsID: googleAnalyticsID,
 		options:           options,
+		visibility:        visibility,
 	}
 }
 
@@ -28,7 +30,7 @@ func (c *StatisticsPage) WriteTo(w io.Writer) (int64, error) {
 			NewSpace(),
 			NewRow(
 				NewColumn(HalfRow, NewComponents(
-					NewIndividualStatistics(c.document),
+					NewIndividualStatistics(c.document, c.visibility),
 					NewSpace(),
 					NewFamilyStatistics(c.document),
 					NewSpace(),

--- a/html/surname_index.go
+++ b/html/surname_index.go
@@ -10,12 +10,14 @@ import (
 type SurnameIndex struct {
 	document       *gedcom.Document
 	selectedLetter rune
+	visibility     LivingVisibility
 }
 
-func NewSurnameIndex(document *gedcom.Document, selectedLetter rune) *SurnameIndex {
+func NewSurnameIndex(document *gedcom.Document, selectedLetter rune, visibility LivingVisibility) *SurnameIndex {
 	return &SurnameIndex{
 		document:       document,
 		selectedLetter: selectedLetter,
+		visibility:     visibility,
 	}
 }
 
@@ -24,7 +26,13 @@ func (c *SurnameIndex) WriteTo(w io.Writer) (int64, error) {
 
 	for _, individual := range c.document.Individuals() {
 		if individual.IsLiving() {
-			continue
+			switch c.visibility {
+			case LivingVisibilityHide, LivingVisibilityPlaceholder:
+				continue
+
+			case LivingVisibilityShow:
+				// Proceed.
+			}
 		}
 
 		surname := individual.Name().Surname()

--- a/html/util.go
+++ b/html/util.go
@@ -62,7 +62,17 @@ func PageIndividuals(firstLetter rune) string {
 	return fmt.Sprintf("individuals-%c.html", firstLetter)
 }
 
-func PageIndividual(document *gedcom.Document, individual *gedcom.IndividualNode) string {
+func PageIndividual(document *gedcom.Document, individual *gedcom.IndividualNode, visibility LivingVisibility) string {
+	if individual.IsLiving() {
+		switch visibility {
+		case LivingVisibilityHide, LivingVisibilityPlaceholder:
+			return "#"
+
+		case LivingVisibilityShow:
+			// Proceed.
+		}
+	}
+
 	individuals := GetIndividuals(document)
 
 	for key, value := range individuals {


### PR DESCRIPTION
Controls how information for living individuals are handled:

"show": Show all living individuals and their information.

"hide": Remove all living individuals as if they never existed.

"placeholder": Show a "Hidden" placeholder that only that
individuals are known but will not be displayed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/gedcom/213)
<!-- Reviewable:end -->
