### PR TITLE
gedcomdiff: Added -prefer-pointer-above

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,16 @@ github.com/elliotchance/gedcom
 [![Join the chat at https://gitter.im/gedcom-app/community](https://badges.gitter.im/gedcom-app/community.svg)](https://gitter.im/gedcom-app/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Maintainability](https://api.codeclimate.com/v1/badges/1a31841a6c25ca0e5c24/maintainability)](https://codeclimate.com/github/elliotchance/gedcom/maintainability)
 
+---
+
+### You can use most of the tools right now for free at:
+### [https://gedcom.app](https://gedcom.app).
+
+**Have questions? Want to get help or give feedback? Discuss new features? Join the chat:
+[![Join the chat at https://gitter.im/gedcom-app/community](https://badges.gitter.im/gedcom-app/community.svg)](https://gitter.im/gedcom-app/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)**
+
+---
+
 `github.com/elliotchance/gedcom` is an advanced Go-style library and set of
 command-line tools for dealing with
 [GEDCOM files](https://en.wikipedia.org/wiki/GEDCOM).
@@ -15,8 +25,29 @@ You can download the latest binaries for macOS, Windows and Linux on the
 [Releases page](https://github.com/elliotchance/gedcom/releases). This will not
 require you to install Go or any other dependencies.
 
-**Have questions? Want to get help or give feedback? Discuss new features? Join the chat: 
-[![Join the chat at https://gitter.im/gedcom-app/community](https://badges.gitter.im/gedcom-app/community.svg)](https://gitter.im/gedcom-app/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)**
+What Can It Do?
+---------------
+
+* **Decode and encode** GEDCOM files.
+
+* **Traverse and manipulate** GEDCOM files with the provided API.
+
+* A powerful **query language called
+[gedcomq](https://godoc.org/github.com/elliotchance/gedcom/gedcomq)** lets you
+query GEDCOM files with a CLI tool. It can output CSV, JSON and other GEDCOM
+files.
+
+* Render GEDCOM files as **fully static HTML websites**. See an example at
+[http://dechauncy.family](http://dechauncy.family).
+
+* **Compare GEDCOM files** from the same or different providers to find
+differences using the very advanced and configurable tool:
+[gedcomdiff](https://godoc.org/github.com/elliotchance/gedcom/gedcomdiff).
+
+* **Merge GEDCOM files** using the same advanced Compare algorithm with gedcomq.
+
+Packages
+--------
 
 | Package              | Description |
 | -------------------- | ----------- |

--- a/html/card.go
+++ b/html/card.go
@@ -11,12 +11,12 @@ const (
 
 // Card is a simple box with a header and body section.
 type Card struct {
-	title string
+	title Component
 	body  Component
 	count int
 }
 
-func NewCard(title string, count int, body Component) *Card {
+func NewCard(title Component, count int, body Component) *Card {
 	return &Card{
 		title: title,
 		body:  body,
@@ -25,10 +25,10 @@ func NewCard(title string, count int, body Component) *Card {
 }
 
 func (c *Card) WriteTo(w io.Writer) (int64, error) {
-	var count Component = NewText(c.title)
+	var count = c.title
 	if c.count != noBadgeCount {
 		count = NewComponents(
-			NewText(c.title),
+			c.title,
 			NewBadgePill("secondary", "float-right",
 				NewText(strconv.Itoa(c.count))),
 		)

--- a/html/diff_page_test.go
+++ b/html/diff_page_test.go
@@ -64,9 +64,10 @@ func TestDiffPage_WriteTo(t *testing.T) {
 	filterFlags := &util.FilterFlags{}
 	googleAnalyticsID := ""
 
+	compareOptions := gedcom.NewIndividualNodesCompareOptions()
 	component := html.NewDiffPage(comparisons, filterFlags, googleAnalyticsID,
-		html.DiffPageShowAll, html.DiffPageSortHighestSimilarity,
-		html.LivingVisibilityPlaceholder)
+		html.DiffPageShowAll, html.DiffPageSortHighestSimilarity, nil,
+		compareOptions, html.LivingVisibilityPlaceholder)
 
 	buf := bytes.NewBuffer(nil)
 	component.WriteTo(buf)

--- a/html/event_statistics.go
+++ b/html/event_statistics.go
@@ -49,5 +49,5 @@ func (c *EventStatistics) WriteTo(w io.Writer) (int64, error) {
 
 	table := NewTable("", NewComponents(rows...))
 
-	return NewCard("Events", noBadgeCount, table).WriteTo(w)
+	return NewCard(NewText("Events"), noBadgeCount, table).WriteTo(w)
 }

--- a/html/family_statistics.go
+++ b/html/family_statistics.go
@@ -41,5 +41,6 @@ func (c *FamilyStatistics) WriteTo(w io.Writer) (int64, error) {
 
 	s := NewComponents(totalFamiliesRow, marriageCountRow, divorceCountRow)
 
-	return NewCard("Families", noBadgeCount, NewTable("", s)).WriteTo(w)
+	return NewCard(NewText("Families"), noBadgeCount, NewTable("", s)).
+		WriteTo(w)
 }

--- a/html/individual_additional_names.go
+++ b/html/individual_additional_names.go
@@ -29,5 +29,5 @@ func (c *IndividualAdditionalNames) WriteTo(w io.Writer) (int64, error) {
 
 	table := NewTable("", rows...)
 
-	return NewCard("Additional Names", len(names)-1, table).WriteTo(w)
+	return NewCard(NewText("Additional Names"), len(names)-1, table).WriteTo(w)
 }

--- a/html/individual_events.go
+++ b/html/individual_events.go
@@ -95,6 +95,6 @@ func (c *IndividualEvents) WriteTo(w io.Writer) (int64, error) {
 	s := NewTable("text-center", tableHead, components)
 
 	return NewRow(NewColumn(EntireRow,
-		NewCard("Events", len(events), s),
+		NewCard(NewText("Events"), len(events), s),
 	)).WriteTo(w)
 }

--- a/html/individual_name_and_sex.go
+++ b/html/individual_name_and_sex.go
@@ -46,7 +46,7 @@ func (c *IndividualNameAndSex) WriteTo(w io.Writer) (int64, error) {
 		sexRow,
 	)
 
-	return NewCard("Name & Sex", noBadgeCount, NewTable("", s)).WriteTo(w)
+	return NewCard(NewText("Name & Sex"), noBadgeCount, NewTable("", s)).WriteTo(w)
 }
 
 func keyedRow(title, value string) *KeyedTableRow {

--- a/html/individual_statistics.go
+++ b/html/individual_statistics.go
@@ -47,7 +47,7 @@ func (c *IndividualStatistics) WriteTo(w io.Writer) (int64, error) {
 
 	s := NewComponents(totalRow, livingRow, deadRow)
 
-	return NewCard("Individuals", noBadgeCount, NewTable("", s)).WriteTo(w)
+	return NewCard(NewText("Individuals"), noBadgeCount, NewTable("", s)).WriteTo(w)
 }
 
 func keyedNumberRow(title string, total int) *KeyedTableRow {

--- a/html/place_statistics.go
+++ b/html/place_statistics.go
@@ -22,5 +22,5 @@ func (c *PlaceStatistics) WriteTo(w io.Writer) (int64, error) {
 		NewKeyedTableRow("Total", total, true),
 	)
 
-	return NewCard("Places", noBadgeCount, NewTable("", s)).WriteTo(w)
+	return NewCard(NewText("Places"), noBadgeCount, NewTable("", s)).WriteTo(w)
 }

--- a/html/source_statistics.go
+++ b/html/source_statistics.go
@@ -22,5 +22,5 @@ func (c *SourceStatistics) WriteTo(w io.Writer) (int64, error) {
 		NewKeyedTableRow("Total", total, true),
 	)
 
-	return NewCard("Sources", noBadgeCount, NewTable("", s)).WriteTo(w)
+	return NewCard(NewText("Sources"), noBadgeCount, NewTable("", s)).WriteTo(w)
 }

--- a/individual_nodes_test.go
+++ b/individual_nodes_test.go
@@ -11,83 +11,94 @@ import (
 )
 
 var (
+	// John and Jane share the same pointer on purpose. They will be used for
+	// pointer comparisons.
 	elliot = individual("P1", "Elliot /Chance/", "4 Jan 1843", "17 Mar 1907")
 	john   = individual("P2", "John /Smith/", "4 Jan 1803", "17 Mar 1877")
-	jane   = individual("P3", "Jane /Doe/", "3 Mar 1803", "14 June 1877")
+	jane   = individual("P2", "Jane /Doe/", "3 Mar 1803", "14 June 1877")
 	bob    = individual("P4", "Bob /Jones/", "1749", "1810")
 )
 
 var individualNodesTests = map[string]struct {
-	doc1, doc2  *gedcom.Document
-	min         float64
-	wantCompare gedcom.IndividualComparisons
-	wantMerge   gedcom.IndividualNodes
+	Doc1, Doc2 *gedcom.Document
+
+	MinimumWeightedSimilarity float64
+	PreferPointerAbove        float64
+
+	WantCompare gedcom.IndividualComparisons
+	WantMerge   gedcom.IndividualNodes
 }{
 	"BothDocumentsEmpty": {
-		doc1:        gedcom.NewDocument(),
-		doc2:        gedcom.NewDocument(),
-		min:         0.0,
-		wantCompare: gedcom.IndividualComparisons{},
+		Doc1: gedcom.NewDocument(),
+		Doc2: gedcom.NewDocument(),
+		MinimumWeightedSimilarity: 0.0,
+		PreferPointerAbove:        1.0,
+		WantCompare:               gedcom.IndividualComparisons{},
 	},
 	"Doc2Empty": {
-		doc1: gedcom.NewDocumentWithNodes([]gedcom.Node{elliot}),
-		doc2: gedcom.NewDocument(),
-		min:  0.0,
-		wantCompare: gedcom.IndividualComparisons{
+		Doc1: gedcom.NewDocumentWithNodes([]gedcom.Node{elliot}),
+		Doc2: gedcom.NewDocument(),
+		MinimumWeightedSimilarity: 0.0,
+		PreferPointerAbove:        1.0,
+		WantCompare: gedcom.IndividualComparisons{
 			{elliot, nil, nil},
 		},
-		wantMerge: gedcom.IndividualNodes{
+		WantMerge: gedcom.IndividualNodes{
 			elliot,
 		},
 	},
 	"Doc1Empty": {
-		doc1: gedcom.NewDocument(),
-		doc2: gedcom.NewDocumentWithNodes([]gedcom.Node{elliot}),
-		min:  0.0,
-		wantCompare: gedcom.IndividualComparisons{
+		Doc1: gedcom.NewDocument(),
+		Doc2: gedcom.NewDocumentWithNodes([]gedcom.Node{elliot}),
+		MinimumWeightedSimilarity: 0.0,
+		PreferPointerAbove:        1.0,
+		WantCompare: gedcom.IndividualComparisons{
 			{nil, elliot, nil},
 		},
-		wantMerge: gedcom.IndividualNodes{
+		WantMerge: gedcom.IndividualNodes{
 			elliot,
 		},
 	},
 	"SameIndividualInBothDocuments": {
-		doc1: gedcom.NewDocumentWithNodes([]gedcom.Node{elliot}),
-		doc2: gedcom.NewDocumentWithNodes([]gedcom.Node{elliot}),
-		min:  0.0,
-		wantCompare: gedcom.IndividualComparisons{
+		Doc1: gedcom.NewDocumentWithNodes([]gedcom.Node{elliot}),
+		Doc2: gedcom.NewDocumentWithNodes([]gedcom.Node{elliot}),
+		MinimumWeightedSimilarity: 0.0,
+		PreferPointerAbove:        1.0,
+		WantCompare: gedcom.IndividualComparisons{
 			{elliot, elliot, gedcom.NewSurroundingSimilarity(0.5, 1.0, 1.0, 1.0)},
 		},
-		wantMerge: gedcom.IndividualNodes{
+		WantMerge: gedcom.IndividualNodes{
 			elliot,
 		},
 	},
 	"SameIndividualsInDifferentOrder": {
-		doc1: gedcom.NewDocumentWithNodes([]gedcom.Node{elliot, john, jane}),
-		doc2: gedcom.NewDocumentWithNodes([]gedcom.Node{jane, elliot, john}),
-		min:  0.0,
-		wantCompare: gedcom.IndividualComparisons{
+		Doc1: gedcom.NewDocumentWithNodes([]gedcom.Node{elliot, john, jane}),
+		Doc2: gedcom.NewDocumentWithNodes([]gedcom.Node{jane, elliot, john}),
+		MinimumWeightedSimilarity: 0.0,
+		PreferPointerAbove:        1.0,
+		WantCompare: gedcom.IndividualComparisons{
 			{elliot, elliot, gedcom.NewSurroundingSimilarity(0.5, 1.0, 1.0, 1.0)},
 			{john, john, gedcom.NewSurroundingSimilarity(0.5, 1.0, 1.0, 1.0)},
 			{jane, jane, gedcom.NewSurroundingSimilarity(0.5, 1.0, 1.0, 1.0)},
 		},
-		wantMerge: gedcom.IndividualNodes{
+		WantMerge: gedcom.IndividualNodes{
 			elliot,
 			john,
 			jane,
 		},
 	},
 	"ZeroMinimumSimilarity": {
-		doc1: gedcom.NewDocumentWithNodes([]gedcom.Node{elliot, jane}),
-		doc2: gedcom.NewDocumentWithNodes([]gedcom.Node{jane, john}),
-		min:  0.0,
-		wantCompare: gedcom.IndividualComparisons{
+		Doc1: gedcom.NewDocumentWithNodes([]gedcom.Node{elliot, jane}),
+		Doc2: gedcom.NewDocumentWithNodes([]gedcom.Node{jane, john}),
+		MinimumWeightedSimilarity: 0.0,
+		PreferPointerAbove:        1.0,
+		WantCompare: gedcom.IndividualComparisons{
 			// elliot and john match because the minimumSimilarity is so
 			// low.
 			{jane, jane, gedcom.NewSurroundingSimilarity(0.5, 1, 1.0, 1.0)},
 			{elliot, john, gedcom.NewSurroundingSimilarity(0.5, 0.24743589743589745, 1.0, 1.0)},
 		},
-		wantMerge: gedcom.IndividualNodes{
+		WantMerge: gedcom.IndividualNodes{
 			jane,
 			gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
 				gedcom.NewNameNode(nil, "Elliot /Chance/", "", nil),
@@ -104,35 +115,66 @@ var individualNodesTests = map[string]struct {
 		},
 	},
 	"OneMatch": {
-		doc1: gedcom.NewDocumentWithNodes([]gedcom.Node{elliot, jane}),
-		doc2: gedcom.NewDocumentWithNodes([]gedcom.Node{jane, john}),
-		min:  0.75,
-		wantCompare: gedcom.IndividualComparisons{
+		Doc1: gedcom.NewDocumentWithNodes([]gedcom.Node{elliot, jane}),
+		Doc2: gedcom.NewDocumentWithNodes([]gedcom.Node{jane, john}),
+		MinimumWeightedSimilarity: 0.75,
+		PreferPointerAbove:        1.0,
+		WantCompare: gedcom.IndividualComparisons{
 			{jane, jane, gedcom.NewSurroundingSimilarity(0.5, 1.0, 1.0, 1.0)},
 			{elliot, nil, nil},
 			{nil, john, nil},
 		},
-		wantMerge: gedcom.IndividualNodes{
+		WantMerge: gedcom.IndividualNodes{
 			jane,
 			elliot,
 			john,
 		},
 	},
 	"NoMatches": {
-		doc1: gedcom.NewDocumentWithNodes([]gedcom.Node{elliot, jane}),
-		doc2: gedcom.NewDocumentWithNodes([]gedcom.Node{bob, john}),
-		min:  0.9,
-		wantCompare: gedcom.IndividualComparisons{
+		Doc1: gedcom.NewDocumentWithNodes([]gedcom.Node{elliot, jane}),
+		Doc2: gedcom.NewDocumentWithNodes([]gedcom.Node{bob, john}),
+		MinimumWeightedSimilarity: 0.9,
+		PreferPointerAbove:        1.0,
+		WantCompare: gedcom.IndividualComparisons{
 			{elliot, nil, nil},
 			{jane, nil, nil},
 			{nil, bob, nil},
 			{nil, john, nil},
 		},
-		wantMerge: gedcom.IndividualNodes{
+		WantMerge: gedcom.IndividualNodes{
 			elliot,
 			jane,
 			bob,
 			john,
+		},
+	},
+	"AlwaysUsePointer": {
+		// John and Jane are both P2. Even though they are completely different
+		// we force pointers to match with a prefer value of 0.0.
+		Doc1: gedcom.NewDocumentWithNodes([]gedcom.Node{elliot, jane}),
+		Doc2: gedcom.NewDocumentWithNodes([]gedcom.Node{bob, john}),
+		MinimumWeightedSimilarity: 0.9,
+		PreferPointerAbove:        0.0,
+		WantCompare: gedcom.IndividualComparisons{
+			{jane, john, gedcom.NewSurroundingSimilarity(0.5, 0.8209932199959546, 1.0, 1.0)},
+			{elliot, nil, nil},
+			{nil, bob, nil},
+		},
+		WantMerge: gedcom.IndividualNodes{
+			gedcom.NewIndividualNode(nil, "", "P2", []gedcom.Node{
+				gedcom.NewNameNode(nil, "Jane /Doe/", "", nil),
+				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
+					gedcom.NewDateNode(nil, "4 Jan 1803", "", nil), // john
+					gedcom.NewDateNode(nil, "3 Mar 1803", "", nil), // jane
+				}),
+				gedcom.NewDeathNode(nil, "", "", []gedcom.Node{
+					gedcom.NewDateNode(nil, "17 Mar 1877", "", nil),  // john
+					gedcom.NewDateNode(nil, "14 June 1877", "", nil), // jane
+				}),
+				gedcom.NewNameNode(nil, "John /Smith/", "", nil),
+			}),
+			elliot,
+			bob,
 		},
 	},
 }
@@ -472,35 +514,37 @@ func TestIndividualNodes_Similarity(t *testing.T) {
 func TestIndividualNodes_Compare(t *testing.T) {
 	for testName, test := range individualNodesTests {
 		t.Run(testName, func(t *testing.T) {
-			for _, n := range test.doc1.Nodes() {
-				n.SetDocument(test.doc1)
-			}
-			for _, n := range test.doc2.Nodes() {
-				n.SetDocument(test.doc2)
+			for _, n := range test.Doc1.Nodes() {
+				n.SetDocument(test.Doc1)
 			}
 
-			options := gedcom.NewSimilarityOptions()
-			options.MinimumWeightedSimilarity = test.min
+			for _, n := range test.Doc2.Nodes() {
+				n.SetDocument(test.Doc2)
+			}
+
+			similarityOptions := gedcom.NewSimilarityOptions()
+			similarityOptions.MinimumWeightedSimilarity = test.MinimumWeightedSimilarity
+			similarityOptions.PreferPointerAbove = test.PreferPointerAbove
 
 			compareOptions := gedcom.NewIndividualNodesCompareOptions()
-			compareOptions.SimilarityOptions = options
+			compareOptions.SimilarityOptions = similarityOptions
 
-			individuals1 := test.doc1.Individuals()
-			individuals2 := test.doc2.Individuals()
+			individuals1 := test.Doc1.Individuals()
+			individuals2 := test.Doc2.Individuals()
 			got := individuals1.Compare(individuals2, compareOptions)
 
 			// The comparison results (got) will include the options from above.
 			// However, the fixture for this test does not provide the
 			// compareOptions as it would make the fixture verbose and
-			// confusing. Instead we set the test.min on each of the comparison
+			// confusing. Instead we set the Options on each of the comparison
 			// results so that the deep equal passes.
-			for _, x := range test.wantCompare {
+			for _, x := range test.WantCompare {
 				if x.Similarity != nil {
-					x.Similarity.Options.MinimumWeightedSimilarity = test.min
+					x.Similarity.Options = similarityOptions
 				}
 			}
 
-			assertEqual(t, test.wantCompare, got)
+			assertEqual(t, test.WantCompare, got)
 		})
 	}
 }
@@ -534,25 +578,27 @@ func TestIndividualNodes_Nodes(t *testing.T) {
 func TestIndividualNodes_Merge(t *testing.T) {
 	for testName, test := range individualNodesTests {
 		t.Run(testName, func(t *testing.T) {
-			for _, n := range test.doc1.Nodes() {
-				n.SetDocument(test.doc1)
-			}
-			for _, n := range test.doc2.Nodes() {
-				n.SetDocument(test.doc2)
+			for _, n := range test.Doc1.Nodes() {
+				n.SetDocument(test.Doc1)
 			}
 
-			options := gedcom.NewSimilarityOptions()
-			options.MinimumWeightedSimilarity = test.min
+			for _, n := range test.Doc2.Nodes() {
+				n.SetDocument(test.Doc2)
+			}
+
+			similarityOptions := gedcom.NewSimilarityOptions()
+			similarityOptions.MinimumWeightedSimilarity = test.MinimumWeightedSimilarity
+			similarityOptions.PreferPointerAbove = test.PreferPointerAbove
 
 			compareOptions := gedcom.NewIndividualNodesCompareOptions()
-			compareOptions.SimilarityOptions = options
+			compareOptions.SimilarityOptions = similarityOptions
 
-			individuals1 := test.doc1.Individuals()
-			individuals2 := test.doc2.Individuals()
+			individuals1 := test.Doc1.Individuals()
+			individuals2 := test.Doc2.Individuals()
 			got, err := individuals1.Merge(individuals2, compareOptions)
 
 			assert.NoError(t, err)
-			assertIndividualNodes(t, test.wantMerge, got)
+			assertIndividualNodes(t, test.WantMerge, got)
 		})
 	}
 }

--- a/merge_test.go
+++ b/merge_test.go
@@ -525,6 +525,7 @@ func TestMergeDocumentsAndIndividuals(t *testing.T) {
 
 			options := gedcom.NewIndividualNodesCompareOptions()
 			options.SimilarityOptions.MinimumWeightedSimilarity = test.minimumSimilarity
+			options.SimilarityOptions.PreferPointerAbove = 1.0
 
 			actual, err := gedcom.MergeDocumentsAndIndividuals(
 				test.left, test.right, test.mergeFn, options)

--- a/similarity_options.go
+++ b/similarity_options.go
@@ -40,6 +40,24 @@ type SimilarityOptions struct {
 	// values have been chosen with gedcomtune.
 	JaroBoostThreshold float64
 	JaroPrefixSize     int
+
+	// PreferPointerAbove controls if two individuals should be considered a
+	// match by their pointer value.
+	//
+	// The default value is DefaultMinimumSimilarity which means that the
+	// individuals will be considered a match if they share the same pointer and
+	// hit the same default minimum similarity.
+	//
+	// A value of 1.0 would have to be a perfect match to be considered equal on
+	// their pointer, this is the same as disabling the feature.
+	//
+	// A value of 0.0 would mean that it always trusts the pointer match, even
+	// if the individuals are nothing alike.
+	//
+	// PreferPointerAbove makes sense when you are comparing documents that have
+	// come from the same base and retained the pointers between individuals of
+	// the existing data.
+	PreferPointerAbove float64
 }
 
 // NewSimilarityOptions returns sensible defaults that are used around many of
@@ -59,6 +77,10 @@ func NewSimilarityOptions() SimilarityOptions {
 		NameToDateRatio:    0.5,
 		JaroBoostThreshold: DefaultJaroWinklerBoostThreshold,
 		JaroPrefixSize:     DefaultJaroWinklerPrefixSize,
+
+		// Allow individuals to me matched using their pointer if they hit the
+		// same default minimum threshold.
+		PreferPointerAbove: DefaultMinimumSimilarity,
 	}
 }
 

--- a/similarity_options_test.go
+++ b/similarity_options_test.go
@@ -20,7 +20,8 @@ func TestSimilarityOptions_String(t *testing.T) {
 		"ChildrenWeight:0.06666666666666667, " +
 		"NameToDateRatio:0.5, " +
 		"JaroBoostThreshold:0, " +
-		"JaroPrefixSize:8")
+		"JaroPrefixSize:8, " +
+		"PreferPointerAbove:0.733")
 }
 
 func TestNewSimilarityOptions(t *testing.T) {
@@ -31,5 +32,9 @@ func TestNewSimilarityOptions(t *testing.T) {
 			options.SpousesWeight + options.ChildrenWeight
 
 		assert.Equal(t, 1.0, shouldBeOne)
+	})
+
+	t.Run("PreferPointerAbove", func(t *testing.T) {
+		assert.Equal(t, gedcom.DefaultMinimumSimilarity, options.PreferPointerAbove)
 	})
 }

--- a/util/filter_flags.go
+++ b/util/filter_flags.go
@@ -42,7 +42,10 @@ func (ff *FilterFlags) SetupCLI() {
 
 	flag.BoolVar(&ff.HideEqual, "hide-equal", false, "Hide equal values.")
 
-	flag.BoolVar(&ff.SimpleNames, "simple-names", false, "Simplify names.")
+	flag.BoolVar(&ff.SimpleNames, "simple-names", false, CLIDescription(`
+		The NAME node can be represented a single string, or name parts such as
+		Given name, Surname, Title, etc. When enabled, this option flattens name
+		parts into a single string as their GEDCOM name, like "John /Smith/".`))
 }
 
 func (ff *FilterFlags) FilterFunctions() []gedcom.FilterFunction {


### PR DESCRIPTION
Controls if two individuals should be considered a match by their pointer value.

The default value is 0.735 which means that the individuals will be considered a match if they share the same pointer and hit the same default minimum similarity.

A value of 1.0 would have to be a perfect match to be considered equal on their pointer, this is the same as disabling the feature.

A value of 0.0 would mean that it always trusts the pointer match, even if the individuals are nothing alike.

This option makes sense when you are comparing documents that have come from the same base and retained the pointers between individuals of the existing data.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/gedcom/214)
<!-- Reviewable:end -->
