### PR TITLE
NameFormat: allow "-name-format" on CLI

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -117,16 +117,19 @@ func OfficialTagFilter() FilterFunction {
 	}
 }
 
-// SimpleNameFilter flattens NAME nodes.
+// SimpleNameFilter flattens NAME nodes with the provided format.
 //
 // This is useful for comparing names when the components of the name (title,
 // suffix, etc) are less important than the name itself.
-//
-// The new name nodes will have a value constructed with NameNode.GedcomName.
-func SimpleNameFilter() FilterFunction {
+func SimpleNameFilter(format NameFormat) FilterFunction {
 	return func(node Node) (Node, bool) {
 		if name, ok := node.(*NameNode); ok {
-			newNode := NewNameNode(name.Document(), name.GedcomName(), name.Pointer(), nil)
+			newNode := NewNameNode(
+				name.Document(),
+				name.Format(format),
+				name.Pointer(),
+				nil,
+			)
 
 			return newNode, false
 		}

--- a/filter_test.go
+++ b/filter_test.go
@@ -245,6 +245,7 @@ func TestSimpleNameFilter(t *testing.T) {
 	// ghost:ignore
 	for _, test := range []struct {
 		root     gedcom.Node
+		format   gedcom.NameFormat
 		expected string
 	}{
 		{
@@ -254,6 +255,7 @@ func TestSimpleNameFilter(t *testing.T) {
 					gedcom.NewDateNode(nil, "6 MAY 1989", "", nil),
 				}),
 			}),
+			format: gedcom.NameFormatGEDCOM,
 			expected: `0 @P1@ INDI
 1 NAME Elliot /Chance/
 1 BIRT
@@ -269,6 +271,7 @@ func TestSimpleNameFilter(t *testing.T) {
 					gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, "Smith", "", nil),
 				}),
 			}),
+			format: gedcom.NameFormatGEDCOM,
 			expected: `0 @P1@ INDI
 1 BIRT
 2 DATE 6 MAY 1989
@@ -285,15 +288,47 @@ func TestSimpleNameFilter(t *testing.T) {
 					gedcom.NewDateNode(nil, "6 MAY 1989", "", nil),
 				}),
 			}),
+			format: gedcom.NameFormatGEDCOM,
 			expected: `0 @P1@ INDI
 1 NAME Bob /Smith/
 1 BIRT
 2 DATE 6 MAY 1989
 `,
 		},
+		{
+			root: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
+				gedcom.NewNameNode(nil, "Elliot /Chance/", "", nil),
+				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
+					gedcom.NewDateNode(nil, "6 MAY 1989", "", nil),
+				}),
+			}),
+			format: gedcom.NameFormatWritten,
+			expected: `0 @P1@ INDI
+1 NAME Elliot Chance
+1 BIRT
+2 DATE 6 MAY 1989
+`,
+		},
+		{
+			root: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
+				gedcom.NewNameNode(nil, "", "", []gedcom.Node{
+					gedcom.NewNodeWithChildren(nil, gedcom.TagGivenName, "Bob", "", nil),
+					gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, "Smith", "", nil),
+				}),
+				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
+					gedcom.NewDateNode(nil, "6 MAY 1989", "", nil),
+				}),
+			}),
+			format: gedcom.NameFormatIndex,
+			expected: `0 @P1@ INDI
+1 NAME Smith, Bob
+1 BIRT
+2 DATE 6 MAY 1989
+`,
+		},
 	} {
 		t.Run("", func(t *testing.T) {
-			filter := gedcom.SimpleNameFilter()
+			filter := gedcom.SimpleNameFilter(test.format)
 			result := gedcom.GEDCOMString(gedcom.Filter(test.root, filter), 0)
 			assert.Equal(t, test.expected, result)
 		})

--- a/name_format.go
+++ b/name_format.go
@@ -1,0 +1,66 @@
+package gedcom
+
+// NameFormat describes how an individuals name should be formatted.
+//
+// The format is a string that contains placeholders and works similar to
+// fmt.Printf where placeholders represent different components of the name:
+//
+//   %% "%"
+//   %f GivenName
+//   %l Surname
+//   %m SurnamePrefix
+//   %p Prefix
+//   %s Suffix
+//   %t Title
+//
+// Each of the letters may be in upper case to convert the name part to upper
+// case also. Whitespace before, after and between name components will be
+// removed:
+//
+//   name.Format("%l, %f")     // "Smith, Bob"
+//   name.Format("%f %L")      // "Bob SMITH"
+//   name.Format("%f %m (%l)") // "Bob (Smith)"
+//
+type NameFormat string
+
+// NameFormat constants can be used with NameNode.Format.
+const (
+	// This is the written format, also used by String().
+	NameFormatWritten NameFormat = "%t %p %f %m %l %s"
+
+	// This is the style used in GEDCOM NAME nodes. It is used in GedcomName().
+	//
+	// It should be noted that while the formatted name is valid GEDCOM, it
+	// cannot be reverse back into its individual name parts.
+	NameFormatGEDCOM NameFormat = "%t %p %f %m /%l/ %s"
+
+	// NameFormatIndex is appropriate for showing names that are indexed by
+	// their surname, such as "Smith, Bob"
+	NameFormatIndex NameFormat = "%m %l, %t %p %f %s"
+)
+
+// NewNameFormatByName returns one of the NameFormat constants.
+//
+// The name is the lowercase name of the constant without the prefix. For
+// example, "NameFormatWritten" would have the name "written".
+//
+// It will return the original name and false if the name is not known. This
+// allows custom formats to be passed through like:
+//
+//   NewNameFormatByName("gedcom") // "%t %p %f %m /%l/ %s", true
+//   NewNameFormatByName("%L %f")  // "%L %f", false
+//
+func NewNameFormatByName(name string) (NameFormat, bool) {
+	switch name {
+	case "written":
+		return NameFormatWritten, true
+
+	case "gedcom":
+		return NameFormatGEDCOM, true
+
+	case "index":
+		return NameFormatIndex, true
+	}
+
+	return NameFormat(name), false
+}

--- a/name_format_test.go
+++ b/name_format_test.go
@@ -1,0 +1,18 @@
+package gedcom_test
+
+import (
+	"github.com/elliotchance/gedcom"
+	"github.com/elliotchance/tf"
+	"testing"
+)
+
+func TestNewNameFormatByName(t *testing.T) {
+	NewNameFormatByName := tf.Function(t, gedcom.NewNameFormatByName)
+
+	NewNameFormatByName("written").Returns(gedcom.NameFormatWritten, true)
+	NewNameFormatByName("gedcom").Returns(gedcom.NameFormatGEDCOM, true)
+	NewNameFormatByName("index").Returns(gedcom.NameFormatIndex, true)
+
+	NewNameFormatByName("%L %f").Returns("%L %f", false)
+	NewNameFormatByName("").Returns("", false)
+}

--- a/name_node.go
+++ b/name_node.go
@@ -1,49 +1,9 @@
-// Individual Names
-//
-// A NameNode represents all the parts that make up a single name. An individual
-// may have more than one name, each one would be represented by a NameNode.
-//
-// Apart from functions to extract name parts there is also Format which works
-// similar to `fmt.Printf` where placeholders represent different components of
-// the name:
-//
-//   %% "%"
-//   %f GivenName
-//   %l Surname
-//   %m SurnamePrefix
-//   %p Prefix
-//   %s Suffix
-//   %t Title
-//
-// Each of the letters may be in upper case to convert the name part to upper
-// case also. Whitespace before, after and between name components will be
-// removed:
-//
-//   name.Format("%l, %f")     // "Smith, Bob"
-//   name.Format("%f %L")      // "Bob SMITH"
-//   name.Format("%f %m (%l)") // "Bob (Smith)"
 package gedcom
 
 import (
 	"regexp"
 	"strings"
 	"unicode"
-)
-
-// NameFormat constants can be used with NameNode.Format.
-const (
-	// This is the written format, also used by String().
-	NameFormatWritten = "%t %p %f %m %l %s"
-
-	// This is the style used in GEDCOM NAME nodes. It is used in GedcomName().
-	//
-	// It should be noted that while the formatted name is valid GEDCOM, it
-	// cannot be reverse back into its individual name parts.
-	NameFormatGEDCOM = "%t %p %f %m /%l/ %s"
-
-	// NameFormatIndex is appropriate for showing names that are indexed by
-	// their surname, such as "Smith, Bob"
-	NameFormatIndex = "%m %l, %t %p %f %s"
 )
 
 // NameNode represents all the parts that make up a single name. An individual
@@ -204,31 +164,9 @@ func (node *NameNode) GedcomName() (name string) {
 
 // Format returns a formatted name.
 //
-// There are some common formats described with the NameFormat constants.
-//
-// Format works similar to Printf where placeholders represent different
-// components of the name:
-//
-//   %% "%"
-//   %f GivenName
-//   %l Surname
-//   %m SurnamePrefix
-//   %p Prefix
-//   %s Suffix
-//   %t Title
-//
-// Each of the letters may be in upper case to convert the name part to upper
-// case also.
-//
-// Whitespace before, after and between name components will be removed.
-//
-// Examples:
-//
-//   name.Format("%l, %f")     // Smith, Bob
-//   name.Format("%f %L")      // Bob SMITH
-//   name.Format("%f %m (%l)") // Bob (Smith)
-//
-func (node *NameNode) Format(format string) string {
+// There are some common formats described with the NameFormat constants. See
+// NameFormat for a full description.
+func (node *NameNode) Format(format NameFormat) string {
 	result := ""
 	formatLen := len(format)
 

--- a/util/filter_flags.go
+++ b/util/filter_flags.go
@@ -24,7 +24,7 @@ type FilterFlags struct {
 	HideEqual bool
 
 	// Condense NAME nodes to a simple string.
-	SimpleNames bool
+	NameFormat string
 }
 
 func (ff *FilterFlags) SetupCLI() {
@@ -42,10 +42,22 @@ func (ff *FilterFlags) SetupCLI() {
 
 	flag.BoolVar(&ff.HideEqual, "hide-equal", false, "Hide equal values.")
 
-	flag.BoolVar(&ff.SimpleNames, "simple-names", false, CLIDescription(`
+	flag.StringVar(&ff.NameFormat, "name-format", "written", CLIDescription(`
 		The NAME node can be represented a single string, or name parts such as
 		Given name, Surname, Title, etc. When enabled, this option flattens name
-		parts into a single string as their GEDCOM name, like "John /Smith/".`))
+		parts into a single string with the given format:
+
+		"written": Default. Flatten names to their written names, like
+		"John Smith".
+
+		"gedcom": Flatten names to their GEDCOM name, like "John /Smith/".
+
+		"index": Flatten names to their index name, like "Smith, John".
+
+		"unmodified": Do not make any modifications to the name or name parts.
+
+		You can also provide a custom format (see NameFormat) by not using one
+		of the presets above.`))
 }
 
 func (ff *FilterFlags) FilterFunctions() []gedcom.FilterFunction {
@@ -76,8 +88,9 @@ func (ff *FilterFlags) FilterFunctions() []gedcom.FilterFunction {
 		filters = append(filters, gedcom.OfficialTagFilter())
 	}
 
-	if ff.SimpleNames {
-		filters = append(filters, gedcom.SimpleNameFilter())
+	if ff.NameFormat != "unmodified" {
+		format, _ := gedcom.NewNameFormatByName(ff.NameFormat)
+		filters = append(filters, gedcom.SimpleNameFilter(format))
 	}
 
 	return filters


### PR DESCRIPTION
This is more flexible when doing comparions. You can also provide a custom format.