### PR TITLE
FamilySearchIDNode

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -209,6 +209,9 @@ func NewNodeWithChildren(document *Document, tag Tag, value, pointer string, chi
 	case TagFamily:
 		return NewFamilyNode(document, pointer, children)
 
+	case UnofficialTagFamilySearchID1, UnofficialTagFamilySearchID2:
+		return NewFamilySearchIDNode(document, tag, value)
+
 	case TagFormat:
 		return NewFormatNode(document, value, pointer, nil)
 
@@ -250,6 +253,9 @@ func NewNodeWithChildren(document *Document, tag Tag, value, pointer string, chi
 
 	case TagType:
 		return NewTypeNode(document, value, pointer, nil)
+
+	case UnofficialTagUniqueID:
+		return NewUniqueIDNode(document, value, pointer, nil)
 	}
 
 	return newSimpleNode(document, tag, value, pointer, children)

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -265,6 +265,8 @@ func TestNewNode(t *testing.T) {
 		{gedcom.TagDeath, gedcom.NewDeathNode(nil, v, p, nil)},
 		{gedcom.TagEvent, gedcom.NewEventNode(nil, v, p, nil)},
 		{gedcom.TagFamily, gedcom.NewFamilyNode(nil, p, nil)},
+		{gedcom.UnofficialTagFamilySearchID1, gedcom.NewFamilySearchIDNode(nil, gedcom.UnofficialTagFamilySearchID1, v)},
+		{gedcom.UnofficialTagFamilySearchID2, gedcom.NewFamilySearchIDNode(nil, gedcom.UnofficialTagFamilySearchID2, v)},
 		{gedcom.TagFormat, gedcom.NewFormatNode(nil, v, p, nil)},
 		{gedcom.TagIndividual, gedcom.NewIndividualNode(nil, v, p, nil)},
 		{gedcom.TagLatitude, gedcom.NewLatitudeNode(nil, v, p, nil)},
@@ -280,6 +282,7 @@ func TestNewNode(t *testing.T) {
 		{gedcom.TagSource, gedcom.NewSourceNode(nil, v, p, nil)},
 		{gedcom.TagType, gedcom.NewTypeNode(nil, v, p, nil)},
 		{gedcom.TagVersion, gedcom.NewNode(nil, gedcom.TagVersion, v, p)},
+		{gedcom.UnofficialTagUniqueID, gedcom.NewUniqueIDNode(nil, v, p, nil)},
 	} {
 		t.Run(test.tag.String(), func(t *testing.T) {
 			assert.Equal(t, test.expected, gedcom.NewNode(nil, test.tag, v, p))

--- a/familysearch_id_node.go
+++ b/familysearch_id_node.go
@@ -1,0 +1,30 @@
+package gedcom
+
+// FamilySearchIDNode is the unique identifier for the person on
+// FamilySearch.org. A FamilySearch ID always takes the form of:
+//
+//   LZDP-V9V
+//
+// There are several known tags that carry the FamilySearch ID:
+//
+//   _FID (UnofficialTagFamilySearchID1): Seen exported from MacFamilyFree.
+//   _FSFTID (UnofficialTagFamilySearchID2): Some other applications.
+//
+type FamilySearchIDNode struct {
+	*SimpleNode
+}
+
+func NewFamilySearchIDNode(document *Document, tag Tag, value string) *FamilySearchIDNode {
+	return &FamilySearchIDNode{
+		newSimpleNode(document, tag, value, "", nil),
+	}
+}
+
+// FamilySearchIDNodeTags returns all of the known GEDCOM tags that can be
+// represented by a FamilySearchIDNode.
+func FamilySearchIDNodeTags() []Tag {
+	return []Tag{
+		UnofficialTagFamilySearchID1,
+		UnofficialTagFamilySearchID2,
+	}
+}

--- a/familysearch_id_node_test.go
+++ b/familysearch_id_node_test.go
@@ -1,0 +1,53 @@
+package gedcom_test
+
+import (
+	"testing"
+
+	"github.com/elliotchance/gedcom"
+	"github.com/stretchr/testify/assert"
+)
+
+var familySearchIDNodeTests = map[string]struct {
+	node  *gedcom.FamilySearchIDNode
+	tag   gedcom.Tag
+	value string
+}{
+	"1": {
+		node:  gedcom.NewFamilySearchIDNode(nil, gedcom.UnofficialTagFamilySearchID1, "LZDP-V7V"),
+		tag:   gedcom.UnofficialTagFamilySearchID1,
+		value: "LZDP-V7V",
+	},
+	"2": {
+		node:  gedcom.NewFamilySearchIDNode(nil, gedcom.UnofficialTagFamilySearchID2, "ZZDP-V7V"),
+		tag:   gedcom.UnofficialTagFamilySearchID2,
+		value: "ZZDP-V7V",
+	},
+}
+
+func TestNewFamilySearchIDNode(t *testing.T) {
+	doc := gedcom.NewDocument()
+	node := gedcom.NewFamilySearchIDNode(doc, gedcom.UnofficialTagFamilySearchID2, "LZDP-V7V")
+
+	assert.NotNil(t, node)
+	assert.IsType(t, node, (*gedcom.FamilySearchIDNode)(nil))
+	assert.Equal(t, gedcom.UnofficialTagFamilySearchID2, node.Tag())
+	assert.Equal(t, []gedcom.Node(nil), node.Nodes())
+	assert.Equal(t, doc, node.Document())
+	assert.Equal(t, "LZDP-V7V", node.Value())
+	assert.Equal(t, "", node.Pointer())
+}
+
+func TestNewFamilySearchIDNode_String(t *testing.T) {
+	for testName, test := range familySearchIDNodeTests {
+		t.Run(testName, func(t *testing.T) {
+			assert.Equal(t, test.value, test.node.String())
+		})
+	}
+}
+
+func TestFamilySearchIDNodeTags(t *testing.T) {
+	assert.Equal(t, []gedcom.Tag{
+		gedcom.UnofficialTagFamilySearchID1,
+		gedcom.UnofficialTagFamilySearchID2,
+	}, gedcom.FamilySearchIDNodeTags())
+}

--- a/individual_node.go
+++ b/individual_node.go
@@ -835,3 +835,29 @@ func (node *IndividualNode) String() string {
 
 	return fmt.Sprintf("%s (%s)", name, strings.Join(dateParts, ", "))
 }
+
+func (node *IndividualNode) FamilySearchIDs() (nodes []*FamilySearchIDNode) {
+	if node == nil {
+		return nil
+	}
+
+	for _, tag := range FamilySearchIDNodeTags() {
+		for _, n := range NodesWithTag(node, tag) {
+			nodes = append(nodes, n.(*FamilySearchIDNode))
+		}
+	}
+
+	return
+}
+
+func (node *IndividualNode) UniqueIDs() (nodes []*UniqueIDNode) {
+	if node == nil {
+		return nil
+	}
+
+	for _, n := range NodesWithTag(node, UnofficialTagUniqueID) {
+		nodes = append(nodes, n.(*UniqueIDNode))
+	}
+
+	return
+}

--- a/individual_node_test.go
+++ b/individual_node_test.go
@@ -2,11 +2,12 @@ package gedcom_test
 
 import (
 	"fmt"
+	"strings"
+	"testing"
+
 	"github.com/elliotchance/gedcom"
 	"github.com/elliotchance/tf"
 	"github.com/stretchr/testify/assert"
-	"strings"
-	"testing"
 )
 
 var individualTests = []struct {
@@ -1773,4 +1774,61 @@ func TestIndividualNode_String(t *testing.T) {
 			gedcom.NewDateNode(nil, "14 Jun 2007", "", nil),
 		}),
 	})).Returns("Jane Doe (d. 7 Jun 2007)")
+}
+
+func TestIndividualNode_FamilySearchIDs(t *testing.T) {
+	FamilySearchIDs := tf.NamedFunction(t, "IndividualNode_FamilySearchIDs",
+		(*gedcom.IndividualNode).FamilySearchIDs)
+
+	FamilySearchIDs(gedcom.NewIndividualNode(nil, "", "", nil)).
+		Returns(nil)
+
+	FamilySearchIDs(gedcom.NewIndividualNode(nil, "", "", []gedcom.Node{
+		gedcom.NewNameNode(nil, "", "", nil),
+	})).Returns(nil)
+
+	FamilySearchIDs(gedcom.NewIndividualNode(nil, "", "", []gedcom.Node{
+		gedcom.NewNameNode(nil, "", "", nil),
+		gedcom.NewFamilySearchIDNode(nil, gedcom.UnofficialTagFamilySearchID1, "LZDP-V7V"),
+	})).Returns([]*gedcom.FamilySearchIDNode{
+		gedcom.NewFamilySearchIDNode(nil, gedcom.UnofficialTagFamilySearchID1, "LZDP-V7V"),
+	})
+
+	FamilySearchIDs(gedcom.NewIndividualNode(nil, "", "", []gedcom.Node{
+		gedcom.NewFamilySearchIDNode(nil, gedcom.UnofficialTagFamilySearchID2, "AZDP-V7V"),
+		gedcom.NewFamilySearchIDNode(nil, gedcom.UnofficialTagFamilySearchID1, "BZDP-V7V"),
+		gedcom.NewFamilySearchIDNode(nil, gedcom.UnofficialTagFamilySearchID2, "CZDP-V7V"),
+	})).Returns([]*gedcom.FamilySearchIDNode{
+		gedcom.NewFamilySearchIDNode(nil, gedcom.UnofficialTagFamilySearchID1, "BZDP-V7V"),
+		gedcom.NewFamilySearchIDNode(nil, gedcom.UnofficialTagFamilySearchID2, "AZDP-V7V"),
+		gedcom.NewFamilySearchIDNode(nil, gedcom.UnofficialTagFamilySearchID2, "CZDP-V7V"),
+	})
+}
+
+func TestIndividualNode_UniqueIDs(t *testing.T) {
+	UniqueIDs := tf.NamedFunction(t, "IndividualNode_UniqueIDs",
+		(*gedcom.IndividualNode).UniqueIDs)
+
+	UniqueIDs(gedcom.NewIndividualNode(nil, "", "", nil)).
+		Returns(nil)
+
+	UniqueIDs(gedcom.NewIndividualNode(nil, "", "", []gedcom.Node{
+		gedcom.NewNameNode(nil, "", "", nil),
+	})).Returns(nil)
+
+	UniqueIDs(gedcom.NewIndividualNode(nil, "", "", []gedcom.Node{
+		gedcom.NewNameNode(nil, "", "", nil),
+		gedcom.NewUniqueIDNode(nil, "LZDP-V7V", "", nil),
+	})).Returns([]*gedcom.UniqueIDNode{
+		gedcom.NewUniqueIDNode(nil, "LZDP-V7V", "", nil),
+	})
+
+	UniqueIDs(gedcom.NewIndividualNode(nil, "", "", []gedcom.Node{
+		gedcom.NewUniqueIDNode(nil, "AZDP-V7V", "", nil),
+		gedcom.NewNameNode(nil, "", "", nil),
+		gedcom.NewUniqueIDNode(nil, "BZDP-V7V", "", nil),
+	})).Returns([]*gedcom.UniqueIDNode{
+		gedcom.NewUniqueIDNode(nil, "AZDP-V7V", "", nil),
+		gedcom.NewUniqueIDNode(nil, "BZDP-V7V", "", nil),
+	})
 }

--- a/q/functions.go
+++ b/q/functions.go
@@ -10,5 +10,5 @@ var Functions = map[string]Expression{
 	"Last":                         &LastExpr{},
 	"Length":                       &LengthExpr{},
 	"MergeDocumentsAndIndividuals": &MergeDocumentsAndIndividualsExpr{},
-	"Only":                         &OnlyExpr{},
+	"Only": &OnlyExpr{},
 }

--- a/q/merge_documents_and_individuals_expr.go
+++ b/q/merge_documents_and_individuals_expr.go
@@ -2,8 +2,8 @@ package q
 
 import (
 	"errors"
-	"github.com/elliotchance/gedcom"
 	"fmt"
+	"github.com/elliotchance/gedcom"
 )
 
 // MergeDocumentsAndIndividualsExpr is a function. See Evaluate.

--- a/q/merge_documents_and_individuals_expr_test.go
+++ b/q/merge_documents_and_individuals_expr_test.go
@@ -2,10 +2,10 @@ package q_test
 
 import (
 	"errors"
+	"github.com/elliotchance/gedcom"
 	"github.com/elliotchance/gedcom/q"
 	"github.com/elliotchance/tf"
 	"testing"
-	"github.com/elliotchance/gedcom"
 )
 
 func TestMergeDocumentsAndIndividualsExpr_Evaluate(t *testing.T) {

--- a/tag.go
+++ b/tag.go
@@ -625,9 +625,11 @@ var (
 )
 
 var (
-	// Unofficial. The unique identifier for the person on FamilySearch.org.
-	// This has been seen exported from MacFamilyFree.
-	UnofficialTagFamilySearchID = newTag("_FID", "FamilySearch ID", tagOptionNone, tagSortIndividualUnofficial)
+	// Unofficial.
+
+	// See FamilySearchIDNode
+	UnofficialTagFamilySearchID1 = newTag("_FID", "FamilySearch ID", tagOptionNone, tagSortIndividualUnofficial)
+	UnofficialTagFamilySearchID2 = newTag("_FSFTID", "FamilySearch ID", tagOptionNone, tagSortIndividualUnofficial)
 
 	// Unofficial. Latitude degrees. This has been seen exported from
 	// MacFamilyFree.
@@ -729,7 +731,8 @@ func Tags() []Tag {
 		TagTrailer, TagType, TagVersion, TagWife, TagWWW, TagWill, TagLabel,
 
 		// Unofficial
-		UnofficialTagFamilySearchID, UnofficialTagLatitudeDegrees,
+		UnofficialTagFamilySearchID1, UnofficialTagFamilySearchID2,
+		UnofficialTagLatitudeDegrees,
 		UnofficialTagLatitudeMinutes, UnofficialTagLatitudeSeconds,
 		UnofficialTagLongitudeDegress, UnofficialTagLongitudeMinutes,
 		UnofficialTagLongitudeNorth, UnofficialTagLongitudeSeconds,

--- a/tag_test.go
+++ b/tag_test.go
@@ -164,20 +164,21 @@ var tagTests = map[string]struct {
 	"WWW":   {y, y, n, &gedcom.TagWWW, "WWW"},
 
 	// Unofficial
-	//       isKnown
-	//       |  isOfficial
-	//       |  |  isEvent
-	"_COR": {y, n, n, &gedcom.UnofficialTagCoordinates, "Coordinates"},
-	"_CRE": {y, n, n, &gedcom.UnofficialTagCreated, "Created"},
-	"_FID": {y, n, n, &gedcom.UnofficialTagFamilySearchID, "FamilySearch ID"},
-	"_LAD": {y, n, n, &gedcom.UnofficialTagLatitudeDegrees, "Latitude Degrees"},
-	"_LAM": {y, n, n, &gedcom.UnofficialTagLatitudeMinutes, "Latitude Minutes"},
-	"_LAS": {y, n, n, &gedcom.UnofficialTagLatitudeSeconds, "Latitude Seconds"},
-	"_LOD": {y, n, n, &gedcom.UnofficialTagLongitudeDegress, "Longitude Degress"},
-	"_LOM": {y, n, n, &gedcom.UnofficialTagLongitudeMinutes, "Longitude Minutes"},
-	"_LON": {y, n, n, &gedcom.UnofficialTagLongitudeNorth, "Longitude North"},
-	"_LOS": {y, n, n, &gedcom.UnofficialTagLongitudeSeconds, "Longitude Seconds"},
-	"_UID": {y, n, n, &gedcom.UnofficialTagUniqueID, "Unique ID"},
+	//          isKnown
+	//          |  isOfficial
+	//          |  |  isEvent
+	"_COR":    {y, n, n, &gedcom.UnofficialTagCoordinates, "Coordinates"},
+	"_CRE":    {y, n, n, &gedcom.UnofficialTagCreated, "Created"},
+	"_FID":    {y, n, n, &gedcom.UnofficialTagFamilySearchID1, "FamilySearch ID"},
+	"_FSFTID": {y, n, n, &gedcom.UnofficialTagFamilySearchID2, "FamilySearch ID"},
+	"_LAD":    {y, n, n, &gedcom.UnofficialTagLatitudeDegrees, "Latitude Degrees"},
+	"_LAM":    {y, n, n, &gedcom.UnofficialTagLatitudeMinutes, "Latitude Minutes"},
+	"_LAS":    {y, n, n, &gedcom.UnofficialTagLatitudeSeconds, "Latitude Seconds"},
+	"_LOD":    {y, n, n, &gedcom.UnofficialTagLongitudeDegress, "Longitude Degress"},
+	"_LOM":    {y, n, n, &gedcom.UnofficialTagLongitudeMinutes, "Longitude Minutes"},
+	"_LON":    {y, n, n, &gedcom.UnofficialTagLongitudeNorth, "Longitude North"},
+	"_LOS":    {y, n, n, &gedcom.UnofficialTagLongitudeSeconds, "Longitude Seconds"},
+	"_UID":    {y, n, n, &gedcom.UnofficialTagUniqueID, "Unique ID"},
 
 	// Unknown
 	//       isKnown
@@ -397,7 +398,8 @@ func TestTags(t *testing.T) {
 
 			gedcom.UnofficialTagCoordinates,
 			gedcom.UnofficialTagCreated,
-			gedcom.UnofficialTagFamilySearchID,
+			gedcom.UnofficialTagFamilySearchID1,
+			gedcom.UnofficialTagFamilySearchID2,
 			gedcom.UnofficialTagLatitudeDegrees,
 			gedcom.UnofficialTagLatitudeMinutes,
 			gedcom.UnofficialTagLatitudeSeconds,

--- a/unique_id_node_test.go
+++ b/unique_id_node_test.go
@@ -1,10 +1,10 @@
 package gedcom_test
 
 import (
+	"errors"
 	"github.com/elliotchance/gedcom"
 	"github.com/stretchr/testify/assert"
 	"testing"
-	"errors"
 )
 
 var uniqueIDNodeTests = map[string]struct {

--- a/uuid.go
+++ b/uuid.go
@@ -2,8 +2,8 @@ package gedcom
 
 import (
 	"fmt"
-	"strings"
 	"regexp"
+	"strings"
 )
 
 type UUID string

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -1,10 +1,10 @@
 package gedcom_test
 
 import (
-	"testing"
-	"github.com/elliotchance/tf"
-	"github.com/elliotchance/gedcom"
 	"fmt"
+	"github.com/elliotchance/gedcom"
+	"github.com/elliotchance/tf"
+	"testing"
 )
 
 func TestNewUUIDFromString(t *testing.T) {


### PR DESCRIPTION
FamilySearchIDNode is the unique identifier for the person on FamilySearch.org. A FamilySearch ID always takes the form of: LZDP-V9V

There are several known tags that carry the FamilySearch ID:

- _FID (UnofficialTagFamilySearchID1): Seen exported from MacFamilyFree.
- _FSFTID (UnofficialTagFamilySearchID2): Some other applications.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/gedcom/219)
<!-- Reviewable:end -->
