### PR TITLE
gedcomdiff: Added "-no-empty-deaths" option

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -156,3 +156,18 @@ func OnlyVitalsTagFilter() FilterFunction {
 		TagNameSuffix, TagTitle, TagDate, TagPlace,
 	)
 }
+
+// RemoveEmptyDeathTagFilter removes any Death (DEAT) events that do not have
+// any child nodes (which would otherwise be information like the date or place.
+//
+// This is because some applications use the death tag as a marker without any
+// further information which can cause problems when comparing individuals.
+func RemoveEmptyDeathTagFilter() FilterFunction {
+	return func(node Node) (Node, bool) {
+		if death, ok := node.(*DeathNode); ok && len(death.Nodes()) == 0 {
+			return nil, false
+		}
+
+		return node, true
+	}
+}

--- a/util/filter_flags.go
+++ b/util/filter_flags.go
@@ -7,15 +7,16 @@ import (
 
 type FilterFlags struct {
 	// Specific exclusions.
-	NoEvents     bool
-	NoResidences bool
-	NoPlaces     bool
-	NoSources    bool
-	NoMaps       bool
-	NoChanges    bool
-	NoObjects    bool
-	NoLabels     bool
-	NoCensuses   bool
+	NoEvents      bool
+	NoResidences  bool
+	NoPlaces      bool
+	NoSources     bool
+	NoMaps        bool
+	NoChanges     bool
+	NoObjects     bool
+	NoLabels      bool
+	NoCensuses    bool
+	NoEmptyDeaths bool
 
 	// Only vitals (name, birth, baptism, death and burial).
 	OnlyVitals bool
@@ -40,6 +41,11 @@ func (ff *FilterFlags) SetupCLI() {
 	flag.BoolVar(&ff.NoObjects, "no-objects", false, "Exclude objects.")
 	flag.BoolVar(&ff.NoLabels, "no-labels", false, "Exclude labels.")
 	flag.BoolVar(&ff.NoCensuses, "no-censuses", false, "Exclude censuses.")
+
+	flag.BoolVar(&ff.NoEmptyDeaths, "no-empty-deaths", false, CLIDescription(
+		`Remove death nodes (DEAT) that do not have children. This is caused by
+		applications signalling that the individual is not living but can lead
+		to unwanted discrepancies in the comparison.`))
 
 	flag.BoolVar(&ff.OnlyVitals, "only-vitals", false, CLIDescription(`
 		Remove all data except for vital information. The vital nodes are (or
@@ -104,6 +110,10 @@ func (ff *FilterFlags) FilterFunctions() []gedcom.FilterFunction {
 
 	if ff.OnlyVitals {
 		filters = append(filters, gedcom.OnlyVitalsTagFilter())
+	}
+
+	if ff.NoEmptyDeaths {
+		filters = append(filters, gedcom.RemoveEmptyDeathTagFilter())
 	}
 
 	return filters


### PR DESCRIPTION
When enabled death tags (DEAT) will be removed if they have no children. This is because some applications use the death tag as a marker without any further information.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/gedcom/224)
<!-- Reviewable:end -->
