### PR TITLE
DateNode: More variations for "circa". Fixes #222

### DIFF
--- a/date.go
+++ b/date.go
@@ -14,7 +14,7 @@ import (
 const (
 	DateWordsBetween = "Bet.|bet|between|from"
 	DateWordsAnd     = "and|to|-"
-	DateWordsAbout   = "Abt.|abt|about|c.|circa"
+	DateWordsAbout   = "Abt.|abt|about|c.|ca|ca.|cca|cca.|circa"
 	DateWordsAfter   = "Aft.|aft|after"
 	DateWordsBefore  = "Bef.|bef|before"
 )

--- a/date_node_test.go
+++ b/date_node_test.go
@@ -378,6 +378,26 @@ var dateTests = map[string]struct {
 		gedcom.Date{8, time.March, 1505, true, gedcom.DateConstraintAbout}, parseTime("8 Mar 1505 23"),
 		"Abt. 8 Mar 1505",
 	},
+	"ca. 8 Mar 1505": {
+		gedcom.Date{8, time.March, 1505, false, gedcom.DateConstraintAbout}, parseTime("8 Mar 1505 00"),
+		gedcom.Date{8, time.March, 1505, true, gedcom.DateConstraintAbout}, parseTime("8 Mar 1505 23"),
+		"Abt. 8 Mar 1505",
+	},
+	"CA 8 Mar 1505": {
+		gedcom.Date{8, time.March, 1505, false, gedcom.DateConstraintAbout}, parseTime("8 Mar 1505 00"),
+		gedcom.Date{8, time.March, 1505, true, gedcom.DateConstraintAbout}, parseTime("8 Mar 1505 23"),
+		"Abt. 8 Mar 1505",
+	},
+	"cca. 8 Mar 1505": {
+		gedcom.Date{8, time.March, 1505, false, gedcom.DateConstraintAbout}, parseTime("8 Mar 1505 00"),
+		gedcom.Date{8, time.March, 1505, true, gedcom.DateConstraintAbout}, parseTime("8 Mar 1505 23"),
+		"Abt. 8 Mar 1505",
+	},
+	"Cca 8 Mar 1505": {
+		gedcom.Date{8, time.March, 1505, false, gedcom.DateConstraintAbout}, parseTime("8 Mar 1505 00"),
+		gedcom.Date{8, time.March, 1505, true, gedcom.DateConstraintAbout}, parseTime("8 Mar 1505 23"),
+		"Abt. 8 Mar 1505",
+	},
 	"circa 21 Dec 1884": {
 		gedcom.Date{21, time.December, 1884, false, gedcom.DateConstraintAbout}, parseTime("21 Dec 1884 00"),
 		gedcom.Date{21, time.December, 1884, true, gedcom.DateConstraintAbout}, parseTime("21 Dec 1884 23"),


### PR DESCRIPTION
"Circa" representing "Abt." is also often used as "ca", "ca.", "cca" and "cca."

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/gedcom/228)
<!-- Reviewable:end -->
