### PR TITLE
Decoder: More flexible pointers. Fixes #230

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -149,7 +149,7 @@ func (dec *Decoder) readLine() (string, error) {
 	return string(buf.Bytes()), nil
 }
 
-var lineRegexp = regexp.MustCompile(`^(\d) (@\w+@ )?(\w+) ?(.*)?$`)
+var lineRegexp = regexp.MustCompile(`^(\d) (@[^@]+@ )?(\w+) ?(.*)?$`)
 
 func parseLine(document *Document, line string) (Node, int, error) {
 	parts := lineRegexp.FindStringSubmatch(line)

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -181,6 +181,27 @@ var tests = map[string]*gedcom.Document{
 	"0 NAME κόσμε": gedcom.NewDocumentWithNodes([]gedcom.Node{
 		gedcom.NewNameNode(nil, "κόσμε", "", nil),
 	}),
+
+	// Non alphanumeric characters are allowed.
+	"0 @R-1577718385@ FAM": gedcom.NewDocumentWithNodes([]gedcom.Node{
+		gedcom.NewFamilyNode(nil, "R-1577718385", nil),
+	}),
+
+	// Crazy long pointer values are also fine.
+	"0 @SomeReallyLongPointerThatShouldProbablyNotBeUsedByWeShouldDemonstrateThatThereIsNoLimitToTheLength@ FAM": gedcom.NewDocumentWithNodes([]gedcom.Node{
+		gedcom.NewFamilyNode(nil, "SomeReallyLongPointerThatShouldProbablyNotBeUsedByWeShouldDemonstrateThatThereIsNoLimitToTheLength", nil),
+	}),
+
+	// Any punctuation is permitted as long as it isn't an "@".
+	"0 @~!-#$%^&*()@ FAM": gedcom.NewDocumentWithNodes([]gedcom.Node{
+		gedcom.NewFamilyNode(nil, "~!-#$%^&*()", nil),
+	}),
+
+	// Make sure we are not using a greedy consume so that "@" can also be in
+	// the value.
+	"0 @uh@ NAME oh@ok": gedcom.NewDocumentWithNodes([]gedcom.Node{
+		gedcom.NewNameNode(nil, "oh@ok", "uh", nil),
+	}),
 }
 
 func TestDecoder_Decode(t *testing.T) {


### PR DESCRIPTION
Pointers can really include anything, apart from a "@". This patch also adds some more test edge cases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/gedcom/231)
<!-- Reviewable:end -->
