### PR TITLE
Vastly improved API

### DIFF
--- a/baptism_node.go
+++ b/baptism_node.go
@@ -8,9 +8,9 @@ type BaptismNode struct {
 }
 
 // NewBaptismNode creates a new BAPM node.
-func NewBaptismNode(document *Document, value, pointer string, children []Node) *BaptismNode {
+func NewBaptismNode(value string, children ...Node) *BaptismNode {
 	return &BaptismNode{
-		newSimpleNode(document, TagBaptism, value, pointer, children),
+		newSimpleNode(TagBaptism, value, "", children...),
 	}
 }
 

--- a/baptism_node_test.go
+++ b/baptism_node_test.go
@@ -9,15 +9,13 @@ import (
 )
 
 func TestNewBaptismNode(t *testing.T) {
-	doc := gedcom.NewDocument()
-	child := gedcom.NewNameNode(doc, "", "", nil)
-	node := gedcom.NewBaptismNode(doc, "foo", "bar", []gedcom.Node{child})
+	child := gedcom.NewNameNode("")
+	node := gedcom.NewBaptismNode("foo", child)
 
 	assert.Equal(t, gedcom.TagBaptism, node.Tag())
-	assert.Equal(t, []gedcom.Node{child}, node.Nodes())
-	assert.Equal(t, doc, node.Document())
+	assert.Equal(t, gedcom.Nodes{child}, node.Nodes())
 	assert.Equal(t, "foo", node.Value())
-	assert.Equal(t, "bar", node.Pointer())
+	assert.Equal(t, "", node.Pointer())
 }
 
 func TestBaptismNode_Dates(t *testing.T) {
@@ -25,31 +23,31 @@ func TestBaptismNode_Dates(t *testing.T) {
 
 	Dates((*gedcom.BaptismNode)(nil)).Returns([]*gedcom.DateNode(nil))
 
-	Dates(gedcom.NewBaptismNode(nil, "", "", nil)).Returns([]*gedcom.DateNode(nil))
+	Dates(gedcom.NewBaptismNode("")).Returns([]*gedcom.DateNode(nil))
 
-	Dates(gedcom.NewBaptismNode(nil, "", "", []gedcom.Node{})).
+	Dates(gedcom.NewBaptismNode("")).
 		Returns([]*gedcom.DateNode(nil))
 
-	Dates(gedcom.NewBaptismNode(nil, "", "", []gedcom.Node{
-		gedcom.NewDateNode(nil, "3 Sep 2001", "", nil),
-	})).Returns([]*gedcom.DateNode{
-		gedcom.NewDateNode(nil, "3 Sep 2001", "", nil),
+	Dates(gedcom.NewBaptismNode("",
+		gedcom.NewDateNode("3 Sep 2001"),
+	)).Returns([]*gedcom.DateNode{
+		gedcom.NewDateNode("3 Sep 2001"),
 	})
 
-	Dates(gedcom.NewBaptismNode(nil, "", "", []gedcom.Node{
-		gedcom.NewDateNode(nil, "7 Jan 2001", "", nil),
-		gedcom.NewDateNode(nil, "3 Sep 2001", "", nil),
-	})).Returns([]*gedcom.DateNode{
-		gedcom.NewDateNode(nil, "7 Jan 2001", "", nil),
-		gedcom.NewDateNode(nil, "3 Sep 2001", "", nil),
+	Dates(gedcom.NewBaptismNode("",
+		gedcom.NewDateNode("7 Jan 2001"),
+		gedcom.NewDateNode("3 Sep 2001"),
+	)).Returns([]*gedcom.DateNode{
+		gedcom.NewDateNode("7 Jan 2001"),
+		gedcom.NewDateNode("3 Sep 2001"),
 	})
 }
 
 func TestBaptismNode_Equals(t *testing.T) {
 	Equals := tf.Function(t, (*gedcom.BaptismNode).Equals)
 
-	n1 := gedcom.NewBaptismNode(nil, "foo", "", nil)
-	n2 := gedcom.NewBaptismNode(nil, "bar", "", nil)
+	n1 := gedcom.NewBaptismNode("foo")
+	n2 := gedcom.NewBaptismNode("bar")
 
 	// nils
 	Equals((*gedcom.BaptismNode)(nil), (*gedcom.BaptismNode)(nil)).Returns(false)
@@ -57,7 +55,7 @@ func TestBaptismNode_Equals(t *testing.T) {
 	Equals((*gedcom.BaptismNode)(nil), n1).Returns(false)
 
 	// Wrong node type.
-	Equals(n1, gedcom.NewNameNode(nil, "foo", "", nil)).Returns(false)
+	Equals(n1, gedcom.NewNameNode("foo")).Returns(false)
 
 	// All other cases are success.
 	Equals(n1, n1).Returns(true)

--- a/birth_node.go
+++ b/birth_node.go
@@ -6,9 +6,9 @@ type BirthNode struct {
 }
 
 // NewBirthNode creates a new BIRT node.
-func NewBirthNode(document *Document, value, pointer string, children []Node) *BirthNode {
+func NewBirthNode(value string, children ...Node) *BirthNode {
 	return &BirthNode{
-		newSimpleNode(document, TagBirth, value, pointer, children),
+		newSimpleNode(TagBirth, value, "", children...),
 	}
 }
 

--- a/birth_node_test.go
+++ b/birth_node_test.go
@@ -9,47 +9,42 @@ import (
 )
 
 func TestNewBirthNode(t *testing.T) {
-	doc := gedcom.NewDocument()
-	child := gedcom.NewNameNode(doc, "", "", nil)
-	node := gedcom.NewBirthNode(doc, "foo", "bar", []gedcom.Node{child})
+	child := gedcom.NewNameNode("")
+	node := gedcom.NewBirthNode("foo", child)
 
 	assert.Equal(t, gedcom.TagBirth, node.Tag())
-	assert.Equal(t, []gedcom.Node{child}, node.Nodes())
-	assert.Equal(t, doc, node.Document())
+	assert.Equal(t, gedcom.Nodes{child}, node.Nodes())
 	assert.Equal(t, "foo", node.Value())
-	assert.Equal(t, "bar", node.Pointer())
+	assert.Equal(t, "", node.Pointer())
 }
 
 func TestBirthNode_Dates(t *testing.T) {
-	Dates := tf.Function(t, (*gedcom.BirthNode).Dates)
+	Dates := tf.NamedFunction(t, "BirthNode_Dates", (*gedcom.BirthNode).Dates)
 
 	Dates((*gedcom.BirthNode)(nil)).Returns([]*gedcom.DateNode(nil))
 
-	Dates(gedcom.NewBirthNode(nil, "", "", nil)).Returns([]*gedcom.DateNode(nil))
+	Dates(gedcom.NewBirthNode("")).Returns([]*gedcom.DateNode(nil))
 
-	Dates(gedcom.NewBirthNode(nil, "", "", []gedcom.Node{})).
-		Returns([]*gedcom.DateNode(nil))
-
-	Dates(gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
-		gedcom.NewDateNode(nil, "3 Sep 2001", "", nil),
-	})).Returns([]*gedcom.DateNode{
-		gedcom.NewDateNode(nil, "3 Sep 2001", "", nil),
+	Dates(gedcom.NewBirthNode("",
+		gedcom.NewDateNode("3 Sep 2001"),
+	)).Returns([]*gedcom.DateNode{
+		gedcom.NewDateNode("3 Sep 2001"),
 	})
 
-	Dates(gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
-		gedcom.NewDateNode(nil, "7 Jan 2001", "", nil),
-		gedcom.NewDateNode(nil, "3 Sep 2001", "", nil),
-	})).Returns([]*gedcom.DateNode{
-		gedcom.NewDateNode(nil, "7 Jan 2001", "", nil),
-		gedcom.NewDateNode(nil, "3 Sep 2001", "", nil),
+	Dates(gedcom.NewBirthNode("",
+		gedcom.NewDateNode("7 Jan 2001"),
+		gedcom.NewDateNode("3 Sep 2001"),
+	)).Returns([]*gedcom.DateNode{
+		gedcom.NewDateNode("7 Jan 2001"),
+		gedcom.NewDateNode("3 Sep 2001"),
 	})
 }
 
 func TestBirthNode_Equals(t *testing.T) {
 	Equals := tf.Function(t, (*gedcom.BirthNode).Equals)
 
-	n1 := gedcom.NewBirthNode(nil, "foo", "", nil)
-	n2 := gedcom.NewBirthNode(nil, "bar", "", nil)
+	n1 := gedcom.NewBirthNode("foo")
+	n2 := gedcom.NewBirthNode("bar")
 
 	// nils
 	Equals((*gedcom.BirthNode)(nil), (*gedcom.BirthNode)(nil)).Returns(false)
@@ -57,7 +52,7 @@ func TestBirthNode_Equals(t *testing.T) {
 	Equals((*gedcom.BirthNode)(nil), n1).Returns(false)
 
 	// Wrong node type.
-	Equals(n1, gedcom.NewNameNode(nil, "foo", "", nil)).Returns(false)
+	Equals(n1, gedcom.NewNameNode("foo")).Returns(false)
 
 	// All other cases are success.
 	Equals(n1, n1).Returns(true)

--- a/burial_node.go
+++ b/burial_node.go
@@ -7,9 +7,9 @@ type BurialNode struct {
 }
 
 // NewBurialNode creates a new BURI node.
-func NewBurialNode(document *Document, value, pointer string, children []Node) *BurialNode {
+func NewBurialNode(value string, children ...Node) *BurialNode {
 	return &BurialNode{
-		newSimpleNode(document, TagBurial, value, pointer, children),
+		newSimpleNode(TagBurial, value, "", children...),
 	}
 }
 

--- a/burial_node_test.go
+++ b/burial_node_test.go
@@ -9,15 +9,13 @@ import (
 )
 
 func TestNewBurialNode(t *testing.T) {
-	doc := gedcom.NewDocument()
-	child := gedcom.NewNameNode(doc, "", "", nil)
-	node := gedcom.NewBurialNode(doc, "foo", "bar", []gedcom.Node{child})
+	child := gedcom.NewNameNode("")
+	node := gedcom.NewBurialNode("foo", child)
 
 	assert.Equal(t, gedcom.TagBurial, node.Tag())
-	assert.Equal(t, []gedcom.Node{child}, node.Nodes())
-	assert.Equal(t, doc, node.Document())
+	assert.Equal(t, gedcom.Nodes{child}, node.Nodes())
 	assert.Equal(t, "foo", node.Value())
-	assert.Equal(t, "bar", node.Pointer())
+	assert.Equal(t, "", node.Pointer())
 }
 
 func TestBurialNode_Dates(t *testing.T) {
@@ -25,31 +23,28 @@ func TestBurialNode_Dates(t *testing.T) {
 
 	Dates((*gedcom.BurialNode)(nil)).Returns([]*gedcom.DateNode(nil))
 
-	Dates(gedcom.NewBurialNode(nil, "", "", nil)).Returns([]*gedcom.DateNode(nil))
+	Dates(gedcom.NewBurialNode("")).Returns([]*gedcom.DateNode(nil))
 
-	Dates(gedcom.NewBurialNode(nil, "", "", []gedcom.Node{})).
-		Returns([]*gedcom.DateNode(nil))
-
-	Dates(gedcom.NewBurialNode(nil, "", "", []gedcom.Node{
-		gedcom.NewDateNode(nil, "3 Sep 2001", "", nil),
-	})).Returns([]*gedcom.DateNode{
-		gedcom.NewDateNode(nil, "3 Sep 2001", "", nil),
+	Dates(gedcom.NewBurialNode("",
+		gedcom.NewDateNode("3 Sep 2001"),
+	)).Returns([]*gedcom.DateNode{
+		gedcom.NewDateNode("3 Sep 2001"),
 	})
 
-	Dates(gedcom.NewBurialNode(nil, "", "", []gedcom.Node{
-		gedcom.NewDateNode(nil, "7 Jan 2001", "", nil),
-		gedcom.NewDateNode(nil, "3 Sep 2001", "", nil),
-	})).Returns([]*gedcom.DateNode{
-		gedcom.NewDateNode(nil, "7 Jan 2001", "", nil),
-		gedcom.NewDateNode(nil, "3 Sep 2001", "", nil),
+	Dates(gedcom.NewBurialNode("",
+		gedcom.NewDateNode("7 Jan 2001"),
+		gedcom.NewDateNode("3 Sep 2001"),
+	)).Returns([]*gedcom.DateNode{
+		gedcom.NewDateNode("7 Jan 2001"),
+		gedcom.NewDateNode("3 Sep 2001"),
 	})
 }
 
 func TestBurialNode_Equals(t *testing.T) {
 	Equals := tf.Function(t, (*gedcom.BurialNode).Equals)
 
-	n1 := gedcom.NewBurialNode(nil, "foo", "", nil)
-	n2 := gedcom.NewBurialNode(nil, "bar", "", nil)
+	n1 := gedcom.NewBurialNode("foo")
+	n2 := gedcom.NewBurialNode("bar")
 
 	// nils
 	Equals((*gedcom.BurialNode)(nil), (*gedcom.BurialNode)(nil)).Returns(false)
@@ -57,7 +52,7 @@ func TestBurialNode_Equals(t *testing.T) {
 	Equals((*gedcom.BurialNode)(nil), n1).Returns(false)
 
 	// Wrong node type.
-	Equals(n1, gedcom.NewNameNode(nil, "foo", "", nil)).Returns(false)
+	Equals(n1, gedcom.NewNameNode("foo")).Returns(false)
 
 	// All other cases are success.
 	Equals(n1, n1).Returns(true)

--- a/child_node.go
+++ b/child_node.go
@@ -1,0 +1,33 @@
+package gedcom
+
+import "fmt"
+
+// ChildNode is the natural, adopted, or sealed (LDS) child of a father and a
+// mother.
+type ChildNode struct {
+	*SimpleNode
+	family *FamilyNode
+}
+
+func newChildNode(family *FamilyNode, value string, children ...Node) *ChildNode {
+	return &ChildNode{
+		newSimpleNode(TagChild, value, "", children...),
+		family,
+	}
+}
+
+func newChildNodeWithIndividual(family *FamilyNode, individual *IndividualNode) *ChildNode {
+	// TODO: check individual belongs to the same document as family
+	return newChildNode(family, fmt.Sprintf("@%s@", individual.Pointer()))
+}
+
+func (node *ChildNode) Family() *FamilyNode {
+	return node.family
+}
+
+func (node *ChildNode) Individual() *IndividualNode {
+	n := node.family.document.NodeByPointer(valueToPointer(node.value))
+
+	// TODO: may not exist
+	return n.(*IndividualNode)
+}

--- a/child_nodes.go
+++ b/child_nodes.go
@@ -1,0 +1,38 @@
+package gedcom
+
+type ChildNodes []*ChildNode
+
+func (nodes ChildNodes) Individuals() (individuals IndividualNodes) {
+	for _, child := range nodes {
+		pointer := valueToPointer(child.Value())
+		individual := nodes[0].Family().Document().NodeByPointer(pointer)
+
+		individuals = append(individuals, individual.(*IndividualNode))
+	}
+
+	return
+}
+
+func (nodes ChildNodes) Similarity(other ChildNodes, options SimilarityOptions) float64 {
+	return nodes.Individuals().Similarity(other.Individuals(), options)
+}
+
+func (nodes ChildNodes) ByPointer(pointer string) *ChildNode {
+	for _, node := range nodes {
+		if node.Individual().Pointer() == pointer {
+			return node
+		}
+	}
+
+	return nil
+}
+
+func (nodes ChildNodes) IndividualByPointer(pointer string) *IndividualNode {
+	for _, node := range nodes {
+		if node.Individual().Pointer() == pointer {
+			return node.Individual()
+		}
+	}
+
+	return nil
+}

--- a/copy_test.go
+++ b/copy_test.go
@@ -7,19 +7,19 @@ import (
 )
 
 func TestDeepCopy(t *testing.T) {
-	dateNode1 := gedcom.NewDateNode(nil, "1851", "", nil)
-	dateNode2 := gedcom.NewDateNode(nil, "1856", "", nil)
-	birthNode := gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
+	dateNode1 := gedcom.NewDateNode("1851")
+	dateNode2 := gedcom.NewDateNode("1856")
+	birthNode := gedcom.NewBirthNode("",
 		dateNode1,
-	})
-	deathNode := gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
+	)
+	deathNode := gedcom.NewBirthNode("",
 		dateNode1,
 		dateNode2,
-	})
-	individualNode := gedcom.NewIndividualNode(nil, "", "P221", []gedcom.Node{
+	)
+	individualNode := gedcom.NewDocument().AddIndividual("P221",
 		birthNode,
 		deathNode,
-	})
+	)
 
 	t.Run("Nil", func(t *testing.T) {
 		actual := gedcom.DeepCopy(nil)

--- a/date_node.go
+++ b/date_node.go
@@ -163,9 +163,9 @@ type DateNode struct {
 }
 
 // NewDateNode creates a new DATE node.
-func NewDateNode(document *Document, value, pointer string, children []Node) *DateNode {
+func NewDateNode(value string, children ...Node) *DateNode {
 	return &DateNode{
-		newSimpleNode(document, TagDate, value, pointer, children),
+		newSimpleNode(TagDate, value, "", children...),
 		false, Date{}, Date{},
 	}
 }

--- a/date_node_test.go
+++ b/date_node_test.go
@@ -486,7 +486,7 @@ var dateTests = map[string]struct {
 func TestDateNode_StartDate(t *testing.T) {
 	for date, test := range dateTests {
 		t.Run(date, func(t *testing.T) {
-			node := gedcom.NewDateNode(nil, date, "", nil)
+			node := gedcom.NewDateNode(date)
 
 			assert.Equal(t, node.StartDate(), test.startDate)
 		})
@@ -500,7 +500,7 @@ func TestDateNode_StartDate(t *testing.T) {
 func TestDateNode_EndDate(t *testing.T) {
 	for date, test := range dateTests {
 		t.Run(date, func(t *testing.T) {
-			node := gedcom.NewDateNode(nil, date, "", nil)
+			node := gedcom.NewDateNode(date)
 
 			assert.Equal(t, node.EndDate(), test.endDate)
 		})
@@ -514,7 +514,7 @@ func TestDateNode_EndDate(t *testing.T) {
 func TestDateNode_String(t *testing.T) {
 	for date, test := range dateTests {
 		t.Run(date, func(t *testing.T) {
-			node := gedcom.NewDateNode(nil, date, "", nil)
+			node := gedcom.NewDateNode(date)
 
 			assert.Equalf(t, test.str, node.String(), "%#+v", date)
 		})
@@ -534,42 +534,42 @@ func TestDateNode_Years(t *testing.T) {
 		{nil, 0.0},
 
 		// Zero
-		{gedcom.NewDateNode(nil, "", "", nil), 0.0},
+		{gedcom.NewDateNode(""), 0.0},
 
 		// Year
-		{gedcom.NewDateNode(nil, "750", "", nil), 750.5},
-		{gedcom.NewDateNode(nil, "1845", "", nil), 1845.5},
+		{gedcom.NewDateNode("750"), 750.5},
+		{gedcom.NewDateNode("1845"), 1845.5},
 
 		// Months
-		{gedcom.NewDateNode(nil, "Jan 1845", "", nil), 1845.0437158469945},
-		{gedcom.NewDateNode(nil, "Mar 1999", "", nil), 1999.204918032787},
-		{gedcom.NewDateNode(nil, "Dec 1832", "", nil), 1832.956403269755},
+		{gedcom.NewDateNode("Jan 1845"), 1845.0437158469945},
+		{gedcom.NewDateNode("Mar 1999"), 1999.204918032787},
+		{gedcom.NewDateNode("Dec 1832"), 1832.956403269755},
 
 		// Days
-		{gedcom.NewDateNode(nil, "1 Jan 1789", "", nil), 1789.0027322404371},
-		{gedcom.NewDateNode(nil, "31 Jan 1435", "", nil), 1435.0846994535518},
-		{gedcom.NewDateNode(nil, "1 Feb 1601", "", nil), 1601.0874316939892},
-		{gedcom.NewDateNode(nil, "1 Mar 845", "", nil), 845.1639344262295},
-		{gedcom.NewDateNode(nil, "31 Dec 2010", "", nil), 2010.9972677595629},
+		{gedcom.NewDateNode("1 Jan 1789"), 1789.0027322404371},
+		{gedcom.NewDateNode("31 Jan 1435"), 1435.0846994535518},
+		{gedcom.NewDateNode("1 Feb 1601"), 1601.0874316939892},
+		{gedcom.NewDateNode("1 Mar 845"), 845.1639344262295},
+		{gedcom.NewDateNode("31 Dec 2010"), 2010.9972677595629},
 
 		// Ranges
 		{
-			gedcom.NewDateNode(nil, "Bet. 1 Jan 1789 and 1 Mar 1789", "", nil),
+			gedcom.NewDateNode("Bet. 1 Jan 1789 and 1 Mar 1789"),
 			1789.0833333333335,
 		},
 		{
-			gedcom.NewDateNode(nil, "Bet. 1 Jan 1789 and 1 Jan 1789", "", nil),
+			gedcom.NewDateNode("Bet. 1 Jan 1789 and 1 Jan 1789"),
 			// Same as "1 Jan 1789"
 			1789.0027322404371,
 		},
 		{
-			gedcom.NewDateNode(nil, "Bet. 1430 and 1435", "", nil),
+			gedcom.NewDateNode("Bet. 1430 and 1435"),
 			// From the start of 1430 to the end of 1435 is actually 6 years.
 			1433,
 		},
 
 		// Invalid
-		{gedcom.NewDateNode(nil, "Foo", "", nil), 0},
+		{gedcom.NewDateNode("Foo"), 0},
 	}
 
 	for _, test := range tests {
@@ -587,143 +587,143 @@ func TestDateNode_Similarity(t *testing.T) {
 	}{
 		// Two unknown dates will be equal to each other.
 		{
-			gedcom.NewDateNode(nil, "", "", nil),
-			gedcom.NewDateNode(nil, "", "", nil),
+			gedcom.NewDateNode(""),
+			gedcom.NewDateNode(""),
 			1,
 		},
 
 		// The difference will be same regardless of time line so the two next
 		// tests must return the same similarity.
 		{
-			gedcom.NewDateNode(nil, "500", "", nil),
-			gedcom.NewDateNode(nil, "502", "", nil),
+			gedcom.NewDateNode("500"),
+			gedcom.NewDateNode("502"),
 			0.96,
 		},
 		{
-			gedcom.NewDateNode(nil, "2000", "", nil),
-			gedcom.NewDateNode(nil, "2002", "", nil),
+			gedcom.NewDateNode("2000"),
+			gedcom.NewDateNode("2002"),
 			0.96,
 		},
 
 		// A higher score is awarded to values that are closer to each other.
 		{
-			gedcom.NewDateNode(nil, "1900", "", nil),
-			gedcom.NewDateNode(nil, "1901", "", nil),
+			gedcom.NewDateNode("1900"),
+			gedcom.NewDateNode("1901"),
 			0.99,
 		},
 		{
-			gedcom.NewDateNode(nil, "1900", "", nil),
-			gedcom.NewDateNode(nil, "1904", "", nil),
+			gedcom.NewDateNode("1900"),
+			gedcom.NewDateNode("1904"),
 			0.84,
 		},
 
 		// Months
 		{
-			gedcom.NewDateNode(nil, "Feb 2000", "", nil),
-			gedcom.NewDateNode(nil, "Mar 2000", "", nil),
+			gedcom.NewDateNode("Feb 2000"),
+			gedcom.NewDateNode("Mar 2000"),
 			0.9999331793984663,
 		},
 		{
-			gedcom.NewDateNode(nil, "Feb 2000", "", nil),
-			gedcom.NewDateNode(nil, "Feb 2001", "", nil),
+			gedcom.NewDateNode("Feb 2000"),
+			gedcom.NewDateNode("Feb 2001"),
 			0.9900204627124954,
 		},
 
 		// Days
 		{
-			gedcom.NewDateNode(nil, "13 Feb 2000", "", nil),
-			gedcom.NewDateNode(nil, "14 Feb 2000", "", nil),
+			gedcom.NewDateNode("13 Feb 2000"),
+			gedcom.NewDateNode("14 Feb 2000"),
 			0.9999999257548872,
 		},
 		{
-			gedcom.NewDateNode(nil, "13 Feb 2000", "", nil),
-			gedcom.NewDateNode(nil, "13 Apr 2000", "", nil),
+			gedcom.NewDateNode("13 Feb 2000"),
+			gedcom.NewDateNode("13 Apr 2000"),
 			0.9997327175938642,
 		},
 
 		// Exact matches
 		{
-			gedcom.NewDateNode(nil, "2000", "", nil),
-			gedcom.NewDateNode(nil, "2000", "", nil),
+			gedcom.NewDateNode("2000"),
+			gedcom.NewDateNode("2000"),
 			1,
 		},
 		{
-			gedcom.NewDateNode(nil, "Mar 2000", "", nil),
-			gedcom.NewDateNode(nil, "Mar 2000", "", nil),
+			gedcom.NewDateNode("Mar 2000"),
+			gedcom.NewDateNode("Mar 2000"),
 			1,
 		},
 		{
-			gedcom.NewDateNode(nil, "13 Mar 2000", "", nil),
-			gedcom.NewDateNode(nil, "13 Mar 2000", "", nil),
+			gedcom.NewDateNode("13 Mar 2000"),
+			gedcom.NewDateNode("13 Mar 2000"),
 			1,
 		},
 		{
-			gedcom.NewDateNode(nil, "Bet. 2000 and 2003", "", nil),
-			gedcom.NewDateNode(nil, "Between 2000 and 2003", "", nil),
+			gedcom.NewDateNode("Bet. 2000 and 2003"),
+			gedcom.NewDateNode("Between 2000 and 2003"),
 			1,
 		},
 		{
-			gedcom.NewDateNode(nil, "Bet. Mar 2000 and Oct 2000", "", nil),
-			gedcom.NewDateNode(nil, "Bet. Mar 2000 and Oct 2000", "", nil),
+			gedcom.NewDateNode("Bet. Mar 2000 and Oct 2000"),
+			gedcom.NewDateNode("Bet. Mar 2000 and Oct 2000"),
 			1,
 		},
 		{
-			gedcom.NewDateNode(nil, "bet. 13 Mar 2000 and 17 March 2000", "", nil),
-			gedcom.NewDateNode(nil, "Between 13 Mar 2000 and 17 March 2000", "", nil),
+			gedcom.NewDateNode("bet. 13 Mar 2000 and 17 March 2000"),
+			gedcom.NewDateNode("Between 13 Mar 2000 and 17 March 2000"),
 			1,
 		},
 
 		// These ranges are inverse so they have the same difference.
 		{
-			gedcom.NewDateNode(nil, "Bet. 2000 and 2003", "", nil),
-			gedcom.NewDateNode(nil, "Between 2001 and 2003", "", nil),
+			gedcom.NewDateNode("Bet. 2000 and 2003"),
+			gedcom.NewDateNode("Between 2001 and 2003"),
 			0.9975,
 		},
 		{
-			gedcom.NewDateNode(nil, "Bet. 2001 and 2003", "", nil),
-			gedcom.NewDateNode(nil, "Between 2000 and 2003", "", nil),
+			gedcom.NewDateNode("Bet. 2001 and 2003"),
+			gedcom.NewDateNode("Between 2000 and 2003"),
 			0.9975,
 		},
 
 		// Range has the same difference but over different time periods.
 		{
-			gedcom.NewDateNode(nil, "Bet. 2000 and 2003", "", nil),
-			gedcom.NewDateNode(nil, "Between 1997 and 2000", "", nil),
+			gedcom.NewDateNode("Bet. 2000 and 2003"),
+			gedcom.NewDateNode("Between 1997 and 2000"),
 			0.91,
 		},
 
 		// Other ranges.
 		{
-			gedcom.NewDateNode(nil, "Bet. Mar 2000 and Oct 2000", "", nil),
-			gedcom.NewDateNode(nil, "Bet. Feb 2000 and Oct 2000", "", nil),
+			gedcom.NewDateNode("Bet. Mar 2000 and Oct 2000"),
+			gedcom.NewDateNode("Bet. Feb 2000 and Oct 2000"),
 			0.9999832948496166,
 		},
 		{
-			gedcom.NewDateNode(nil, "bet. 15 Mar 2000 and 23 March 2000", "", nil),
-			gedcom.NewDateNode(nil, "Between 15 Mar 2000 and 25 March 2000", "", nil),
+			gedcom.NewDateNode("bet. 15 Mar 2000 and 23 March 2000"),
+			gedcom.NewDateNode("Between 15 Mar 2000 and 25 March 2000"),
 			0.9999999257548872,
 		},
 
 		// Invalid
 		{
-			gedcom.NewDateNode(nil, "Foo", "", nil),
-			gedcom.NewDateNode(nil, "13 Mar 2000", "", nil),
+			gedcom.NewDateNode("Foo"),
+			gedcom.NewDateNode("13 Mar 2000"),
 			0,
 		},
 		{
-			gedcom.NewDateNode(nil, "13 Mar 2000", "", nil),
-			gedcom.NewDateNode(nil, "Bar", "", nil),
+			gedcom.NewDateNode("13 Mar 2000"),
+			gedcom.NewDateNode("Bar"),
 			0,
 		},
 
 		// Nil cases
 		{
 			nil,
-			gedcom.NewDateNode(nil, "Jan 1845", "", nil),
+			gedcom.NewDateNode("Jan 1845"),
 			0.5,
 		},
 		{
-			gedcom.NewDateNode(nil, "Jan 1845", "", nil),
+			gedcom.NewDateNode("Jan 1845"),
 			nil,
 			0.5,
 		},
@@ -744,25 +744,25 @@ func TestDateNode_Similarity(t *testing.T) {
 
 func TestDateNode_Equals(t *testing.T) {
 	// d1 and d2 are the same value.
-	d1 := gedcom.NewDateNode(nil, "15 SEP 1985", "", nil)
-	d2 := gedcom.NewDateNode(nil, "15 September 1985", "", nil)
+	d1 := gedcom.NewDateNode("15 SEP 1985")
+	d2 := gedcom.NewDateNode("15 September 1985")
 
 	// d3 and d4 represent the same enclosed ranges.
-	d3 := gedcom.NewDateNode(nil, "Bet. Oct 2000 and 3 Apr 2008", "", nil)
-	d4 := gedcom.NewDateNode(nil, "From OCT 2000 to Bef. Jun 2008", "", nil)
+	d3 := gedcom.NewDateNode("Bet. Oct 2000 and 3 Apr 2008")
+	d4 := gedcom.NewDateNode("From OCT 2000 to Bef. Jun 2008")
 
 	// d5 has a different Start from d3 and d4.
-	d5 := gedcom.NewDateNode(nil, "From Jun 2000 to 3 Apr 2008", "", nil)
+	d5 := gedcom.NewDateNode("From Jun 2000 to 3 Apr 2008")
 
 	// d6 to d8 are phrases.
-	d6 := gedcom.NewDateNode(nil, "(Foo)", "", nil)
-	d7 := gedcom.NewDateNode(nil, "(15 SEP 1985)", "", nil)
-	d8 := gedcom.NewDateNode(nil, "(Foo)", "", nil)
+	d6 := gedcom.NewDateNode("(Foo)")
+	d7 := gedcom.NewDateNode("(15 SEP 1985)")
+	d8 := gedcom.NewDateNode("(Foo)")
 
 	// d9 to d11 are invalid.
-	d9 := gedcom.NewDateNode(nil, "@#DJULIAN@ 01 JAN 1323", "", nil)
-	d10 := gedcom.NewDateNode(nil, "!! 15 SEP 1985", "", nil)
-	d11 := gedcom.NewDateNode(nil, "@#DJULIAN@ 01 JAN 1323", "", nil)
+	d9 := gedcom.NewDateNode("@#DJULIAN@ 01 JAN 1323")
+	d10 := gedcom.NewDateNode("!! 15 SEP 1985")
+	d11 := gedcom.NewDateNode("@#DJULIAN@ 01 JAN 1323")
 
 	Equals := tf.Function(t, (*gedcom.DateNode).Equals)
 
@@ -773,8 +773,8 @@ func TestDateNode_Equals(t *testing.T) {
 	Equals(d6, (*gedcom.DateNode)(nil)).Returns(false)
 
 	// Bad input
-	Equals(d1, gedcom.NewNameNode(nil, "15 SEP 1985", "", nil)).Returns(false)
-	Equals(d6, gedcom.NewNameNode(nil, "15 SEP 1985", "", nil)).Returns(false)
+	Equals(d1, gedcom.NewNameNode("15 SEP 1985")).Returns(false)
+	Equals(d6, gedcom.NewNameNode("15 SEP 1985")).Returns(false)
 
 	// General cases.
 	Equals(d1, d2).Returns(true)
@@ -810,12 +810,12 @@ func TestDateNode_IsPhrase(t *testing.T) {
 	IsPhrase := tf.Function(t, (*gedcom.DateNode).IsPhrase)
 
 	IsPhrase((*gedcom.DateNode)(nil)).Returns(false)
-	IsPhrase(gedcom.NewDateNode(nil, "", "", nil)).Returns(false)
-	IsPhrase(gedcom.NewDateNode(nil, "(", "", nil)).Returns(false)
-	IsPhrase(gedcom.NewDateNode(nil, ")", "", nil)).Returns(false)
-	IsPhrase(gedcom.NewDateNode(nil, "3 Mar 1981", "", nil)).Returns(false)
+	IsPhrase(gedcom.NewDateNode("")).Returns(false)
+	IsPhrase(gedcom.NewDateNode("(")).Returns(false)
+	IsPhrase(gedcom.NewDateNode(")")).Returns(false)
+	IsPhrase(gedcom.NewDateNode("3 Mar 1981")).Returns(false)
 
-	IsPhrase(gedcom.NewDateNode(nil, "()", "", nil)).Returns(true)
-	IsPhrase(gedcom.NewDateNode(nil, "(Foo)", "", nil)).Returns(true)
-	IsPhrase(gedcom.NewDateNode(nil, "(Foo BAR)", "", nil)).Returns(true)
+	IsPhrase(gedcom.NewDateNode("()")).Returns(true)
+	IsPhrase(gedcom.NewDateNode("(Foo)")).Returns(true)
+	IsPhrase(gedcom.NewDateNode("(Foo BAR)")).Returns(true)
 }

--- a/date_nodes_test.go
+++ b/date_nodes_test.go
@@ -10,9 +10,9 @@ import (
 func TestDateNodes_Minimum(t *testing.T) {
 	Minimum := tf.Function(t, gedcom.DateNodes.Minimum)
 
-	at3Sep1923 := gedcom.NewDateNode(nil, "3 Sep 1923", "", nil)
-	at4Mar1923 := gedcom.NewDateNode(nil, "4 Mar 1923", "", nil)
-	at5Mar1923 := gedcom.NewDateNode(nil, "5 Mar 1923", "", nil)
+	at3Sep1923 := gedcom.NewDateNode("3 Sep 1923")
+	at4Mar1923 := gedcom.NewDateNode("4 Mar 1923")
+	at5Mar1923 := gedcom.NewDateNode("5 Mar 1923")
 
 	// Nils
 	Minimum(([]*gedcom.DateNode)(nil)).Returns((*gedcom.DateNode)(nil))
@@ -36,8 +36,8 @@ func TestDateNodes_Minimum(t *testing.T) {
 
 	// When comparing date ranges we must look at the specific bounds, rather
 	// than just the average.
-	btw1923And1943 := gedcom.NewDateNode(nil, "Between 1923 and 1943", "", nil)
-	btw1924And1934 := gedcom.NewDateNode(nil, "Between 1924 and 1934", "", nil)
+	btw1923And1943 := gedcom.NewDateNode("Between 1923 and 1943")
+	btw1924And1934 := gedcom.NewDateNode("Between 1924 and 1934")
 	Minimum([]*gedcom.DateNode{
 		btw1923And1943, // avg = 1933, value = 1923
 		btw1924And1934, // avg = 1929, value = 1924
@@ -47,9 +47,9 @@ func TestDateNodes_Minimum(t *testing.T) {
 func TestDateNodes_Maximum(t *testing.T) {
 	Maximum := tf.Function(t, gedcom.DateNodes.Maximum)
 
-	at3Sep1923 := gedcom.NewDateNode(nil, "3 Sep 1923", "", nil)
-	at4Mar1923 := gedcom.NewDateNode(nil, "4 Mar 1923", "", nil)
-	at5Mar1923 := gedcom.NewDateNode(nil, "5 Mar 1923", "", nil)
+	at3Sep1923 := gedcom.NewDateNode("3 Sep 1923")
+	at4Mar1923 := gedcom.NewDateNode("4 Mar 1923")
+	at5Mar1923 := gedcom.NewDateNode("5 Mar 1923")
 
 	// Nils
 	Maximum(([]*gedcom.DateNode)(nil)).Returns((*gedcom.DateNode)(nil))
@@ -73,8 +73,8 @@ func TestDateNodes_Maximum(t *testing.T) {
 
 	// When comparing date ranges we must look at the specific bounds, rather
 	// than just the average.
-	btw1903And1924 := gedcom.NewDateNode(nil, "Between 1904 and 1924", "", nil)
-	btw1913And1923 := gedcom.NewDateNode(nil, "Between 1913 and 1923", "", nil)
+	btw1903And1924 := gedcom.NewDateNode("Between 1904 and 1924")
+	btw1913And1923 := gedcom.NewDateNode("Between 1913 and 1923")
 	Maximum([]*gedcom.DateNode{
 		btw1903And1924, // avg = 1914, value = 1924
 		btw1913And1923, // avg = 1919, value = 1923
@@ -84,9 +84,9 @@ func TestDateNodes_Maximum(t *testing.T) {
 func TestDateNodes_StripZero(t *testing.T) {
 	StripZero := tf.Function(t, gedcom.DateNodes.StripZero)
 
-	at3Sep1923 := gedcom.NewDateNode(nil, "3 Sep 1923", "", nil)
-	at5Mar1923 := gedcom.NewDateNode(nil, "5 Mar 1923", "", nil)
-	zeroDate := gedcom.NewDateNode(nil, "foo bar", "", nil)
+	at3Sep1923 := gedcom.NewDateNode("3 Sep 1923")
+	at5Mar1923 := gedcom.NewDateNode("5 Mar 1923")
+	zeroDate := gedcom.NewDateNode("foo bar")
 
 	// Nils.
 	StripZero(nil).Returns(nil)

--- a/date_test.go
+++ b/date_test.go
@@ -12,7 +12,7 @@ func TestDate_Time(t *testing.T) {
 	t.Run("StartDate", func(t *testing.T) {
 		for date, test := range dateTests {
 			t.Run(date, func(t *testing.T) {
-				node := gedcom.NewDateNode(nil, date, "", nil)
+				node := gedcom.NewDateNode(date)
 
 				assert.Equal(t, node.StartDate().Time(), test.startTime)
 			})
@@ -22,7 +22,7 @@ func TestDate_Time(t *testing.T) {
 	t.Run("EndDate", func(t *testing.T) {
 		for date, test := range dateTests {
 			t.Run(date, func(t *testing.T) {
-				node := gedcom.NewDateNode(nil, date, "", nil)
+				node := gedcom.NewDateNode(date)
 
 				assert.Equal(t, node.EndDate().Time(), test.endTime)
 			})

--- a/dater_test.go
+++ b/dater_test.go
@@ -13,39 +13,39 @@ func TestDates(t *testing.T) {
 	}{
 		{nil, nil},
 		{
-			gedcom.NewNodeWithChildren(nil, gedcom.TagVersion, "foo", "", nil),
+			gedcom.NewNode(gedcom.TagVersion, "foo", ""),
 			nil,
 		},
 		{
-			gedcom.NewNameNode(nil, "foo bar", "", []gedcom.Node{
-				gedcom.NewDateNode(nil, "2 Sep 1981", "", nil),
-			}),
+			gedcom.NewNameNode("foo bar",
+				gedcom.NewDateNode("2 Sep 1981"),
+			),
 			gedcom.DateNodes{
-				gedcom.NewDateNode(nil, "2 Sep 1981", "", nil),
+				gedcom.NewDateNode("2 Sep 1981"),
 			},
 		},
 		{
-			gedcom.NewNameNode(nil, "foo bar", "", []gedcom.Node{
-				gedcom.NewDateNode(nil, "2 Sep 1981", "", nil),
-				gedcom.NewDateNode(nil, "3 Sep 1981", "", nil),
-			}),
+			gedcom.NewNameNode("foo bar",
+				gedcom.NewDateNode("2 Sep 1981"),
+				gedcom.NewDateNode("3 Sep 1981"),
+			),
 			gedcom.DateNodes{
-				gedcom.NewDateNode(nil, "2 Sep 1981", "", nil),
-				gedcom.NewDateNode(nil, "3 Sep 1981", "", nil),
+				gedcom.NewDateNode("2 Sep 1981"),
+				gedcom.NewDateNode("3 Sep 1981"),
 			},
 		},
 		{
-			gedcom.NewNameNode(nil, "foo bar", "", nil),
+			gedcom.NewNameNode("foo bar"),
 			nil,
 		},
 		{
-			gedcom.NewNameNode(nil, "foo bar", "", []gedcom.Node{
-				gedcom.NewDateNode(nil, "bar baz", "", nil),
-				gedcom.NewDateNode(nil, "3 Sep 1981", "", nil),
-			}),
+			gedcom.NewNameNode("foo bar",
+				gedcom.NewDateNode("bar baz"),
+				gedcom.NewDateNode("3 Sep 1981"),
+			),
 			[]*gedcom.DateNode{
-				gedcom.NewDateNode(nil, "bar baz", "", nil),
-				gedcom.NewDateNode(nil, "3 Sep 1981", "", nil),
+				gedcom.NewDateNode("bar baz"),
+				gedcom.NewDateNode("3 Sep 1981"),
 			},
 		},
 	}

--- a/death_node.go
+++ b/death_node.go
@@ -6,9 +6,9 @@ type DeathNode struct {
 }
 
 // NewDeathNode creates a new DEAT node.
-func NewDeathNode(document *Document, value, pointer string, children []Node) *DeathNode {
+func NewDeathNode(value string, children ...Node) *DeathNode {
 	return &DeathNode{
-		newSimpleNode(document, TagDeath, value, pointer, children),
+		newSimpleNode(TagDeath, value, "", children...),
 	}
 }
 

--- a/death_node_test.go
+++ b/death_node_test.go
@@ -9,15 +9,13 @@ import (
 )
 
 func TestNewDeathNode(t *testing.T) {
-	doc := gedcom.NewDocument()
-	child := gedcom.NewNameNode(doc, "", "", nil)
-	node := gedcom.NewDeathNode(doc, "foo", "bar", []gedcom.Node{child})
+	child := gedcom.NewNameNode("")
+	node := gedcom.NewDeathNode("foo", child)
 
 	assert.Equal(t, gedcom.TagDeath, node.Tag())
-	assert.Equal(t, []gedcom.Node{child}, node.Nodes())
-	assert.Equal(t, doc, node.Document())
+	assert.Equal(t, gedcom.Nodes{child}, node.Nodes())
 	assert.Equal(t, "foo", node.Value())
-	assert.Equal(t, "bar", node.Pointer())
+	assert.Equal(t, "", node.Pointer())
 }
 
 func TestDeathNode_Dates(t *testing.T) {
@@ -25,31 +23,28 @@ func TestDeathNode_Dates(t *testing.T) {
 
 	Dates((*gedcom.DeathNode)(nil)).Returns([]*gedcom.DateNode(nil))
 
-	Dates(gedcom.NewDeathNode(nil, "", "", nil)).Returns([]*gedcom.DateNode(nil))
+	Dates(gedcom.NewDeathNode("")).Returns([]*gedcom.DateNode(nil))
 
-	Dates(gedcom.NewDeathNode(nil, "", "", []gedcom.Node{})).
-		Returns([]*gedcom.DateNode(nil))
-
-	Dates(gedcom.NewDeathNode(nil, "", "", []gedcom.Node{
-		gedcom.NewDateNode(nil, "3 Sep 2001", "", nil),
-	})).Returns([]*gedcom.DateNode{
-		gedcom.NewDateNode(nil, "3 Sep 2001", "", nil),
+	Dates(gedcom.NewDeathNode("",
+		gedcom.NewDateNode("3 Sep 2001"),
+	)).Returns([]*gedcom.DateNode{
+		gedcom.NewDateNode("3 Sep 2001"),
 	})
 
-	Dates(gedcom.NewDeathNode(nil, "", "", []gedcom.Node{
-		gedcom.NewDateNode(nil, "7 Jan 2001", "", nil),
-		gedcom.NewDateNode(nil, "3 Sep 2001", "", nil),
-	})).Returns([]*gedcom.DateNode{
-		gedcom.NewDateNode(nil, "7 Jan 2001", "", nil),
-		gedcom.NewDateNode(nil, "3 Sep 2001", "", nil),
+	Dates(gedcom.NewDeathNode("",
+		gedcom.NewDateNode("7 Jan 2001"),
+		gedcom.NewDateNode("3 Sep 2001"),
+	)).Returns([]*gedcom.DateNode{
+		gedcom.NewDateNode("7 Jan 2001"),
+		gedcom.NewDateNode("3 Sep 2001"),
 	})
 }
 
 func TestDeathNode_Equals(t *testing.T) {
 	Equals := tf.Function(t, (*gedcom.DeathNode).Equals)
 
-	n1 := gedcom.NewDeathNode(nil, "foo", "", nil)
-	n2 := gedcom.NewDeathNode(nil, "bar", "", nil)
+	n1 := gedcom.NewDeathNode("foo")
+	n2 := gedcom.NewDeathNode("bar")
 
 	// nils
 	Equals((*gedcom.DeathNode)(nil), (*gedcom.DeathNode)(nil)).Returns(false)
@@ -57,7 +52,7 @@ func TestDeathNode_Equals(t *testing.T) {
 	Equals((*gedcom.DeathNode)(nil), n1).Returns(false)
 
 	// Wrong node type.
-	Equals(n1, gedcom.NewNameNode(nil, "foo", "", nil)).Returns(false)
+	Equals(n1, gedcom.NewNameNode("foo")).Returns(false)
 
 	// All other cases are success.
 	Equals(n1, n1).Returns(true)

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -8,227 +8,319 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var tests = map[string]*gedcom.Document{
-	"":     gedcom.NewDocumentWithNodes(nil),
-	"\n\n": gedcom.NewDocumentWithNodes(nil),
-	"0 HEAD": gedcom.NewDocumentWithNodes([]gedcom.Node{
-		gedcom.NewNode(nil, gedcom.TagHeader, "", ""),
-	}),
-	"0 HEAD\n1 CHAR UTF-8": gedcom.NewDocumentWithNodes([]gedcom.Node{
-		gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-			gedcom.NewNode(nil, gedcom.TagCharacterSet, "UTF-8", ""),
-		}),
-	}),
-	"0 HEAD\n\n1 CHAR UTF-8\n": gedcom.NewDocumentWithNodes([]gedcom.Node{
-		gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-			gedcom.NewNode(nil, gedcom.TagCharacterSet, "UTF-8", ""),
-		}),
-	}),
-	"0 HEAD\n1 CHAR UTF-8\n1 SOUR Ancestry.com Family Trees": gedcom.NewDocumentWithNodes([]gedcom.Node{
-		gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-			gedcom.NewNode(nil, gedcom.TagCharacterSet, "UTF-8", ""),
-			gedcom.NewSourceNode(nil, "Ancestry.com Family Trees", "", nil),
-		}),
-	}),
-	"0 HEAD\n1 CHAR UTF-8\n1 CHAR UTF-8": gedcom.NewDocumentWithNodes([]gedcom.Node{
-		gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-			gedcom.NewNode(nil, gedcom.TagCharacterSet, "UTF-8", ""),
-			gedcom.NewNode(nil, gedcom.TagCharacterSet, "UTF-8", ""),
-		}),
-	}),
-	"0 HEAD\n1 SOUR Ancestry.com Family Trees": gedcom.NewDocumentWithNodes([]gedcom.Node{
-		gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-			gedcom.NewSourceNode(nil, "Ancestry.com Family Trees", "", nil),
-		}),
-	}),
-	"0 HEAD\n1 BIRT": gedcom.NewDocumentWithNodes([]gedcom.Node{
-		gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-			gedcom.NewBirthNode(nil, "", "", nil),
-		}),
-	}),
-	"0 HEAD\n1 GEDC\n2 VERS (2010.3)": gedcom.NewDocumentWithNodes([]gedcom.Node{
-		gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-			gedcom.NewNodeWithChildren(nil, gedcom.TagGedcomInformation, "", "", []gedcom.Node{
-				gedcom.NewNode(nil, gedcom.TagVersion, "(2010.3)", ""),
-			}),
-		}),
-	}),
-	"0 HEAD\n1 GEDC\n2 VERS 5.5": gedcom.NewDocumentWithNodes([]gedcom.Node{
-		gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-			gedcom.NewNodeWithChildren(nil, gedcom.TagGedcomInformation, "", "", []gedcom.Node{
-				gedcom.NewNode(nil, gedcom.TagVersion, "5.5", ""),
-			}),
-		}),
-	}),
-	"0 HEAD\n1 GEDC\n2 FORM LINEAGE-LINKED": gedcom.NewDocumentWithNodes([]gedcom.Node{
-		gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-			gedcom.NewNodeWithChildren(nil, gedcom.TagGedcomInformation, "", "", []gedcom.Node{
-				gedcom.NewFormatNode(nil, "LINEAGE-LINKED", "", nil),
-			}),
-		}),
-	}),
-	"0 HEAD\n1 BIRT\n2 PLAC Camperdown, Nsw, Australia": gedcom.NewDocumentWithNodes([]gedcom.Node{
-		gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-			gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
-				gedcom.NewPlaceNode(nil, "Camperdown, Nsw, Australia", "", nil),
-			}),
-		}),
-	}),
-	"0 HEAD\n1 NAME Elliot Rupert de Peyster /Chance/": gedcom.NewDocumentWithNodes([]gedcom.Node{
-		gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-			gedcom.NewNameNode(nil, "Elliot Rupert de Peyster /Chance/", "", nil),
-		}),
-	}),
-	"0 HEAD\n0 @P1@ INDI": gedcom.NewDocumentWithNodes([]gedcom.Node{
-		gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", nil),
-		gedcom.NewIndividualNode(nil, "", "P1", nil),
-	}),
-	"0 HEAD\n1 SEX M\n0 @P1@ INDI": gedcom.NewDocumentWithNodes([]gedcom.Node{
-		gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-			gedcom.NewNode(nil, gedcom.TagSex, "M", ""),
-		}),
-		gedcom.NewIndividualNode(nil, "", "P1", nil),
-	}),
-	"0 HEAD\n1 SEX M": gedcom.NewDocumentWithNodes([]gedcom.Node{
-		gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-			gedcom.NewNode(nil, gedcom.TagSex, "M", ""),
-		}),
-	}),
-	"0 HEAD\n1 BIRT\n2 PLAC Camperdown, Nsw, Australia\n1 SEX M": gedcom.NewDocumentWithNodes([]gedcom.Node{
-		gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-			gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
-				gedcom.NewPlaceNode(nil, "Camperdown, Nsw, Australia", "", nil),
-			}),
-			gedcom.NewNode(nil, gedcom.TagSex, "M", ""),
-		}),
-	}),
-	"0 HEAD\n0 @P1@ INDI\n1 BIRT": gedcom.NewDocumentWithNodes([]gedcom.Node{
-		gedcom.NewNode(nil, gedcom.TagHeader, "", ""),
-		gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-			gedcom.NewBirthNode(nil, "", "", nil),
-		}),
-	}),
-	"0 HEAD\n1 GEDC\n2 FORM LINEAGE-LINKED\n0 @P1@ INDI": gedcom.NewDocumentWithNodes([]gedcom.Node{
-		gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-			gedcom.NewNodeWithChildren(nil, gedcom.TagGedcomInformation, "", "", []gedcom.Node{
-				gedcom.NewFormatNode(nil, "LINEAGE-LINKED", "", nil),
-			}),
-		}),
-		gedcom.NewIndividualNode(nil, "", "P1", nil),
-	}),
-	"0 HEAD0\n1 HEAD1\n2 HEAD2\n3 HEAD3\n0 HEAD00": gedcom.NewDocumentWithNodes([]gedcom.Node{
-		gedcom.NewNodeWithChildren(nil, gedcom.TagFromString("HEAD0"), "", "", []gedcom.Node{
-			gedcom.NewNodeWithChildren(nil, gedcom.TagFromString("HEAD1"), "", "", []gedcom.Node{
-				gedcom.NewNodeWithChildren(nil, gedcom.TagFromString("HEAD2"), "", "", []gedcom.Node{
-					gedcom.NewNode(nil, gedcom.TagFromString("HEAD3"), "", ""),
-				}),
-			}),
-		}),
-		gedcom.NewNode(nil, gedcom.TagFromString("HEAD00"), "", ""),
-	}),
-	"0 HEAD0\n1 HEAD1\n2 HEAD2\n3 HEAD3\n1 HEAD10": gedcom.NewDocumentWithNodes([]gedcom.Node{
-		gedcom.NewNodeWithChildren(nil, gedcom.TagFromString("HEAD0"), "", "", []gedcom.Node{
-			gedcom.NewNodeWithChildren(nil, gedcom.TagFromString("HEAD1"), "", "", []gedcom.Node{
-				gedcom.NewNodeWithChildren(nil, gedcom.TagFromString("HEAD2"), "", "", []gedcom.Node{
-					gedcom.NewNode(nil, gedcom.TagFromString("HEAD3"), "", ""),
-				}),
-			}),
-			gedcom.NewNode(nil, gedcom.TagFromString("HEAD10"), "", ""),
-		}),
-	}),
-	"0 HEAD0\r1 HEAD1": gedcom.NewDocumentWithNodes([]gedcom.Node{
-		gedcom.NewNodeWithChildren(nil, gedcom.TagFromString("HEAD0"), "", "", []gedcom.Node{
-			gedcom.NewNode(nil, gedcom.TagFromString("HEAD1"), "", ""),
-		}),
-	}),
-	"0 HEAD0\r\n1 HEAD1": gedcom.NewDocumentWithNodes([]gedcom.Node{
-		gedcom.NewNodeWithChildren(nil, gedcom.TagFromString("HEAD0"), "", "", []gedcom.Node{
-			gedcom.NewNode(nil, gedcom.TagFromString("HEAD1"), "", ""),
-		}),
-	}),
-	"0 HEAD0\n1 HEAD1\n1 HEAD10\n2 HEAD2": gedcom.NewDocumentWithNodes([]gedcom.Node{
-		gedcom.NewNodeWithChildren(nil, gedcom.TagFromString("HEAD0"), "", "", []gedcom.Node{
-			gedcom.NewNode(nil, gedcom.TagFromString("HEAD1"), "", ""),
-			gedcom.NewNodeWithChildren(nil, gedcom.TagFromString("HEAD10"), "", "", []gedcom.Node{
-				gedcom.NewNode(nil, gedcom.TagFromString("HEAD2"), "", ""),
-			}),
-		}),
-	}),
-	"0 HEAD\n1 BIRT ": gedcom.NewDocumentWithNodes([]gedcom.Node{
-		gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-			gedcom.NewBirthNode(nil, "", "", nil),
-		}),
-	}),
-	"0 @P221@ INDI\n1 BIRT\n2 DATE 1851\n1 DEAT\n2 DATE 1856": gedcom.NewDocumentWithNodes([]gedcom.Node{
-		gedcom.NewIndividualNode(nil, "", "P221", []gedcom.Node{
-			gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
-				gedcom.NewDateNode(nil, "1851", "", nil),
-			}),
-			gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "", "", []gedcom.Node{
-				gedcom.NewDateNode(nil, "1856", "", nil),
-			}),
-		}),
-	}),
-	"0 @F1@ FAM\n1 HUSB @P2@\n1 WIFE @P3@": gedcom.NewDocumentWithNodes([]gedcom.Node{
-		gedcom.NewFamilyNode(nil, "F1", []gedcom.Node{
-			gedcom.NewNode(nil, gedcom.TagHusband, "@P2@", ""),
-			gedcom.NewNode(nil, gedcom.TagWife, "@P3@", ""),
-		}),
-	}),
-	"0 DATE 1856": gedcom.NewDocumentWithNodes([]gedcom.Node{
-		gedcom.NewDateNode(nil, "1856", "", nil),
-	}),
-	"0 NAME κόσμε": gedcom.NewDocumentWithNodes([]gedcom.Node{
-		gedcom.NewNameNode(nil, "κόσμε", "", nil),
-	}),
-
-	// Non alphanumeric characters are allowed.
-	"0 @R-1577718385@ FAM": gedcom.NewDocumentWithNodes([]gedcom.Node{
-		gedcom.NewFamilyNode(nil, "R-1577718385", nil),
-	}),
-
-	// Crazy long pointer values are also fine.
-	"0 @SomeReallyLongPointerThatShouldProbablyNotBeUsedByWeShouldDemonstrateThatThereIsNoLimitToTheLength@ FAM": gedcom.NewDocumentWithNodes([]gedcom.Node{
-		gedcom.NewFamilyNode(nil, "SomeReallyLongPointerThatShouldProbablyNotBeUsedByWeShouldDemonstrateThatThereIsNoLimitToTheLength", nil),
-	}),
-
-	// Any punctuation is permitted as long as it isn't an "@".
-	"0 @~!-#$%^&*()@ FAM": gedcom.NewDocumentWithNodes([]gedcom.Node{
-		gedcom.NewFamilyNode(nil, "~!-#$%^&*()", nil),
-	}),
-
-	// Make sure we are not using a greedy consume so that "@" can also be in
-	// the value.
-	"0 @uh@ NAME oh@ok": gedcom.NewDocumentWithNodes([]gedcom.Node{
-		gedcom.NewNameNode(nil, "oh@ok", "uh", nil),
-	}),
+var decoderTests = map[string]struct {
+	ged      string
+	expected func(*gedcom.Document)
+}{
+	"Empty": {
+		"",
+		func(doc *gedcom.Document) {},
+	},
+	"OnlyNewLine": {
+		"\n\n",
+		func(doc *gedcom.Document) {},
+	},
+	"OnlyRoot": {
+		"0 HEAD",
+		func(doc *gedcom.Document) {
+			doc.AddNode(gedcom.NewNode(gedcom.TagHeader, "", ""))
+		},
+	},
+	"OneChild1": {
+		"0 HEAD\n1 CHAR UTF-8",
+		func(doc *gedcom.Document) {
+			doc.AddNode(gedcom.NewNode(gedcom.TagHeader, "", "",
+				gedcom.NewNode(gedcom.TagCharacterSet, "UTF-8", ""),
+			))
+		},
+	},
+	"OneChild2": {
+		"0 HEAD\n\n1 CHAR UTF-8\n",
+		func(doc *gedcom.Document) {
+			doc.AddNode(gedcom.NewNode(gedcom.TagHeader, "", "",
+				gedcom.NewNode(gedcom.TagCharacterSet, "UTF-8", ""),
+			))
+		},
+	},
+	"TwoChildren": {
+		"0 HEAD\n1 CHAR UTF-8\n1 @S1@ SOUR Ancestry.com Family Trees",
+		func(doc *gedcom.Document) {
+			doc.AddNode(gedcom.NewNode(gedcom.TagHeader, "", "",
+				gedcom.NewNode(gedcom.TagCharacterSet, "UTF-8", ""),
+				gedcom.NewSourceNode("Ancestry.com Family Trees", "S1"),
+			))
+		},
+	},
+	"TwoIdenticalChildren": {
+		"0 HEAD\n1 CHAR UTF-8\n1 CHAR UTF-8",
+		func(doc *gedcom.Document) {
+			doc.AddNode(gedcom.NewNode(gedcom.TagHeader, "", "",
+				gedcom.NewNode(gedcom.TagCharacterSet, "UTF-8", ""),
+				gedcom.NewNode(gedcom.TagCharacterSet, "UTF-8", ""),
+			))
+		},
+	},
+	"SpaceInValue": {
+		"0 HEAD\n1 @S1@ SOUR Ancestry.com Family Trees",
+		func(doc *gedcom.Document) {
+			doc.AddNode(gedcom.NewNode(gedcom.TagHeader, "", "",
+				gedcom.NewSourceNode("Ancestry.com Family Trees", "S1"),
+			))
+		},
+	},
+	"SimpleChild": {
+		"0 HEAD\n1 BIRT",
+		func(doc *gedcom.Document) {
+			doc.AddNode(gedcom.NewNode(gedcom.TagHeader, "", "",
+				gedcom.NewBirthNode(""),
+			))
+		},
+	},
+	"ThreeDeep1": {
+		"0 HEAD\n1 GEDC\n2 VERS (2010.3)",
+		func(doc *gedcom.Document) {
+			doc.AddNode(gedcom.NewNode(gedcom.TagHeader, "", "",
+				gedcom.NewNode(gedcom.TagGedcomInformation, "", "",
+					gedcom.NewNode(gedcom.TagVersion, "(2010.3)", ""),
+				),
+			))
+		},
+	},
+	"ThreeDeep2": {
+		"0 HEAD\n1 GEDC\n2 VERS 5.5",
+		func(doc *gedcom.Document) {
+			doc.AddNode(gedcom.NewNode(gedcom.TagHeader, "", "",
+				gedcom.NewNode(gedcom.TagGedcomInformation, "", "",
+					gedcom.NewNode(gedcom.TagVersion, "5.5", ""),
+				),
+			))
+		},
+	},
+	"FORM": {
+		"0 HEAD\n1 GEDC\n2 FORM LINEAGE-LINKED",
+		func(doc *gedcom.Document) {
+			doc.AddNode(gedcom.NewNode(gedcom.TagHeader, "", "",
+				gedcom.NewNode(gedcom.TagGedcomInformation, "", "",
+					gedcom.NewFormatNode("LINEAGE-LINKED"),
+				),
+			))
+		},
+	},
+	"PLAC": {
+		"0 HEAD\n1 BIRT\n2 PLAC Camperdown, Nsw, Australia",
+		func(doc *gedcom.Document) {
+			doc.AddNode(gedcom.NewNode(gedcom.TagHeader, "", "",
+				gedcom.NewBirthNode("",
+					gedcom.NewPlaceNode("Camperdown, Nsw, Australia"),
+				),
+			))
+		},
+	},
+	"NAME": {
+		"0 HEAD\n1 NAME Elliot Rupert de Peyster /Chance/",
+		func(doc *gedcom.Document) {
+			doc.AddNode(gedcom.NewNode(gedcom.TagHeader, "", "",
+				gedcom.NewNameNode("Elliot Rupert de Peyster /Chance/"),
+			))
+		},
+	},
+	"Pointer": {
+		"0 HEAD\n0 @P1@ INDI",
+		func(doc *gedcom.Document) {
+			doc.AddNode(gedcom.NewNode(gedcom.TagHeader, "", ""))
+			doc.AddIndividual("P1")
+		},
+	},
+	"NestedPointer": {
+		"0 HEAD\n1 SEX M\n0 @P1@ INDI",
+		func(doc *gedcom.Document) {
+			doc.AddNode(gedcom.NewNode(gedcom.TagHeader, "", "",
+				gedcom.NewNode(gedcom.TagSex, "M", ""),
+			))
+			doc.AddIndividual("P1")
+		},
+	},
+	"SEX": {
+		"0 HEAD\n1 SEX M",
+		func(doc *gedcom.Document) {
+			doc.AddNode(gedcom.NewNode(gedcom.TagHeader, "", "",
+				gedcom.NewNode(gedcom.TagSex, "M", ""),
+			))
+		},
+	},
+	"Nested1": {
+		"0 HEAD\n1 BIRT\n2 PLAC Camperdown, Nsw, Australia\n1 SEX M",
+		func(doc *gedcom.Document) {
+			doc.AddNode(gedcom.NewNode(gedcom.TagHeader, "", "",
+				gedcom.NewBirthNode("",
+					gedcom.NewPlaceNode("Camperdown, Nsw, Australia"),
+				),
+				gedcom.NewNode(gedcom.TagSex, "M", ""),
+			))
+		},
+	},
+	"MultipleRoots": {
+		"0 HEAD\n0 @P1@ INDI\n1 BIRT",
+		func(doc *gedcom.Document) {
+			doc.AddNode(gedcom.NewNode(gedcom.TagHeader, "", ""))
+			doc.AddIndividual("P1",
+				gedcom.NewBirthNode(""),
+			)
+		},
+	},
+	"Nested2": {
+		"0 HEAD\n1 GEDC\n2 FORM LINEAGE-LINKED\n0 @P1@ INDI",
+		func(doc *gedcom.Document) {
+			doc.AddNode(gedcom.NewNode(gedcom.TagHeader, "", "",
+				gedcom.NewNode(gedcom.TagGedcomInformation, "", "",
+					gedcom.NewFormatNode("LINEAGE-LINKED"),
+				),
+			))
+			doc.AddIndividual("P1")
+		},
+	},
+	"Nested3": {
+		"0 HEAD0\n1 HEAD1\n2 HEAD2\n3 HEAD3\n0 HEAD00",
+		func(doc *gedcom.Document) {
+			doc.AddNode(gedcom.NewNode(gedcom.TagFromString("HEAD0"), "", "",
+				gedcom.NewNode(gedcom.TagFromString("HEAD1"), "", "",
+					gedcom.NewNode(gedcom.TagFromString("HEAD2"), "", "",
+						gedcom.NewNode(gedcom.TagFromString("HEAD3"), "", ""),
+					),
+				),
+			))
+			doc.AddNode(gedcom.NewNode(gedcom.TagFromString("HEAD00"), "", ""))
+		},
+	},
+	"Nested4": {
+		"0 HEAD0\n1 HEAD1\n2 HEAD2\n3 HEAD3\n1 HEAD10",
+		func(doc *gedcom.Document) {
+			doc.AddNode(gedcom.NewNode(gedcom.TagFromString("HEAD0"), "", "",
+				gedcom.NewNode(gedcom.TagFromString("HEAD1"), "", "",
+					gedcom.NewNode(gedcom.TagFromString("HEAD2"), "", "",
+						gedcom.NewNode(gedcom.TagFromString("HEAD3"), "", ""),
+					),
+				),
+				gedcom.NewNode(gedcom.TagFromString("HEAD10"), "", ""),
+			))
+		},
+	},
+	"BadTag1": {
+		"0 HEAD0\r1 HEAD1",
+		func(doc *gedcom.Document) {
+			doc.AddNode(gedcom.NewNode(gedcom.TagFromString("HEAD0"), "", "",
+				gedcom.NewNode(gedcom.TagFromString("HEAD1"), "", ""),
+			))
+		},
+	},
+	"WindowsLineEnding": {
+		"0 HEAD0\r\n1 HEAD1",
+		func(doc *gedcom.Document) {
+			doc.AddNode(gedcom.NewNode(gedcom.TagFromString("HEAD0"), "", "",
+				gedcom.NewNode(gedcom.TagFromString("HEAD1"), "", ""),
+			))
+		},
+	},
+	"BadTag2": {
+		"0 HEAD0\n1 HEAD1\n1 HEAD10\n2 HEAD2",
+		func(doc *gedcom.Document) {
+			doc.AddNode(gedcom.NewNode(gedcom.TagFromString("HEAD0"), "", "",
+				gedcom.NewNode(gedcom.TagFromString("HEAD1"), "", ""),
+				gedcom.NewNode(gedcom.TagFromString("HEAD10"), "", "",
+					gedcom.NewNode(gedcom.TagFromString("HEAD2"), "", ""),
+				),
+			))
+		},
+	},
+	"SpaceWithoutValue": {
+		"0 HEAD\n1 BIRT ",
+		func(doc *gedcom.Document) {
+			doc.AddNode(gedcom.NewNode(gedcom.TagHeader, "", "",
+				gedcom.NewBirthNode(""),
+			))
+		},
+	},
+	"Nested5": {
+		"0 @P221@ INDI\n1 BIRT\n2 DATE 1851\n1 DEAT\n2 DATE 1856",
+		func(doc *gedcom.Document) {
+			doc.AddIndividual("P221",
+				gedcom.NewBirthNode("",
+					gedcom.NewDateNode("1851"),
+				),
+				gedcom.NewNode(gedcom.TagDeath, "", "",
+					gedcom.NewDateNode("1856"),
+				),
+			)
+		},
+	},
+	"HUSB_WIFE": {
+		"0 @F1@ FAM\n1 HUSB @P2@\n1 WIFE @P3@",
+		func(doc *gedcom.Document) {
+			f1 := doc.AddFamily("F1")
+			f1.SetHusbandPointer("P2")
+			f1.SetWifePointer("P3")
+		},
+	},
+	"RootDate": {
+		"0 DATE 1856",
+		func(doc *gedcom.Document) {
+			doc.AddNode(gedcom.NewDateNode("1856"))
+		},
+	},
+	"UTF-8": {
+		"0 NAME κόσμε",
+		func(doc *gedcom.Document) {
+			doc.AddNode(gedcom.NewNameNode("κόσμε"))
+		},
+	},
+	"NonAlphanumericCharactersAreAllowed": {
+		"0 @R-1577718385@ FAM",
+		func(doc *gedcom.Document) {
+			doc.AddFamily("R-1577718385")
+		},
+	},
+	"CrazyLongPointerValuesAreAlsoFine": {
+		"0 @SomeReallyLongPointerThatShouldProbablyNotBeUsedByWeShouldDemonstrateThatThereIsNoLimitToTheLength@ FAM",
+		func(doc *gedcom.Document) {
+			doc.AddFamily("SomeReallyLongPointerThatShouldProbablyNotBeUsedByWeShouldDemonstrateThatThereIsNoLimitToTheLength")
+		},
+	},
+	"AnyPunctuationIsPermittedAsLongAsItIsntAn@": {
+		"0 @~!-#$%^&*()@ FAM",
+		func(doc *gedcom.Document) {
+			doc.AddFamily("~!-#$%^&*()")
+		},
+	},
+	"NonGreedyConsume": {
+		"0 @uh@ NAME oh@ok",
+		func(doc *gedcom.Document) {
+			doc.AddNode(gedcom.NewNode(gedcom.TagName, "oh@ok", "uh"))
+		},
+	},
 }
 
 func TestDecoder_Decode(t *testing.T) {
-	for ged, expected := range tests {
-		t.Run("", func(t *testing.T) {
-			decoder := gedcom.NewDecoder(strings.NewReader(ged))
+	for testName, test := range decoderTests {
+		t.Run(testName, func(t *testing.T) {
+			decoder := gedcom.NewDecoder(strings.NewReader(test.ged))
 
 			actual, err := decoder.Decode()
-			assert.NoError(t, err, ged)
+			assert.NoError(t, err, test.ged)
 
-			expected.MaxLivingAge = gedcom.DefaultMaxLivingAge
+			doc := gedcom.NewDocument()
+			test.expected(doc)
 
-			for _, n := range expected.Nodes() {
-				n.SetDocument(expected)
-			}
-
-			assertDocumentEqual(t, expected, actual, ged)
+			assertDocumentEqual(t, doc, actual)
 		})
 	}
 
 	t.Run("BOM", func(t *testing.T) {
 		ged := "\xEF\xBB\xBF0 HEAD\n1 CHAR UTF-8"
 		decoder := gedcom.NewDecoder(strings.NewReader(ged))
-		expected := gedcom.NewDocumentWithNodes([]gedcom.Node{
-			gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", []gedcom.Node{
-				gedcom.NewNode(nil, gedcom.TagCharacterSet, "UTF-8", ""),
-			}),
+		expected := gedcom.NewDocumentWithNodes(gedcom.Nodes{
+			gedcom.NewNode(gedcom.TagHeader, "", "",
+				gedcom.NewNode(gedcom.TagCharacterSet, "UTF-8", ""),
+			),
 		})
 		expected.HasBOM = true
 
@@ -236,10 +328,6 @@ func TestDecoder_Decode(t *testing.T) {
 		assert.NoError(t, err, ged)
 
 		expected.MaxLivingAge = gedcom.DefaultMaxLivingAge
-
-		for _, n := range expected.Nodes() {
-			n.SetDocument(expected)
-		}
 
 		assertDocumentEqual(t, expected, actual, ged)
 	})
@@ -254,19 +342,23 @@ func trimSpaces(s string) string {
 }
 
 func TestDocument_String(t *testing.T) {
-	for expected, actual := range tests {
-		t.Run("", func(t *testing.T) {
-			newGed := actual.String()
-			assert.Equal(t, trimSpaces(expected), trimSpaces(newGed), expected)
+	for testName, test := range decoderTests {
+		t.Run(testName, func(t *testing.T) {
+			doc := gedcom.NewDocument()
+			test.expected(doc)
+			newGed := doc.String()
+			assert.Equal(t, trimSpaces(test.ged), trimSpaces(newGed))
 		})
 	}
 }
 
 func TestDocument_GEDCOMString(t *testing.T) {
-	for expected, actual := range tests {
-		t.Run("", func(t *testing.T) {
-			newGed := actual.GEDCOMString(0)
-			assert.Equal(t, trimSpaces(expected), trimSpaces(newGed), expected)
+	for testName, test := range decoderTests {
+		t.Run(testName, func(t *testing.T) {
+			doc := gedcom.NewDocument()
+			test.expected(doc)
+			newGed := doc.GEDCOMString(0)
+			assert.Equal(t, trimSpaces(test.ged), trimSpaces(newGed))
 		})
 	}
 }
@@ -275,48 +367,48 @@ func TestNewNode(t *testing.T) {
 	const p = "pointer"
 	const v = "value"
 
+	// Nodes that require a document like Individual and Family are not included
+	// in this tests.
 	for _, test := range []struct {
 		tag      gedcom.Tag
 		expected gedcom.Node
 	}{
-		{gedcom.TagBaptism, gedcom.NewBaptismNode(nil, v, p, nil)},
-		{gedcom.TagBirth, gedcom.NewBirthNode(nil, v, p, nil)},
-		{gedcom.TagBurial, gedcom.NewBurialNode(nil, v, p, nil)},
-		{gedcom.TagDate, gedcom.NewDateNode(nil, v, p, nil)},
-		{gedcom.TagDeath, gedcom.NewDeathNode(nil, v, p, nil)},
-		{gedcom.TagEvent, gedcom.NewEventNode(nil, v, p, nil)},
-		{gedcom.TagFamily, gedcom.NewFamilyNode(nil, p, nil)},
-		{gedcom.UnofficialTagFamilySearchID1, gedcom.NewFamilySearchIDNode(nil, gedcom.UnofficialTagFamilySearchID1, v)},
-		{gedcom.UnofficialTagFamilySearchID2, gedcom.NewFamilySearchIDNode(nil, gedcom.UnofficialTagFamilySearchID2, v)},
-		{gedcom.TagFormat, gedcom.NewFormatNode(nil, v, p, nil)},
-		{gedcom.TagIndividual, gedcom.NewIndividualNode(nil, v, p, nil)},
-		{gedcom.TagLatitude, gedcom.NewLatitudeNode(nil, v, p, nil)},
-		{gedcom.TagLongitude, gedcom.NewLongitudeNode(nil, v, p, nil)},
-		{gedcom.TagMap, gedcom.NewMapNode(nil, v, p, nil)},
-		{gedcom.TagName, gedcom.NewNameNode(nil, v, p, nil)},
-		{gedcom.TagNote, gedcom.NewNoteNode(nil, v, p, nil)},
-		{gedcom.TagNickname, gedcom.NewNicknameNode(nil, v, p, nil)},
-		{gedcom.TagPhonetic, gedcom.NewPhoneticVariationNode(nil, v, p, nil)},
-		{gedcom.TagPlace, gedcom.NewPlaceNode(nil, v, p, nil)},
-		{gedcom.TagResidence, gedcom.NewResidenceNode(nil, v, p, nil)},
-		{gedcom.TagRomanized, gedcom.NewRomanizedVariationNode(nil, v, p, nil)},
-		{gedcom.TagSource, gedcom.NewSourceNode(nil, v, p, nil)},
-		{gedcom.TagType, gedcom.NewTypeNode(nil, v, p, nil)},
-		{gedcom.TagVersion, gedcom.NewNode(nil, gedcom.TagVersion, v, p)},
-		{gedcom.UnofficialTagUniqueID, gedcom.NewUniqueIDNode(nil, v, p, nil)},
+		{gedcom.TagBaptism, gedcom.NewBaptismNode(v)},
+		{gedcom.TagBirth, gedcom.NewBirthNode(v)},
+		{gedcom.TagBurial, gedcom.NewBurialNode(v)},
+		{gedcom.TagDate, gedcom.NewDateNode(v)},
+		{gedcom.TagDeath, gedcom.NewDeathNode(v)},
+		{gedcom.TagEvent, gedcom.NewEventNode(v)},
+		{gedcom.UnofficialTagFamilySearchID1, gedcom.NewFamilySearchIDNode(gedcom.UnofficialTagFamilySearchID1, v)},
+		{gedcom.UnofficialTagFamilySearchID2, gedcom.NewFamilySearchIDNode(gedcom.UnofficialTagFamilySearchID2, v)},
+		{gedcom.TagFormat, gedcom.NewFormatNode(v)},
+		{gedcom.TagLatitude, gedcom.NewLatitudeNode(v)},
+		{gedcom.TagLongitude, gedcom.NewLongitudeNode(v)},
+		{gedcom.TagMap, gedcom.NewMapNode(v)},
+		{gedcom.TagName, gedcom.NewNameNode(v)},
+		{gedcom.TagNote, gedcom.NewNoteNode(v)},
+		{gedcom.TagNickname, gedcom.NewNicknameNode(v)},
+		{gedcom.TagPhonetic, gedcom.NewPhoneticVariationNode(v)},
+		{gedcom.TagPlace, gedcom.NewPlaceNode(v)},
+		{gedcom.TagResidence, gedcom.NewResidenceNode(v)},
+		{gedcom.TagRomanized, gedcom.NewRomanizedVariationNode(v)},
+		{gedcom.TagSource, gedcom.NewSourceNode(v, p)},
+		{gedcom.TagType, gedcom.NewTypeNode(v)},
+		{gedcom.TagVersion, gedcom.NewNode(gedcom.TagVersion, v, p)},
+		{gedcom.UnofficialTagUniqueID, gedcom.NewUniqueIDNode(v)},
 	} {
 		t.Run(test.tag.String(), func(t *testing.T) {
-			assert.Equal(t, test.expected, gedcom.NewNode(nil, test.tag, v, p))
+			assertEqual(t, test.expected, gedcom.NewNode(test.tag, v, p))
 		})
 	}
 
 	t.Run("ImplementsGEDCOMStringer", func(t *testing.T) {
-		node := gedcom.NewDateNode(nil, "", "", nil)
+		node := gedcom.NewDateNode("")
 		assert.Implements(t, (*gedcom.GEDCOMStringer)(nil), node)
 	})
 
 	t.Run("ImplementsGEDCOMLiner", func(t *testing.T) {
-		node := gedcom.NewDateNode(nil, "", "", nil)
+		node := gedcom.NewDateNode("")
 		assert.Implements(t, (*gedcom.GEDCOMLiner)(nil), node)
 	})
 }

--- a/document_noder.go
+++ b/document_noder.go
@@ -1,0 +1,5 @@
+package gedcom
+
+type DocumentNoder interface {
+	Document() *Document
+}

--- a/document_test.go
+++ b/document_test.go
@@ -12,84 +12,84 @@ import (
 var documentTests = []struct {
 	doc         *gedcom.Document
 	individuals gedcom.IndividualNodes
-	families    []*gedcom.FamilyNode
+	families    gedcom.FamilyNodes
 	p2          gedcom.Node
 }{
 	{
 		doc:         gedcom.NewDocument(),
 		individuals: gedcom.IndividualNodes{},
 		p2:          nil,
-		families:    []*gedcom.FamilyNode{},
+		families:    gedcom.FamilyNodes{},
 	},
 	{
-		doc: gedcom.NewDocumentWithNodes([]gedcom.Node{
-			gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewNameNode(nil, "Joe /Bloggs/", "", []gedcom.Node{}),
-			}),
+		doc: gedcom.NewDocumentWithNodes(gedcom.Nodes{
+			gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNameNode("Joe /Bloggs/"),
+			),
 		}),
 		individuals: gedcom.IndividualNodes{
-			gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewNameNode(nil, "Joe /Bloggs/", "", []gedcom.Node{}),
-			}),
+			gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNameNode("Joe /Bloggs/"),
+			),
 		},
 		p2:       nil,
-		families: []*gedcom.FamilyNode{},
+		families: gedcom.FamilyNodes{},
 	},
 	{
-		doc: gedcom.NewDocumentWithNodes([]gedcom.Node{
-			gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewNameNode(nil, "Joe /Bloggs/", "", []gedcom.Node{}),
-			}),
-			gedcom.NewNodeWithChildren(nil, gedcom.TagVersion, "", "", []gedcom.Node{}),
-			gedcom.NewIndividualNode(nil, "", "P2", []gedcom.Node{
-				gedcom.NewNameNode(nil, "John /Doe/", "", []gedcom.Node{}),
-			}),
+		doc: gedcom.NewDocumentWithNodes(gedcom.Nodes{
+			gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNameNode("Joe /Bloggs/"),
+			),
+			gedcom.NewNode(gedcom.TagVersion, "", ""),
+			gedcom.NewDocument().AddIndividual("P2",
+				gedcom.NewNameNode("John /Doe/"),
+			),
 		}),
 		individuals: gedcom.IndividualNodes{
-			gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewNameNode(nil, "Joe /Bloggs/", "", []gedcom.Node{}),
-			}),
-			gedcom.NewIndividualNode(nil, "", "P2", []gedcom.Node{
-				gedcom.NewNameNode(nil, "John /Doe/", "", []gedcom.Node{}),
-			}),
+			gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNameNode("Joe /Bloggs/"),
+			),
+			gedcom.NewDocument().AddIndividual("P2",
+				gedcom.NewNameNode("John /Doe/"),
+			),
 		},
-		p2: gedcom.NewIndividualNode(nil, "", "P2", []gedcom.Node{
-			gedcom.NewNameNode(nil, "John /Doe/", "", []gedcom.Node{}),
-		}),
-		families: []*gedcom.FamilyNode{},
+		p2: gedcom.NewDocument().AddIndividual("P2",
+			gedcom.NewNameNode("John /Doe/"),
+		),
+		families: gedcom.FamilyNodes{},
 	},
 	{
-		doc: gedcom.NewDocumentWithNodes([]gedcom.Node{
-			gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewNameNode(nil, "Joe /Bloggs/", "", []gedcom.Node{}),
-			}),
-			gedcom.NewFamilyNode(nil, "F1", []gedcom.Node{}),
+		doc: gedcom.NewDocumentWithNodes(gedcom.Nodes{
+			gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNameNode("Joe /Bloggs/"),
+			),
+			gedcom.NewDocument().AddFamily("F1"),
 		}),
 		individuals: gedcom.IndividualNodes{
-			gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewNameNode(nil, "Joe /Bloggs/", "", []gedcom.Node{}),
-			}),
+			gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNameNode("Joe /Bloggs/"),
+			),
 		},
 		p2: nil,
-		families: []*gedcom.FamilyNode{
-			gedcom.NewFamilyNode(nil, "F1", []gedcom.Node{}),
+		families: gedcom.FamilyNodes{
+			gedcom.NewDocument().AddFamily("F1"),
 		},
 	},
 	{
-		doc: gedcom.NewDocumentWithNodes([]gedcom.Node{
-			gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewNameNode(nil, "Joe /Bloggs/", "", []gedcom.Node{}),
-			}),
-			gedcom.NewFamilyNode(nil, "F3", []gedcom.Node{}),
+		doc: gedcom.NewDocumentWithNodes(gedcom.Nodes{
+			gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNameNode("Joe /Bloggs/"),
+			),
+			gedcom.NewDocument().AddFamily("F3"),
 		}),
 		individuals: gedcom.IndividualNodes{
-			gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewNameNode(nil, "Joe /Bloggs/", "", []gedcom.Node{}),
-			}),
+			gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNameNode("Joe /Bloggs/"),
+			),
 		},
 		p2: nil,
-		families: []*gedcom.FamilyNode{
-			gedcom.NewFamilyNode(nil, "F3", []gedcom.Node{}),
+		families: gedcom.FamilyNodes{
+			gedcom.NewDocument().AddFamily("F3"),
 		},
 	},
 }
@@ -97,7 +97,7 @@ var documentTests = []struct {
 func TestDocument_Individuals(t *testing.T) {
 	for _, test := range documentTests {
 		t.Run("", func(t *testing.T) {
-			assert.Equal(t, test.doc.Individuals(), test.individuals)
+			assertEqual(t, test.doc.Individuals(), test.individuals)
 		})
 	}
 }
@@ -114,7 +114,7 @@ func TestDocument_NodeByPointer(t *testing.T) {
 func TestDocument_Families(t *testing.T) {
 	for _, test := range documentTests {
 		t.Run("", func(t *testing.T) {
-			assert.Equal(t, test.doc.Families(), test.families)
+			assertEqual(t, test.doc.Families(), test.families)
 		})
 	}
 }
@@ -174,41 +174,41 @@ func TestNewDocument(t *testing.T) {
 func TestDocument_AddNode(t *testing.T) {
 	t.Run("One", func(t *testing.T) {
 		doc := gedcom.NewDocument()
-		nameNode := gedcom.NewNameNode(doc, "foo", "", nil)
+		nameNode := gedcom.NewNameNode("foo")
 
 		doc.AddNode(nameNode)
 
-		assert.Equal(t, doc.Nodes(), []gedcom.Node{nameNode})
+		assert.Equal(t, doc.Nodes(), gedcom.Nodes{nameNode})
 	})
 
 	t.Run("Two", func(t *testing.T) {
 		doc := gedcom.NewDocument()
-		nameNode1 := gedcom.NewNameNode(doc, "foo", "", nil)
-		nameNode2 := gedcom.NewNameNode(doc, "foo", "", nil)
+		nameNode1 := gedcom.NewNameNode("foo")
+		nameNode2 := gedcom.NewNameNode("foo")
 
 		doc.AddNode(nameNode1)
 		doc.AddNode(nameNode2)
 
-		assert.Equal(t, doc.Nodes(), []gedcom.Node{nameNode1, nameNode2})
+		assert.Equal(t, doc.Nodes(), gedcom.Nodes{nameNode1, nameNode2})
 	})
 
 	t.Run("Duplicate", func(t *testing.T) {
 		doc := gedcom.NewDocument()
-		nameNode := gedcom.NewNameNode(doc, "foo", "", nil)
+		nameNode := gedcom.NewNameNode("foo")
 
 		doc.AddNode(nameNode)
 		doc.AddNode(nameNode)
 
-		assert.Equal(t, doc.Nodes(), []gedcom.Node{nameNode, nameNode})
+		assert.Equal(t, doc.Nodes(), gedcom.Nodes{nameNode, nameNode})
 	})
 
 	t.Run("Nil", func(t *testing.T) {
 		doc := gedcom.NewDocument()
-		nameNode := gedcom.NewNameNode(doc, "foo", "", nil)
+		nameNode := gedcom.NewNameNode("foo")
 
 		doc.AddNode(nil)
 		doc.AddNode(nameNode)
 
-		assert.Equal(t, doc.Nodes(), []gedcom.Node{nameNode})
+		assert.Equal(t, doc.Nodes(), gedcom.Nodes{nameNode})
 	})
 }

--- a/entity_map.go
+++ b/entity_map.go
@@ -1,0 +1,14 @@
+package gedcom
+
+type entityMap map[interface{}]interface{}
+
+func (m entityMap) GetOrAssign(n interface{}, assign func() interface{}) interface{} {
+	if existing, ok := m[n]; ok {
+		return existing
+	}
+
+	newNode := assign()
+	m[n] = newNode
+
+	return newNode
+}

--- a/equal.go
+++ b/equal.go
@@ -65,7 +65,7 @@ func DeepEqual(left, right Node) bool {
 // equal amount of duplicates.
 //
 // See DeepEqual for semantics on how nodes are compared.
-func DeepEqualNodes(left, right []Node) bool {
+func DeepEqualNodes(left, right Nodes) bool {
 	leftLen := len(left)
 	rightLen := len(right)
 

--- a/equal_test.go
+++ b/equal_test.go
@@ -11,48 +11,48 @@ func TestDeepEqual(t *testing.T) {
 	DeepEqual := tf.Function(t, gedcom.DeepEqual)
 
 	// These two are the same.
-	n1 := gedcom.NewResidenceNode(nil, "", "", []gedcom.Node{
-		gedcom.NewDateNode(nil, "3 SEP 1987", "", nil),
-	})
-	n2 := gedcom.NewResidenceNode(nil, "", "", []gedcom.Node{
-		gedcom.NewDateNode(nil, "3 SEP 1987", "", nil),
-	})
+	n1 := gedcom.NewResidenceNode("",
+		gedcom.NewDateNode("3 SEP 1987"),
+	)
+	n2 := gedcom.NewResidenceNode("",
+		gedcom.NewDateNode("3 SEP 1987"),
+	)
 
 	// Different variations.
-	n3 := gedcom.NewResidenceNode(nil, "", "", []gedcom.Node{
-		gedcom.NewDateNode(nil, "5 SEP 1987", "", nil),
-	})
-	n4 := gedcom.NewResidenceNode(nil, "", "", []gedcom.Node{
-		gedcom.NewDateNode(nil, "5 SEP 1987", "", nil),
-		gedcom.NewDateNode(nil, "3 SEP 1987", "", nil),
-	})
-	n5 := gedcom.NewResidenceNode(nil, "", "", []gedcom.Node{
-		gedcom.NewDateNode(nil, "3 SEP 1987", "", nil),
-		gedcom.NewDateNode(nil, "5 SEP 1987", "", nil),
-	})
+	n3 := gedcom.NewResidenceNode("",
+		gedcom.NewDateNode("5 SEP 1987"),
+	)
+	n4 := gedcom.NewResidenceNode("",
+		gedcom.NewDateNode("5 SEP 1987"),
+		gedcom.NewDateNode("3 SEP 1987"),
+	)
+	n5 := gedcom.NewResidenceNode("",
+		gedcom.NewDateNode("3 SEP 1987"),
+		gedcom.NewDateNode("5 SEP 1987"),
+	)
 
 	// More complex examples.
-	n6 := gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-		gedcom.NewNameNode(nil, "Elliot /Chance/", "", nil),
-		gedcom.NewResidenceNode(nil, "", "", []gedcom.Node{
-			gedcom.NewDateNode(nil, "3 SEP 1987", "", nil),
-			gedcom.NewPlaceNode(nil, "England", "", nil),
-		}),
-	})
-	n7 := gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-		gedcom.NewNameNode(nil, "Elliot /Chance/", "", nil),
-		gedcom.NewResidenceNode(nil, "", "", []gedcom.Node{
-			gedcom.NewDateNode(nil, "3 SEP 1987", "", nil),
-			gedcom.NewPlaceNode(nil, "England", "", nil),
-		}),
-	})
-	n8 := gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-		gedcom.NewNameNode(nil, "Elliot /Chance/", "", nil),
-		gedcom.NewResidenceNode(nil, "", "", []gedcom.Node{
-			gedcom.NewDateNode(nil, "3 SEP 1987", "", nil),
-			gedcom.NewPlaceNode(nil, "London, England", "", nil),
-		}),
-	})
+	n6 := gedcom.NewDocument().AddIndividual("P1",
+		gedcom.NewNameNode("Elliot /Chance/"),
+		gedcom.NewResidenceNode("",
+			gedcom.NewDateNode("3 SEP 1987"),
+			gedcom.NewPlaceNode("England"),
+		),
+	)
+	n7 := gedcom.NewDocument().AddIndividual("P1",
+		gedcom.NewNameNode("Elliot /Chance/"),
+		gedcom.NewResidenceNode("",
+			gedcom.NewDateNode("3 SEP 1987"),
+			gedcom.NewPlaceNode("England"),
+		),
+	)
+	n8 := gedcom.NewDocument().AddIndividual("P1",
+		gedcom.NewNameNode("Elliot /Chance/"),
+		gedcom.NewResidenceNode("",
+			gedcom.NewDateNode("3 SEP 1987"),
+			gedcom.NewPlaceNode("London, England"),
+		),
+	)
 
 	// Nils.
 	DeepEqual((*gedcom.SimpleNode)(nil), (*gedcom.SimpleNode)(nil)).Returns(false)
@@ -81,24 +81,24 @@ func TestDeepEqualNodes(t *testing.T) {
 	DeepEqualNodes := tf.Function(t, gedcom.DeepEqualNodes)
 
 	// These two are the same.
-	n1 := gedcom.NewResidenceNode(nil, "", "", []gedcom.Node{
-		gedcom.NewDateNode(nil, "3 SEP 1987", "", nil),
-	})
-	n2 := gedcom.NewResidenceNode(nil, "", "", []gedcom.Node{
-		gedcom.NewDateNode(nil, "3 SEP 1987", "", nil),
-	})
-	n3 := gedcom.NewResidenceNode(nil, "", "", []gedcom.Node{
-		gedcom.NewDateNode(nil, "5 SEP 1987", "", nil),
-	})
+	n1 := gedcom.NewResidenceNode("",
+		gedcom.NewDateNode("3 SEP 1987"),
+	)
+	n2 := gedcom.NewResidenceNode("",
+		gedcom.NewDateNode("3 SEP 1987"),
+	)
+	n3 := gedcom.NewResidenceNode("",
+		gedcom.NewDateNode("5 SEP 1987"),
+	)
 
 	// There aren't too many tests here because the fiddly stuff is handled in
 	// the tests for DeepEqual.
 
 	DeepEqualNodes(nil, nil).Returns(true)
-	DeepEqualNodes([]gedcom.Node{n1}, []gedcom.Node{n1}).Returns(true)
-	DeepEqualNodes([]gedcom.Node{n1}, []gedcom.Node{n2}).Returns(true)
-	DeepEqualNodes([]gedcom.Node{n1, n2}, []gedcom.Node{n1, n2}).Returns(true)
+	DeepEqualNodes(gedcom.Nodes{n1}, gedcom.Nodes{n1}).Returns(true)
+	DeepEqualNodes(gedcom.Nodes{n1}, gedcom.Nodes{n2}).Returns(true)
+	DeepEqualNodes(gedcom.Nodes{n1, n2}, gedcom.Nodes{n1, n2}).Returns(true)
 
-	DeepEqualNodes([]gedcom.Node{n1, n2}, []gedcom.Node{n1}).Returns(false)
-	DeepEqualNodes([]gedcom.Node{n1}, []gedcom.Node{n3}).Returns(false)
+	DeepEqualNodes(gedcom.Nodes{n1, n2}, gedcom.Nodes{n1}).Returns(false)
+	DeepEqualNodes(gedcom.Nodes{n1}, gedcom.Nodes{n3}).Returns(false)
 }

--- a/event_node.go
+++ b/event_node.go
@@ -7,9 +7,9 @@ type EventNode struct {
 }
 
 // EventNode creates a new EVEN node.
-func NewEventNode(document *Document, value, pointer string, children []Node) *EventNode {
+func NewEventNode(value string, children ...Node) *EventNode {
 	return &EventNode{
-		newSimpleNode(document, TagEvent, value, pointer, children),
+		newSimpleNode(TagEvent, value, "", children...),
 	}
 }
 

--- a/event_node_test.go
+++ b/event_node_test.go
@@ -9,15 +9,13 @@ import (
 )
 
 func TestNewEventNode(t *testing.T) {
-	doc := gedcom.NewDocument()
-	child := gedcom.NewNameNode(doc, "", "", nil)
-	node := gedcom.NewEventNode(doc, "foo", "bar", []gedcom.Node{child})
+	child := gedcom.NewNameNode("")
+	node := gedcom.NewEventNode("foo", child)
 
 	assert.Equal(t, gedcom.TagEvent, node.Tag())
-	assert.Equal(t, []gedcom.Node{child}, node.Nodes())
-	assert.Equal(t, doc, node.Document())
+	assert.Equal(t, gedcom.Nodes{child}, node.Nodes())
 	assert.Equal(t, "foo", node.Value())
-	assert.Equal(t, "bar", node.Pointer())
+	assert.Equal(t, "", node.Pointer())
 }
 
 func TestEventNode_Dates(t *testing.T) {
@@ -25,42 +23,39 @@ func TestEventNode_Dates(t *testing.T) {
 
 	Dates((*gedcom.EventNode)(nil)).Returns([]*gedcom.DateNode(nil))
 
-	Dates(gedcom.NewEventNode(nil, "", "", nil)).Returns([]*gedcom.DateNode(nil))
+	Dates(gedcom.NewEventNode("")).Returns([]*gedcom.DateNode(nil))
 
-	Dates(gedcom.NewEventNode(nil, "", "", []gedcom.Node{})).
-		Returns([]*gedcom.DateNode(nil))
-
-	Dates(gedcom.NewEventNode(nil, "", "", []gedcom.Node{
-		gedcom.NewDateNode(nil, "3 Sep 2001", "", nil),
-	})).Returns([]*gedcom.DateNode{
-		gedcom.NewDateNode(nil, "3 Sep 2001", "", nil),
+	Dates(gedcom.NewEventNode("",
+		gedcom.NewDateNode("3 Sep 2001"),
+	)).Returns([]*gedcom.DateNode{
+		gedcom.NewDateNode("3 Sep 2001"),
 	})
 
-	Dates(gedcom.NewEventNode(nil, "", "", []gedcom.Node{
-		gedcom.NewDateNode(nil, "7 Jan 2001", "", nil),
-		gedcom.NewDateNode(nil, "3 Sep 2001", "", nil),
-	})).Returns([]*gedcom.DateNode{
-		gedcom.NewDateNode(nil, "7 Jan 2001", "", nil),
-		gedcom.NewDateNode(nil, "3 Sep 2001", "", nil),
+	Dates(gedcom.NewEventNode("",
+		gedcom.NewDateNode("7 Jan 2001"),
+		gedcom.NewDateNode("3 Sep 2001"),
+	)).Returns([]*gedcom.DateNode{
+		gedcom.NewDateNode("7 Jan 2001"),
+		gedcom.NewDateNode("3 Sep 2001"),
 	})
 }
 
 func TestEventNode_Equals(t *testing.T) {
 	Equals := tf.NamedFunction(t, "EventNode_Equals", (*gedcom.EventNode).Equals)
 
-	n1 := gedcom.NewEventNode(nil, "foo", "", nil)
-	n2 := gedcom.NewEventNode(nil, "bar", "", nil)
-	n3 := gedcom.NewEventNode(nil, "bar", "", []gedcom.Node{
-		gedcom.NewDateNode(nil, "3 Sep 1943", "", nil),
-		gedcom.NewDateNode(nil, "Oct 1943", "", nil),
-	})
-	n4 := gedcom.NewEventNode(nil, "bar", "", []gedcom.Node{
-		gedcom.NewDateNode(nil, "Oct 1943", "", nil),
-	})
-	n5 := gedcom.NewEventNode(nil, "", "", []gedcom.Node{
-		gedcom.NewNode(nil, gedcom.TagType, "Domicilie", ""),
-		gedcom.NewPlaceNode(nil, "Washington, District of Columbia, District of Columbia, United States", "", nil),
-	})
+	n1 := gedcom.NewEventNode("foo")
+	n2 := gedcom.NewEventNode("bar")
+	n3 := gedcom.NewEventNode("bar",
+		gedcom.NewDateNode("3 Sep 1943"),
+		gedcom.NewDateNode("Oct 1943"),
+	)
+	n4 := gedcom.NewEventNode("bar",
+		gedcom.NewDateNode("Oct 1943"),
+	)
+	n5 := gedcom.NewEventNode("",
+		gedcom.NewNode(gedcom.TagType, "Domicilie", ""),
+		gedcom.NewPlaceNode("Washington, District of Columbia, District of Columbia, United States"),
+	)
 
 	// nils
 	Equals((*gedcom.EventNode)(nil), (*gedcom.EventNode)(nil)).Returns(false)
@@ -68,7 +63,7 @@ func TestEventNode_Equals(t *testing.T) {
 	Equals((*gedcom.EventNode)(nil), n1).Returns(false)
 
 	// Wrong node type.
-	Equals(n1, gedcom.NewNameNode(nil, "foo", "", nil)).Returns(false)
+	Equals(n1, gedcom.NewNameNode("foo")).Returns(false)
 
 	// General cases.
 	Equals(n1, n1).Returns(true)
@@ -83,14 +78,14 @@ func TestEventNode_Years(t *testing.T) {
 
 	Years((*gedcom.EventNode)(nil)).Returns(0.0)
 
-	Years(gedcom.NewEventNode(nil, "", "", nil)).Returns(0.0)
+	Years(gedcom.NewEventNode("")).Returns(0.0)
 
-	Years(gedcom.NewEventNode(nil, "", "", []gedcom.Node{
-		gedcom.NewDateNode(nil, "3 SEP 1943", "", nil),
-	})).Returns(1943.672131147541)
+	Years(gedcom.NewEventNode("",
+		gedcom.NewDateNode("3 SEP 1943"),
+	)).Returns(1943.672131147541)
 
-	Years(gedcom.NewEventNode(nil, "", "", []gedcom.Node{
-		gedcom.NewDateNode(nil, "3 SEP 1943", "", nil),
-		gedcom.NewDateNode(nil, "3 SEP 1920", "", nil),
-	})).Returns(1920.6730245231608)
+	Years(gedcom.NewEventNode("",
+		gedcom.NewDateNode("3 SEP 1943"),
+		gedcom.NewDateNode("3 SEP 1920"),
+	)).Returns(1920.6730245231608)
 }

--- a/family_node_test.go
+++ b/family_node_test.go
@@ -9,199 +9,200 @@ import (
 )
 
 var familyTests = []struct {
-	doc     *gedcom.Document
+	doc     func(*gedcom.Document)
 	husband *gedcom.IndividualNode
 	wife    *gedcom.IndividualNode
 }{
 	{
-		doc: gedcom.NewDocumentWithNodes([]gedcom.Node{
-			gedcom.NewFamilyNode(nil, "F1", nil),
-		}),
+		doc: func(doc *gedcom.Document) {
+			doc.AddFamily("F1")
+		},
 		husband: nil,
 		wife:    nil,
 	},
 	{
-		doc: gedcom.NewDocumentWithNodes([]gedcom.Node{
-			gedcom.NewFamilyNode(nil, "F1", []gedcom.Node{
-				gedcom.NewNodeWithChildren(nil, gedcom.TagHusband, "@P1@", "", []gedcom.Node{}),
-			}),
-			gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{}),
-		}),
-		husband: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{}),
+		doc: func(doc *gedcom.Document) {
+			elliot := individual(doc, "P1", "Elliot /Chance/", "4 Jan 1843", "17 Mar 1907")
+			f1 := doc.AddFamily("F1")
+			f1.SetHusband(elliot)
+		},
+		husband: elliot,
 		wife:    nil,
 	},
 	{
-		doc: gedcom.NewDocumentWithNodes([]gedcom.Node{
-			gedcom.NewFamilyNode(nil, "F2", []gedcom.Node{
-				gedcom.NewNodeWithChildren(nil, gedcom.TagWife, "@P3@", "", []gedcom.Node{}),
-			}),
-			gedcom.NewIndividualNode(nil, "", "P3", []gedcom.Node{}),
-		}),
+		doc: func(doc *gedcom.Document) {
+			jane := individual(doc, "P2", "Jane /Doe/", "3 Mar 1803", "14 June 1877")
+			f2 := doc.AddFamily("F2")
+			f2.SetWife(jane)
+		},
 		husband: nil,
-		wife:    gedcom.NewIndividualNode(nil, "", "P3", []gedcom.Node{}),
+		wife:    jane,
 	},
 }
 
 func TestFamilyNode_Husband(t *testing.T) {
 	for _, test := range familyTests {
 		t.Run("", func(t *testing.T) {
-			node := test.doc.Nodes()[0].(*gedcom.FamilyNode)
-			node.SetDocument(test.doc)
-			assert.Equal(t, node.Husband(), test.husband)
+			doc := gedcom.NewDocument()
+			test.doc(doc)
+			node := doc.Families()[0]
+
+			actualHusband := node.Husband()
+			if test.husband == nil {
+				assert.Nil(t, actualHusband)
+			} else {
+				if assert.NotNil(t, actualHusband) {
+					assertEqual(t, actualHusband.Individual(), test.husband)
+				}
+			}
 		})
 	}
 
 	Husband := tf.Function(t, (*gedcom.FamilyNode).Husband)
 
-	Husband((*gedcom.FamilyNode)(nil)).Returns((*gedcom.IndividualNode)(nil))
+	Husband((*gedcom.FamilyNode)(nil)).Returns((*gedcom.HusbandNode)(nil))
 }
 
 func TestFamilyNode_Wife(t *testing.T) {
 	for _, test := range familyTests {
 		t.Run("", func(t *testing.T) {
-			node := test.doc.Nodes()[0].(*gedcom.FamilyNode)
-			assert.Equal(t, node.Wife(), test.wife)
+			doc := gedcom.NewDocument()
+			test.doc(doc)
+			node := doc.Families()[0]
+
+			actualWife := node.Wife()
+			if test.wife == nil {
+				assert.Nil(t, actualWife)
+			} else {
+				if assert.NotNil(t, actualWife) {
+					assertEqual(t, actualWife.Individual(), test.wife)
+				}
+			}
 		})
 	}
 
 	Wife := tf.Function(t, (*gedcom.FamilyNode).Wife)
 
-	Wife((*gedcom.FamilyNode)(nil)).Returns((*gedcom.IndividualNode)(nil))
+	Wife((*gedcom.FamilyNode)(nil)).Returns((*gedcom.WifeNode)(nil))
 }
 
 func TestFamilyNode_Similarity(t *testing.T) {
 	// ghost:ignore
-	var tests = []struct {
-		doc      *gedcom.Document
+	var tests = map[string]struct {
+		doc      func(*gedcom.Document)
 		expected float64
 	}{
 		// Empty cases.
-		{
-			doc: gedcom.NewDocumentWithNodes([]gedcom.Node{
-				gedcom.NewFamilyNode(nil, "F1", nil),
-				gedcom.NewFamilyNode(nil, "F2", nil),
-			}),
+		"Empty1": {
+			doc: func(doc *gedcom.Document) {
+				doc.AddFamily("F1")
+				doc.AddFamily("F2")
+			},
 			expected: 0.5,
 		},
-		{
-			doc: gedcom.NewDocumentWithNodes([]gedcom.Node{
-				gedcom.NewFamilyNode(nil, "F1", []gedcom.Node{}),
-				gedcom.NewFamilyNode(nil, "F2", []gedcom.Node{}),
-			}),
+		"Empty2": {
+			doc: func(doc *gedcom.Document) {
+				doc.AddFamily("F1")
+				doc.AddFamily("F2")
+			},
 			expected: 0.5,
 		},
 
 		// Perfect cases.
-		{
+		"Perfect": {
 			// All details match exactly.
-			doc: gedcom.NewDocumentWithNodes([]gedcom.Node{
-				gedcom.NewFamilyNode(nil, "F1", []gedcom.Node{
-					gedcom.NewNodeWithChildren(nil, gedcom.TagHusband, "@P1@", "", nil),
-					gedcom.NewNodeWithChildren(nil, gedcom.TagWife, "@P2@", "", nil),
-				}),
-				gedcom.NewFamilyNode(nil, "F2", []gedcom.Node{
-					gedcom.NewNodeWithChildren(nil, gedcom.TagHusband, "@P3@", "", nil),
-					gedcom.NewNodeWithChildren(nil, gedcom.TagWife, "@P4@", "", nil),
-				}),
-				gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-					name("Elliot Rupert de Peyster /Chance/"),
-					born("4 Jan 1843"),
-					died("17 Mar 1907"),
-				}),
-				gedcom.NewIndividualNode(nil, "", "P2", []gedcom.Node{
-					name("Dina Victoria /Wyche/"),
-					born("Abt. Feb 1837"),
-					died("8 Apr 1923"),
-				}),
-				gedcom.NewIndividualNode(nil, "", "P3", []gedcom.Node{
-					name("Elliot Rupert de Peyster /Chance/"),
-					born("4 Jan 1843"),
-					died("17 Mar 1907"),
-				}),
-				gedcom.NewIndividualNode(nil, "", "P4", []gedcom.Node{
-					name("Dina Victoria /Wyche/"),
-					born("Abt. Feb 1837"),
-					died("8 Apr 1923"),
-				}),
-			}),
+			doc: func(doc *gedcom.Document) {
+				p1 := doc.AddIndividual("P1",
+					gedcom.NewNameNode("Elliot Rupert de Peyster /Chance/"),
+					gedcom.NewBirthNode("", gedcom.NewDateNode("4 Jan 1843")),
+					gedcom.NewDeathNode("", gedcom.NewDateNode("17 Mar 1907")),
+				)
+				p2 := doc.AddIndividual("P2",
+					gedcom.NewNameNode("Dina Victoria /Wyche/"),
+					gedcom.NewBirthNode("", gedcom.NewDateNode("Abt. Feb 1837")),
+					gedcom.NewDeathNode("", gedcom.NewDateNode("8 Apr 1923")),
+				)
+				p3 := doc.AddIndividual("P3",
+					gedcom.NewNameNode("Elliot Rupert de Peyster /Chance/"),
+					gedcom.NewBirthNode("", gedcom.NewDateNode("4 Jan 1843")),
+					gedcom.NewDeathNode("", gedcom.NewDateNode("17 Mar 1907")),
+				)
+				p4 := doc.AddIndividual("P4",
+					gedcom.NewNameNode("Dina Victoria /Wyche/"),
+					gedcom.NewBirthNode("", gedcom.NewDateNode("Abt. Feb 1837")),
+					gedcom.NewDeathNode("", gedcom.NewDateNode("8 Apr 1923")),
+				)
+
+				doc.AddFamilyWithHusbandAndWife("F1", p1, p2)
+				doc.AddFamilyWithHusbandAndWife("F2", p3, p4)
+			},
 			expected: 1.0,
 		},
 
 		// Almost perfect matches.
-		{
+		"AlmostPerfect": {
 			// Name is more/less complete.
-			doc: gedcom.NewDocumentWithNodes([]gedcom.Node{
-				gedcom.NewFamilyNode(nil, "F1", []gedcom.Node{
-					gedcom.NewNodeWithChildren(nil, gedcom.TagHusband, "@P1@", "", nil),
-					gedcom.NewNodeWithChildren(nil, gedcom.TagWife, "@P2@", "", nil),
-				}),
-				gedcom.NewFamilyNode(nil, "F2", []gedcom.Node{
-					gedcom.NewNodeWithChildren(nil, gedcom.TagHusband, "@P3@", "", nil),
-					gedcom.NewNodeWithChildren(nil, gedcom.TagWife, "@P4@", "", nil),
-				}),
-				gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-					name("Elliot Rupert de Peyster /Chance/"),
-					born("4 Jan 1843"),
-					died("17 Mar 1907"),
-				}),
-				gedcom.NewIndividualNode(nil, "", "P2", []gedcom.Node{
-					name("Dina Victoria /Wyche/"),
-					born("Abt. Feb 1837"),
-				}),
-				gedcom.NewIndividualNode(nil, "", "P3", []gedcom.Node{
-					name("Elliot R. d. P. /Chance/"),
-					born("4 Jan 1843"),
-					died("17 Mar 1907"),
-				}),
-				gedcom.NewIndividualNode(nil, "", "P4", []gedcom.Node{
-					name("Dina /Wyche/"),
-					born("Bef. Mar 1837"),
-				}),
-			}),
+			doc: func(doc *gedcom.Document) {
+				p1 := doc.AddIndividual("P1",
+					gedcom.NewNameNode("Elliot Rupert de Peyster /Chance/"),
+					gedcom.NewBirthNode("", gedcom.NewDateNode("4 Jan 1843")),
+					gedcom.NewDeathNode("", gedcom.NewDateNode("17 Mar 1907")),
+				)
+				p2 := doc.AddIndividual("P2",
+					gedcom.NewNameNode("Dina Victoria /Wyche/"),
+					gedcom.NewBirthNode("", gedcom.NewDateNode("Abt. Feb 1837")),
+				)
+				p3 := doc.AddIndividual("P3",
+					gedcom.NewNameNode("Elliot R. d. P. /Chance/"),
+					gedcom.NewBirthNode("", gedcom.NewDateNode("4 Jan 1843")),
+					gedcom.NewDeathNode("", gedcom.NewDateNode("17 Mar 1907")),
+				)
+				p4 := doc.AddIndividual("P4",
+					gedcom.NewNameNode("Dina /Wyche/"),
+					gedcom.NewBirthNode("", gedcom.NewDateNode("Bef. Mar 1837")),
+				)
+
+				doc.AddFamilyWithHusbandAndWife("F1", p1, p2)
+				doc.AddFamilyWithHusbandAndWife("F2", p3, p4)
+			},
 			expected: 0.8904318416381887,
 		},
 
 		// These ones are way off.
-		{
-			doc: gedcom.NewDocumentWithNodes([]gedcom.Node{
-				gedcom.NewFamilyNode(nil, "F1", []gedcom.Node{
-					gedcom.NewNodeWithChildren(nil, gedcom.TagHusband, "@P1@", "", nil),
-					gedcom.NewNodeWithChildren(nil, gedcom.TagWife, "@P2@", "", nil),
-				}),
-				gedcom.NewFamilyNode(nil, "F2", []gedcom.Node{
-					gedcom.NewNodeWithChildren(nil, gedcom.TagHusband, "@P3@", "", nil),
-					gedcom.NewNodeWithChildren(nil, gedcom.TagWife, "@P4@", "", nil),
-				}),
-				gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-					name("Elliot Rupert de Peyster /Chance/"),
-					born("4 Jan 1843"),
-					died("17 Mar 1907"),
-				}),
-				gedcom.NewIndividualNode(nil, "", "P2", []gedcom.Node{
-					name("Dina Victoria /Wyche/"),
-					born("Abt. Feb 1837"),
-				}),
-				gedcom.NewIndividualNode(nil, "", "P3", []gedcom.Node{
-					name("Bob /Jones/"),
-					born("1627"),
-				}),
-				gedcom.NewIndividualNode(nil, "", "P4", []gedcom.Node{
-					name("Jane /Doe/"),
-					born("Sep 1845"),
-				}),
-			}),
+		"WayOff": {
+			doc: func(doc *gedcom.Document) {
+				p1 := doc.AddIndividual("P1",
+					gedcom.NewNameNode("Elliot Rupert de Peyster /Chance/"),
+					gedcom.NewBirthNode("", gedcom.NewDateNode("4 Jan 1843")),
+					gedcom.NewDeathNode("", gedcom.NewDateNode("17 Mar 1907")),
+				)
+				p2 := doc.AddIndividual("P2",
+					gedcom.NewNameNode("Dina Victoria /Wyche/"),
+					gedcom.NewBirthNode("", gedcom.NewDateNode("Abt. Feb 1837")),
+				)
+				p3 := doc.AddIndividual("P3",
+					gedcom.NewNameNode("Bob /Jones/"),
+					gedcom.NewBirthNode("", gedcom.NewDateNode("1627")),
+				)
+				p4 := doc.AddIndividual("P4",
+					gedcom.NewNameNode("Jane /Doe/"),
+					gedcom.NewBirthNode("", gedcom.NewDateNode("Sep 1845")),
+				)
+
+				doc.AddFamilyWithHusbandAndWife("F1", p1, p2)
+				doc.AddFamilyWithHusbandAndWife("F2", p3, p4)
+			},
 			expected: 0.37700025152486955,
 		},
 	}
 
 	options := gedcom.NewSimilarityOptions()
-	for _, test := range tests {
-		t.Run("", func(t *testing.T) {
-			family1 := test.doc.Families()[0]
-			family1.SetDocument(test.doc)
-
-			family2 := test.doc.Families()[1]
-			family2.SetDocument(test.doc)
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			doc := gedcom.NewDocument()
+			test.doc(doc)
+			family1 := doc.Families().ByPointer("F1")
+			family2 := doc.Families().ByPointer("F2")
 
 			got := family1.Similarity(family2, 0, options)
 
@@ -213,7 +214,7 @@ func TestFamilyNode_Similarity(t *testing.T) {
 func TestFamilyNode_Children(t *testing.T) {
 	Children := tf.Function(t, (*gedcom.FamilyNode).Children)
 
-	Children((*gedcom.FamilyNode)(nil)).Returns((gedcom.IndividualNodes)(nil))
+	Children((*gedcom.FamilyNode)(nil)).Returns((gedcom.ChildNodes)(nil))
 }
 
 func TestFamilyNode_HasChild(t *testing.T) {

--- a/family_noder.go
+++ b/family_noder.go
@@ -1,0 +1,5 @@
+package gedcom
+
+type FamilyNoder interface {
+	Family() *FamilyNode
+}

--- a/family_nodes.go
+++ b/family_nodes.go
@@ -1,0 +1,13 @@
+package gedcom
+
+type FamilyNodes []*FamilyNode
+
+func (nodes FamilyNodes) ByPointer(pointer string) *FamilyNode {
+	for _, node := range nodes {
+		if node.Pointer() == pointer {
+			return node
+		}
+	}
+
+	return nil
+}

--- a/familysearch_id_node.go
+++ b/familysearch_id_node.go
@@ -14,9 +14,9 @@ type FamilySearchIDNode struct {
 	*SimpleNode
 }
 
-func NewFamilySearchIDNode(document *Document, tag Tag, value string) *FamilySearchIDNode {
+func NewFamilySearchIDNode(tag Tag, value string, children ...Node) *FamilySearchIDNode {
 	return &FamilySearchIDNode{
-		newSimpleNode(document, tag, value, "", nil),
+		newSimpleNode(tag, value, "", children...),
 	}
 }
 

--- a/familysearch_id_node_test.go
+++ b/familysearch_id_node_test.go
@@ -13,26 +13,24 @@ var familySearchIDNodeTests = map[string]struct {
 	value string
 }{
 	"1": {
-		node:  gedcom.NewFamilySearchIDNode(nil, gedcom.UnofficialTagFamilySearchID1, "LZDP-V7V"),
+		node:  gedcom.NewFamilySearchIDNode(gedcom.UnofficialTagFamilySearchID1, "LZDP-V7V"),
 		tag:   gedcom.UnofficialTagFamilySearchID1,
 		value: "LZDP-V7V",
 	},
 	"2": {
-		node:  gedcom.NewFamilySearchIDNode(nil, gedcom.UnofficialTagFamilySearchID2, "ZZDP-V7V"),
+		node:  gedcom.NewFamilySearchIDNode(gedcom.UnofficialTagFamilySearchID2, "ZZDP-V7V"),
 		tag:   gedcom.UnofficialTagFamilySearchID2,
 		value: "ZZDP-V7V",
 	},
 }
 
 func TestNewFamilySearchIDNode(t *testing.T) {
-	doc := gedcom.NewDocument()
-	node := gedcom.NewFamilySearchIDNode(doc, gedcom.UnofficialTagFamilySearchID2, "LZDP-V7V")
+	node := gedcom.NewFamilySearchIDNode(gedcom.UnofficialTagFamilySearchID2, "LZDP-V7V")
 
 	assert.NotNil(t, node)
 	assert.IsType(t, node, (*gedcom.FamilySearchIDNode)(nil))
 	assert.Equal(t, gedcom.UnofficialTagFamilySearchID2, node.Tag())
-	assert.Equal(t, []gedcom.Node(nil), node.Nodes())
-	assert.Equal(t, doc, node.Document())
+	assert.Equal(t, gedcom.Nodes(nil), node.Nodes())
 	assert.Equal(t, "LZDP-V7V", node.Value())
 	assert.Equal(t, "", node.Pointer())
 }

--- a/filter_test.go
+++ b/filter_test.go
@@ -8,12 +8,12 @@ import (
 )
 
 func TestFilter(t *testing.T) {
-	root := gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-		gedcom.NewNameNode(nil, "Elliot /Chance/", "", nil),
-		gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
-			gedcom.NewDateNode(nil, "6 MAY 1989", "", nil),
-		}),
-	})
+	root := gedcom.NewDocument().AddIndividual("P1",
+		gedcom.NewNameNode("Elliot /Chance/"),
+		gedcom.NewBirthNode("",
+			gedcom.NewDateNode("6 MAY 1989"),
+		),
+	)
 
 	for _, test := range []struct {
 		filter   gedcom.FilterFunction
@@ -110,7 +110,7 @@ func TestFilter(t *testing.T) {
 		{
 			filter: func(node gedcom.Node) (gedcom.Node, bool) {
 				if node.Tag().Is(gedcom.TagName) {
-					return gedcom.NewDateNode(nil, "1 APR 1943", "", nil), true
+					return gedcom.NewDateNode("1 APR 1943"), true
 				}
 
 				return node, true
@@ -131,12 +131,12 @@ func TestFilter(t *testing.T) {
 }
 
 func TestWhitelistTagFilter(t *testing.T) {
-	root := gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-		gedcom.NewNameNode(nil, "Elliot /Chance/", "", nil),
-		gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
-			gedcom.NewDateNode(nil, "6 MAY 1989", "", nil),
-		}),
-	})
+	root := gedcom.NewDocument().AddIndividual("P1",
+		gedcom.NewNameNode("Elliot /Chance/"),
+		gedcom.NewBirthNode("",
+			gedcom.NewDateNode("6 MAY 1989"),
+		),
+	)
 
 	for _, test := range []struct {
 		tags     []gedcom.Tag
@@ -171,12 +171,12 @@ func TestWhitelistTagFilter(t *testing.T) {
 }
 
 func TestBlacklistTagFilter(t *testing.T) {
-	root := gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-		gedcom.NewNameNode(nil, "Elliot /Chance/", "", nil),
-		gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
-			gedcom.NewDateNode(nil, "6 MAY 1989", "", nil),
-		}),
-	})
+	root := gedcom.NewDocument().AddIndividual("P1",
+		gedcom.NewNameNode("Elliot /Chance/"),
+		gedcom.NewBirthNode("",
+			gedcom.NewDateNode("6 MAY 1989"),
+		),
+	)
 
 	for _, test := range []struct {
 		tags     []gedcom.Tag
@@ -214,14 +214,14 @@ func TestBlacklistTagFilter(t *testing.T) {
 }
 
 func TestOfficialTagFilter(t *testing.T) {
-	root := gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-		gedcom.NewNodeWithChildren(nil, gedcom.UnofficialTagCreated, "Elliot /Chance/", "", []gedcom.Node{
-			gedcom.NewDateNode(nil, "3 Mar 2007", "", nil),
-		}),
-		gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
-			gedcom.NewDateNode(nil, "6 MAY 1989", "", nil),
-		}),
-	})
+	root := gedcom.NewDocument().AddIndividual("P1",
+		gedcom.NewNode(gedcom.UnofficialTagCreated, "Elliot /Chance/", "",
+			gedcom.NewDateNode("3 Mar 2007"),
+		),
+		gedcom.NewBirthNode("",
+			gedcom.NewDateNode("6 MAY 1989"),
+		),
+	)
 
 	for _, test := range []struct {
 		expected string
@@ -249,12 +249,12 @@ func TestSimpleNameFilter(t *testing.T) {
 		expected string
 	}{
 		{
-			root: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewNameNode(nil, "Elliot /Chance/", "", nil),
-				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
-					gedcom.NewDateNode(nil, "6 MAY 1989", "", nil),
-				}),
-			}),
+			root: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNameNode("Elliot /Chance/"),
+				gedcom.NewBirthNode("",
+					gedcom.NewDateNode("6 MAY 1989"),
+				),
+			),
 			format: gedcom.NameFormatGEDCOM,
 			expected: `0 @P1@ INDI
 1 NAME Elliot /Chance/
@@ -263,14 +263,14 @@ func TestSimpleNameFilter(t *testing.T) {
 `,
 		},
 		{
-			root: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
-					gedcom.NewDateNode(nil, "6 MAY 1989", "", nil),
-				}),
-				gedcom.NewNameNode(nil, "Elliot /Chance/", "", []gedcom.Node{
-					gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, "Smith", "", nil),
-				}),
-			}),
+			root: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewBirthNode("",
+					gedcom.NewDateNode("6 MAY 1989"),
+				),
+				gedcom.NewNameNode("Elliot /Chance/",
+					gedcom.NewNode(gedcom.TagSurname, "Smith", ""),
+				),
+			),
 			format: gedcom.NameFormatGEDCOM,
 			expected: `0 @P1@ INDI
 1 BIRT
@@ -279,15 +279,15 @@ func TestSimpleNameFilter(t *testing.T) {
 `,
 		},
 		{
-			root: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewNameNode(nil, "", "", []gedcom.Node{
-					gedcom.NewNodeWithChildren(nil, gedcom.TagGivenName, "Bob", "", nil),
-					gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, "Smith", "", nil),
-				}),
-				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
-					gedcom.NewDateNode(nil, "6 MAY 1989", "", nil),
-				}),
-			}),
+			root: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNameNode("",
+					gedcom.NewNode(gedcom.TagGivenName, "Bob", ""),
+					gedcom.NewNode(gedcom.TagSurname, "Smith", ""),
+				),
+				gedcom.NewBirthNode("",
+					gedcom.NewDateNode("6 MAY 1989"),
+				),
+			),
 			format: gedcom.NameFormatGEDCOM,
 			expected: `0 @P1@ INDI
 1 NAME Bob /Smith/
@@ -296,12 +296,12 @@ func TestSimpleNameFilter(t *testing.T) {
 `,
 		},
 		{
-			root: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewNameNode(nil, "Elliot /Chance/", "", nil),
-				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
-					gedcom.NewDateNode(nil, "6 MAY 1989", "", nil),
-				}),
-			}),
+			root: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNameNode("Elliot /Chance/"),
+				gedcom.NewBirthNode("",
+					gedcom.NewDateNode("6 MAY 1989"),
+				),
+			),
 			format: gedcom.NameFormatWritten,
 			expected: `0 @P1@ INDI
 1 NAME Elliot Chance
@@ -310,15 +310,15 @@ func TestSimpleNameFilter(t *testing.T) {
 `,
 		},
 		{
-			root: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewNameNode(nil, "", "", []gedcom.Node{
-					gedcom.NewNodeWithChildren(nil, gedcom.TagGivenName, "Bob", "", nil),
-					gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, "Smith", "", nil),
-				}),
-				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
-					gedcom.NewDateNode(nil, "6 MAY 1989", "", nil),
-				}),
-			}),
+			root: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNameNode("",
+					gedcom.NewNode(gedcom.TagGivenName, "Bob", ""),
+					gedcom.NewNode(gedcom.TagSurname, "Smith", ""),
+				),
+				gedcom.NewBirthNode("",
+					gedcom.NewDateNode("6 MAY 1989"),
+				),
+			),
 			format: gedcom.NameFormatIndex,
 			expected: `0 @P1@ INDI
 1 NAME Smith, Bob
@@ -342,12 +342,12 @@ func TestOnlyVitalsTagFilter(t *testing.T) {
 		expected string
 	}{
 		"SimpleNameAndBirthDate": {
-			root: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewNameNode(nil, "Elliot /Chance/", "", nil),
-				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
-					gedcom.NewDateNode(nil, "6 MAY 1989", "", nil),
-				}),
-			}),
+			root: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNameNode("Elliot /Chance/"),
+				gedcom.NewBirthNode("",
+					gedcom.NewDateNode("6 MAY 1989"),
+				),
+			),
 			expected: `0 @P1@ INDI
 1 NAME Elliot /Chance/
 1 BIRT
@@ -355,14 +355,14 @@ func TestOnlyVitalsTagFilter(t *testing.T) {
 `,
 		},
 		"ComplexName1AndDeathDate": {
-			root: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewDeathNode(nil, "", "", []gedcom.Node{
-					gedcom.NewDateNode(nil, "6 MAY 1989", "", nil),
-				}),
-				gedcom.NewNameNode(nil, "Elliot /Chance/", "", []gedcom.Node{
-					gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, "Smith", "", nil),
-				}),
-			}),
+			root: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewDeathNode("",
+					gedcom.NewDateNode("6 MAY 1989"),
+				),
+				gedcom.NewNameNode("Elliot /Chance/",
+					gedcom.NewNode(gedcom.TagSurname, "Smith", ""),
+				),
+			),
 			expected: `0 @P1@ INDI
 1 DEAT
 2 DATE 6 MAY 1989
@@ -371,15 +371,15 @@ func TestOnlyVitalsTagFilter(t *testing.T) {
 `,
 		},
 		"ComplexName2AndBirthPlace": {
-			root: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewNameNode(nil, "", "", []gedcom.Node{
-					gedcom.NewNodeWithChildren(nil, gedcom.TagGivenName, "Bob", "", nil),
-					gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, "Smith", "", nil),
-				}),
-				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
-					gedcom.NewPlaceNode(nil, "Sydney, Australia", "", nil),
-				}),
-			}),
+			root: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNameNode("",
+					gedcom.NewNode(gedcom.TagGivenName, "Bob", ""),
+					gedcom.NewNode(gedcom.TagSurname, "Smith", ""),
+				),
+				gedcom.NewBirthNode("",
+					gedcom.NewPlaceNode("Sydney, Australia"),
+				),
+			),
 			expected: `0 @P1@ INDI
 1 NAME
 2 GIVN Bob
@@ -389,28 +389,28 @@ func TestOnlyVitalsTagFilter(t *testing.T) {
 `,
 		},
 		"Source": {
-			root: gedcom.NewSourceNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewNameNode(nil, "", "", []gedcom.Node{
-					gedcom.NewNodeWithChildren(nil, gedcom.TagGivenName, "Bob", "", nil),
-					gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, "Smith", "", nil),
-				}),
-				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
-					gedcom.NewPlaceNode(nil, "Sydney, Australia", "", nil),
-				}),
-			}),
+			root: gedcom.NewSourceNode("", "P1",
+				gedcom.NewNameNode("",
+					gedcom.NewNode(gedcom.TagGivenName, "Bob", ""),
+					gedcom.NewNode(gedcom.TagSurname, "Smith", ""),
+				),
+				gedcom.NewBirthNode("",
+					gedcom.NewPlaceNode("Sydney, Australia"),
+				),
+			),
 			expected: ``,
 		},
 		"IndividualNote": {
-			root: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewNameNode(nil, "", "", []gedcom.Node{
-					gedcom.NewNodeWithChildren(nil, gedcom.TagGivenName, "Bob", "", nil),
-					gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, "Smith", "", nil),
-				}),
-				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
-					gedcom.NewPlaceNode(nil, "Sydney, Australia", "", nil),
-				}),
-				gedcom.NewNode(nil, gedcom.TagNote, "foo", ""),
-			}),
+			root: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNameNode("",
+					gedcom.NewNode(gedcom.TagGivenName, "Bob", ""),
+					gedcom.NewNode(gedcom.TagSurname, "Smith", ""),
+				),
+				gedcom.NewBirthNode("",
+					gedcom.NewPlaceNode("Sydney, Australia"),
+				),
+				gedcom.NewNode(gedcom.TagNote, "foo", ""),
+			),
 			expected: `0 @P1@ INDI
 1 NAME
 2 GIVN Bob
@@ -420,16 +420,16 @@ func TestOnlyVitalsTagFilter(t *testing.T) {
 `,
 		},
 		"Burial": {
-			root: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewNameNode(nil, "", "", []gedcom.Node{
-					gedcom.NewNodeWithChildren(nil, gedcom.TagGivenName, "Bob", "", nil),
-					gedcom.NewNodeWithChildren(nil, gedcom.TagTitle, "Smith", "", nil),
-				}),
-				gedcom.NewBurialNode(nil, "", "", []gedcom.Node{
-					gedcom.NewPlaceNode(nil, "6 MAY 1989", "", nil),
-					gedcom.NewPlaceNode(nil, "Sydney, Australia", "", nil),
-				}),
-			}),
+			root: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNameNode("",
+					gedcom.NewNode(gedcom.TagGivenName, "Bob", ""),
+					gedcom.NewNode(gedcom.TagTitle, "Smith", ""),
+				),
+				gedcom.NewBurialNode("",
+					gedcom.NewPlaceNode("6 MAY 1989"),
+					gedcom.NewPlaceNode("Sydney, Australia"),
+				),
+			),
 			expected: `0 @P1@ INDI
 1 NAME
 2 GIVN Bob
@@ -440,16 +440,16 @@ func TestOnlyVitalsTagFilter(t *testing.T) {
 `,
 		},
 		"Baptism": {
-			root: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewNameNode(nil, "", "", []gedcom.Node{
-					gedcom.NewNodeWithChildren(nil, gedcom.TagNameSuffix, "Bob", "", nil),
-					gedcom.NewNodeWithChildren(nil, gedcom.TagSurnamePrefix, "Smith", "", nil),
-				}),
-				gedcom.NewBaptismNode(nil, "", "", []gedcom.Node{
-					gedcom.NewPlaceNode(nil, "6 MAY 1989", "", nil),
-					gedcom.NewPlaceNode(nil, "7 MAY 1989", "", nil),
-				}),
-			}),
+			root: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNameNode("",
+					gedcom.NewNode(gedcom.TagNameSuffix, "Bob", ""),
+					gedcom.NewNode(gedcom.TagSurnamePrefix, "Smith", ""),
+				),
+				gedcom.NewBaptismNode("",
+					gedcom.NewPlaceNode("6 MAY 1989"),
+					gedcom.NewPlaceNode("7 MAY 1989"),
+				),
+			),
 			expected: `0 @P1@ INDI
 1 NAME
 2 NSFX Bob
@@ -475,12 +475,12 @@ func TestRemoveEmptyDeathTagFilter(t *testing.T) {
 		expected string
 	}{
 		"WithoutDeath": {
-			root: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewNameNode(nil, "Elliot /Chance/", "", nil),
-				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
-					gedcom.NewDateNode(nil, "6 MAY 1989", "", nil),
-				}),
-			}),
+			root: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNameNode("Elliot /Chance/"),
+				gedcom.NewBirthNode("",
+					gedcom.NewDateNode("6 MAY 1989"),
+				),
+			),
 			expected: `0 @P1@ INDI
 1 NAME Elliot /Chance/
 1 BIRT
@@ -488,12 +488,12 @@ func TestRemoveEmptyDeathTagFilter(t *testing.T) {
 `,
 		},
 		"WithDeath": {
-			root: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewNameNode(nil, "Elliot /Chance/", "", nil),
-				gedcom.NewDeathNode(nil, "", "", []gedcom.Node{
-					gedcom.NewDateNode(nil, "6 MAY 1989", "", nil),
-				}),
-			}),
+			root: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNameNode("Elliot /Chance/"),
+				gedcom.NewDeathNode("",
+					gedcom.NewDateNode("6 MAY 1989"),
+				),
+			),
 			expected: `0 @P1@ INDI
 1 NAME Elliot /Chance/
 1 DEAT
@@ -501,19 +501,19 @@ func TestRemoveEmptyDeathTagFilter(t *testing.T) {
 `,
 		},
 		"WithEmptyDeath1": {
-			root: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewNameNode(nil, "Elliot /Chance/", "", nil),
-				gedcom.NewDeathNode(nil, "", "", nil),
-			}),
+			root: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNameNode("Elliot /Chance/"),
+				gedcom.NewDeathNode(""),
+			),
 			expected: `0 @P1@ INDI
 1 NAME Elliot /Chance/
 `,
 		},
 		"WithEmptyDeath2": {
-			root: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewNameNode(nil, "Elliot /Chance/", "", nil),
-				gedcom.NewDeathNode(nil, "Y", "", nil),
-			}),
+			root: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNameNode("Elliot /Chance/"),
+				gedcom.NewDeathNode("Y"),
+			),
 			expected: `0 @P1@ INDI
 1 NAME Elliot /Chance/
 `,

--- a/flatten.go
+++ b/flatten.go
@@ -17,12 +17,12 @@ package gedcom
 //
 //   Flatten(DeepCopy(node))
 //
-func Flatten(node Node) []Node {
+func Flatten(node Node) Nodes {
 	if IsNil(node) {
 		return nil
 	}
 
-	result := []Node{}
+	result := Nodes{}
 
 	Filter(node, func(node Node) (newNode Node, traverseChildren bool) {
 		result = append(result, node)
@@ -31,20 +31,4 @@ func Flatten(node Node) []Node {
 	})
 
 	return result
-}
-
-// FlattenAll works as Flatten with multiple inputs that are returned as a
-// single slice.
-//
-// If any of the nodes are nil they will be ignored.
-func FlattenAll(nodes []Node) (result []Node) {
-	for _, node := range nodes {
-		if IsNil(node) {
-			continue
-		}
-
-		result = append(result, Flatten(node)...)
-	}
-
-	return
 }

--- a/flatten_test.go
+++ b/flatten_test.go
@@ -7,19 +7,19 @@ import (
 )
 
 func TestFlatten(t *testing.T) {
-	dateNode1 := gedcom.NewDateNode(nil, "1851", "", nil)
-	dateNode2 := gedcom.NewDateNode(nil, "1856", "", nil)
-	birthNode := gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
+	dateNode1 := gedcom.NewDateNode("1851")
+	dateNode2 := gedcom.NewDateNode("1856")
+	birthNode := gedcom.NewBirthNode("",
 		dateNode1,
-	})
-	deathNode := gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
+	)
+	deathNode := gedcom.NewBirthNode("",
 		dateNode1,
 		dateNode2,
-	})
-	individualNode := gedcom.NewIndividualNode(nil, "", "P221", []gedcom.Node{
+	)
+	individualNode := gedcom.NewDocument().AddIndividual("P221",
 		birthNode,
 		deathNode,
-	})
+	)
 
 	t.Run("Nil", func(t *testing.T) {
 		actual := gedcom.Flatten(nil)

--- a/format_node.go
+++ b/format_node.go
@@ -7,8 +7,8 @@ type FormatNode struct {
 }
 
 // NewFormatNode creates a new FORM node.
-func NewFormatNode(document *Document, value, pointer string, children []Node) *FormatNode {
+func NewFormatNode(value string, children ...Node) *FormatNode {
 	return &FormatNode{
-		newSimpleNode(document, TagFormat, value, pointer, children),
+		newSimpleNode(TagFormat, value, "", children...),
 	}
 }

--- a/format_node_test.go
+++ b/format_node_test.go
@@ -8,15 +8,13 @@ import (
 )
 
 func TestNewFormatNode(t *testing.T) {
-	doc := gedcom.NewDocument()
-	child := gedcom.NewNameNode(doc, "", "", nil)
-	node := gedcom.NewFormatNode(doc, "foo", "bar", []gedcom.Node{child})
+	child := gedcom.NewNameNode("")
+	node := gedcom.NewFormatNode("foo", child)
 
 	assert.NotNil(t, node)
 	assert.IsType(t, node, (*gedcom.FormatNode)(nil))
 	assert.Equal(t, gedcom.TagFormat, node.Tag())
-	assert.Equal(t, []gedcom.Node{child}, node.Nodes())
-	assert.Equal(t, doc, node.Document())
+	assert.Equal(t, gedcom.Nodes{child}, node.Nodes())
 	assert.Equal(t, "foo", node.Value())
-	assert.Equal(t, "bar", node.Pointer())
+	assert.Equal(t, "", node.Pointer())
 }

--- a/gedcom2json/transform.go
+++ b/gedcom2json/transform.go
@@ -107,7 +107,7 @@ func reduceTagKeys(m interface{}, options TransformOptions) interface{} {
 	return m
 }
 
-func transformNodes(nodes []gedcom.Node, options TransformOptions) []interface{} {
+func transformNodes(nodes gedcom.Nodes, options TransformOptions) []interface{} {
 	ns := []interface{}{}
 
 	for _, n := range nodes {

--- a/gedcom2json/transform_test.go
+++ b/gedcom2json/transform_test.go
@@ -7,17 +7,17 @@ import (
 )
 
 var transformTests = []struct {
-	doc      *gedcom.Document
+	doc      func(*gedcom.Document)
 	expected []interface{}
 }{
 	{
-		doc:      gedcom.NewDocument(),
+		doc:      func(document *gedcom.Document) {},
 		expected: []interface{}{},
 	},
 	{
-		doc: gedcom.NewDocumentWithNodes([]gedcom.Node{
-			gedcom.NewNode(nil, gedcom.TagVersion, "5.5", ""),
-		}),
+		doc: func(document *gedcom.Document) {
+			document.AddNode(gedcom.NewNode(gedcom.TagVersion, "5.5", ""))
+		},
 		expected: []interface{}{
 			map[string]interface{}{
 				"tag": "VERS",
@@ -26,11 +26,11 @@ var transformTests = []struct {
 		},
 	},
 	{
-		doc: gedcom.NewDocumentWithNodes([]gedcom.Node{
-			gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewNameNode(nil, "Joe /Bloggs/", "", []gedcom.Node{}),
-			}),
-		}),
+		doc: func(document *gedcom.Document) {
+			document.AddIndividual("P1",
+				gedcom.NewNameNode("Joe /Bloggs/"),
+			)
+		},
 		expected: []interface{}{
 			map[string]interface{}{
 				"tag": "INDI",
@@ -50,7 +50,9 @@ func TestTransform(t *testing.T) {
 	for _, test := range transformTests {
 		t.Run("", func(t *testing.T) {
 			options := TransformOptions{}
-			assert.Equal(t, Transform(test.doc, options), test.expected)
+			doc := gedcom.NewDocument()
+			test.doc(doc)
+			assert.Equal(t, Transform(doc, options), test.expected)
 		})
 	}
 }

--- a/gedcom2text/main.go
+++ b/gedcom2text/main.go
@@ -109,10 +109,10 @@ func main() {
 
 			printLine("    -")
 			if father := family.Husband(); father != nil {
-				printLine(fmt.Sprintf("      Father: %s", father.Name()))
+				printLine(fmt.Sprintf("      Father: %s", father.Individual().Name()))
 			}
 			if mother := family.Wife(); mother != nil {
-				printLine(fmt.Sprintf("      Mother: %s", mother.Name()))
+				printLine(fmt.Sprintf("      Mother: %s", mother.Individual().Name()))
 			}
 		}
 
@@ -145,12 +145,13 @@ func main() {
 			// Children of the spouse.
 			children := withSpouse.Children()
 			sort.SliceStable(children, func(i, j int) bool {
-				return children[i].Names()[0].String() < children[j].Names()[0].String()
+				return children[i].Individual().Names()[0].String() <
+					children[j].Individual().Names()[0].String()
 			})
 			printLine("      Children:")
 			for _, child := range children {
 				n := "Unknown"
-				if n2 := child.Name(); n2 != nil {
+				if n2 := child.Individual().Name(); n2 != nil {
 					n = n2.String()
 				}
 				printLine(fmt.Sprintf("        - Name: %s", n))

--- a/gedcomer_test.go
+++ b/gedcomer_test.go
@@ -8,9 +8,9 @@ import (
 
 func TestGEDCOMLine(t *testing.T) {
 	GEDCOMLine := tf.Function(t, gedcom.GEDCOMLine)
-	nameNode := gedcom.NewNameNode(nil, "Joe /Bloggs/", "", []gedcom.Node{
-		gedcom.NewDateNode(nil, "3 Sep 1943", "", nil),
-	})
+	nameNode := gedcom.NewNameNode("Joe /Bloggs/",
+		gedcom.NewDateNode("3 Sep 1943"),
+	)
 
 	GEDCOMLine(nil, 0).Returns("")
 
@@ -23,9 +23,9 @@ func TestGEDCOMLine(t *testing.T) {
 
 func TestGEDCOMString(t *testing.T) {
 	GEDCOMString := tf.Function(t, gedcom.GEDCOMString)
-	nameNode := gedcom.NewNameNode(nil, "Joe /Bloggs/", "", []gedcom.Node{
-		gedcom.NewDateNode(nil, "3 Sep 1943", "", nil),
-	})
+	nameNode := gedcom.NewNameNode("Joe /Bloggs/",
+		gedcom.NewDateNode("3 Sep 1943"),
+	)
 
 	GEDCOMString(nil, 0).Returns("")
 

--- a/html/all_parent_buttons.go
+++ b/html/all_parent_buttons.go
@@ -27,8 +27,8 @@ func (c *AllParentButtons) WriteTo(w io.Writer) (int64, error) {
 	components := []Component{}
 
 	for _, family := range families {
-		husbandMatches := family.Husband().Is(c.individual)
-		wifeMatches := family.Wife().Is(c.individual)
+		husbandMatches := family.Husband().IsIndividual(c.individual)
+		wifeMatches := family.Wife().IsIndividual(c.individual)
 
 		if husbandMatches || wifeMatches {
 			continue
@@ -41,7 +41,7 @@ func (c *AllParentButtons) WriteTo(w io.Writer) (int64, error) {
 	// If there are no families we still want to show an empty family. We just
 	// create a dummy family that has no child nodes.
 	if len(components) == 0 {
-		familyNode := gedcom.NewFamilyNode(nil, "", nil)
+		familyNode := gedcom.NewDocument().AddFamily("")
 		components = []Component{
 			NewParentButtons(c.document, familyNode, c.visibility),
 		}

--- a/html/diff_page_test.go
+++ b/html/diff_page_test.go
@@ -9,51 +9,29 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var (
-	elliot = individual("P1", "Elliot /Chance/", "4 Jan 1843", "17 Mar 1907")
-	john   = individual("P2", "John /Smith/", "4 Jan 1803", "17 Mar 1877")
-	jane   = individual("P3", "Jane /Doe/", "3 Mar 1803", "14 June 1877")
-)
-
-func individual(pointer, fullName, birth, death string) *gedcom.IndividualNode {
-	nodes := []gedcom.Node{}
+func individual(doc *gedcom.Document, pointer, fullName, birth, death string) *gedcom.IndividualNode {
+	individual := doc.AddIndividual(pointer)
 
 	if fullName != "" {
-		nodes = append(nodes, name(fullName))
+		individual.AddNode(gedcom.NewNameNode(fullName))
 	}
 
 	if birth != "" {
-		nodes = append(nodes, born(birth))
+		individual.AddNode(gedcom.NewBirthNode("", gedcom.NewDateNode(birth)))
 	}
 
 	if death != "" {
-		nodes = append(nodes, died(death))
+		individual.AddNode(gedcom.NewDeathNode("", gedcom.NewDateNode(death)))
 	}
 
-	return gedcom.NewIndividualNode(nil, "", pointer, nodes)
-}
-
-func name(value string) gedcom.Node {
-	return gedcom.NewNameNode(nil, value, "", nil)
-}
-
-func born(value string) *gedcom.BirthNode {
-	return gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
-		gedcom.NewDateNode(nil, value, "", []gedcom.Node{}),
-	})
-}
-
-func died(value string) gedcom.Node {
-	return gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "", "", []gedcom.Node{
-		gedcom.NewDateNode(nil, value, "", []gedcom.Node{}),
-	})
+	return individual
 }
 
 func TestDiffPage_WriteTo(t *testing.T) {
 	doc := gedcom.NewDocument()
-	jane.SetDocument(doc)
-	elliot.SetDocument(doc)
-	john.SetDocument(doc)
+	elliot := individual(doc, "P1", "Elliot /Chance/", "4 Jan 1843", "17 Mar 1907")
+	john := individual(doc, "P2", "John /Smith/", "4 Jan 1803", "17 Mar 1877")
+	jane := individual(doc, "P3", "Jane /Doe/", "3 Mar 1803", "14 June 1877")
 
 	comparisons := gedcom.IndividualComparisons{
 		gedcom.NewIndividualComparison(jane, jane, gedcom.NewSurroundingSimilarity(0.5, 1.0, 1.0, 1.0)),

--- a/html/event_date_test.go
+++ b/html/event_date_test.go
@@ -12,11 +12,11 @@ func TestEventDate_WriteTo(t *testing.T) {
 	c(html.NewEventDate("foo", gedcom.DateNodes{})).Returns(``)
 
 	c(html.NewEventDate("foo", gedcom.DateNodes{
-		gedcom.NewDateNode(nil, "3 Sep 1945", "", nil),
+		gedcom.NewDateNode("3 Sep 1945"),
 	})).Returns(`<em>foo</em> 3 Sep 1945`)
 
 	c(html.NewEventDate("bar", gedcom.DateNodes{
-		gedcom.NewDateNode(nil, "17 Sep 1945", "", nil),
-		gedcom.NewDateNode(nil, "3 Sep 1945", "", nil),
+		gedcom.NewDateNode("17 Sep 1945"),
+		gedcom.NewDateNode("3 Sep 1945"),
 	})).Returns(`<em>bar</em> 17 Sep 1945`)
 }

--- a/html/event_dates_test.go
+++ b/html/event_dates_test.go
@@ -13,17 +13,17 @@ func TestEventDates_WriteTo(t *testing.T) {
 
 	c(html.NewEventDates([]*html.EventDate{
 		html.NewEventDate("foo", gedcom.DateNodes{
-			gedcom.NewDateNode(nil, "3 Sep 1945", "", nil),
+			gedcom.NewDateNode("3 Sep 1945"),
 		}),
 	})).Returns("<em>foo</em> 3 Sep 1945")
 
 	c(html.NewEventDates([]*html.EventDate{
 		html.NewEventDate("foo", gedcom.DateNodes{
-			gedcom.NewDateNode(nil, "3 Sep 1945", "", nil),
+			gedcom.NewDateNode("3 Sep 1945"),
 		}),
 		html.NewEventDate("bar", gedcom.DateNodes{
-			gedcom.NewDateNode(nil, "17 Sep 1945", "", nil),
-			gedcom.NewDateNode(nil, "3 Sep 1945", "", nil),
+			gedcom.NewDateNode("17 Sep 1945"),
+			gedcom.NewDateNode("3 Sep 1945"),
 		}),
 	})).Returns("<em>foo</em> 3 Sep 1945&nbsp;&nbsp;&nbsp;<em>bar</em> 17 Sep 1945")
 }

--- a/html/family_in_list.go
+++ b/html/family_in_list.go
@@ -26,8 +26,8 @@ func (c *FamilyInList) WriteTo(w io.Writer) (int64, error) {
 		date = n.Value()
 	}
 
-	husband := NewIndividualLink(c.document, c.family.Husband(), c.visibility)
-	wife := NewIndividualLink(c.document, c.family.Wife(), c.visibility)
+	husband := NewIndividualLink(c.document, c.family.Husband().Individual(), c.visibility)
+	wife := NewIndividualLink(c.document, c.family.Wife().Individual(), c.visibility)
 
 	return NewTableRow(
 		NewTableCell(husband),

--- a/html/individual_button_test.go
+++ b/html/individual_button_test.go
@@ -7,9 +7,10 @@ import (
 )
 
 func TestIndividualButton_WriteTo(t *testing.T) {
-	c := testComponent(t, "IndividualButton")
+	doc := gedcom.NewDocument()
+	elliot := individual(doc, "P1", "Elliot /Chance/", "4 Jan 1843", "17 Mar 1907")
 
-	doc := gedcom.NewDocumentWithNodes([]gedcom.Node{elliot})
+	c := testComponent(t, "IndividualButton")
 
 	c(html.NewIndividualButton(doc, elliot, html.LivingVisibilityPlaceholder)).
 		Returns("<button class=\"btn btn-outline-info btn-block\" onclick=\"location.href='elliot-chance.html'\" type=\"button\"><strong>Elliot Chance</strong><br/><em>b.</em> 4 Jan 1843&nbsp;&nbsp;&nbsp;<em>d.</em> 17 Mar 1907&nbsp;</button>")

--- a/html/individual_compare.go
+++ b/html/individual_compare.go
@@ -120,10 +120,10 @@ func (c *IndividualCompare) writeTo(w io.Writer) (int64, error) {
 	if !gedcom.IsNil(left) {
 		for _, parents := range left.Parents() {
 			if parent := parents.Husband(); parent != nil {
-				leftParents = append(leftParents, parent)
+				leftParents = append(leftParents, parent.Individual())
 			}
 			if parent := parents.Wife(); parent != nil {
-				leftParents = append(leftParents, parent)
+				leftParents = append(leftParents, parent.Individual())
 			}
 		}
 	}
@@ -132,10 +132,10 @@ func (c *IndividualCompare) writeTo(w io.Writer) (int64, error) {
 	if !gedcom.IsNil(right) {
 		for _, parents := range right.Parents() {
 			if parent := parents.Husband(); parent != nil {
-				rightParents = append(rightParents, parent)
+				rightParents = append(rightParents, parent.Individual())
 			}
 			if parent := parents.Wife(); parent != nil {
-				rightParents = append(rightParents, parent)
+				rightParents = append(rightParents, parent.Individual())
 			}
 		}
 	}

--- a/html/individual_dates_test.go
+++ b/html/individual_dates_test.go
@@ -1,12 +1,16 @@
 package html_test
 
 import (
+	"github.com/elliotchance/gedcom"
 	"github.com/elliotchance/gedcom/html"
 	"testing"
 )
 
 func TestIndividualDates_WriteTo(t *testing.T) {
 	c := testComponent(t, "IndividualDates")
+
+	doc := gedcom.NewDocument()
+	elliot := individual(doc, "P1", "Elliot /Chance/", "4 Jan 1843", "17 Mar 1907")
 
 	c(html.NewIndividualDates(elliot, html.LivingVisibilityPlaceholder)).
 		Returns("<em>b.</em> 4 Jan 1843&nbsp;&nbsp;&nbsp;<em>d.</em> 17 Mar 1907")

--- a/html/individual_events.go
+++ b/html/individual_events.go
@@ -50,19 +50,19 @@ func (c *IndividualEvents) WriteTo(w io.Writer) (int64, error) {
 		}
 
 		var description Component = NewEmpty()
-		if family.Husband().Is(c.individual) {
+		if family.Husband().IsIndividual(c.individual) {
 			description = NewHTML(UnknownEmphasis)
 
 			if wife := family.Wife(); wife != nil {
-				description = NewIndividualLink(c.document, wife, c.visibility)
+				description = NewIndividualLink(c.document, wife.Individual(), c.visibility)
 			}
 		}
 
-		if family.Wife().Is(c.individual) {
+		if family.Wife().IsIndividual(c.individual) {
 			description = NewHTML(UnknownEmphasis)
 
 			if husband := family.Husband(); husband != nil {
-				description = NewIndividualLink(c.document, husband, c.visibility)
+				description = NewIndividualLink(c.document, husband.Individual(), c.visibility)
 			}
 		}
 

--- a/html/parent_buttons.go
+++ b/html/parent_buttons.go
@@ -22,8 +22,8 @@ func NewParentButtons(document *gedcom.Document, family *gedcom.FamilyNode, visi
 }
 
 func (c *ParentButtons) WriteTo(w io.Writer) (int64, error) {
-	husband := NewIndividualButton(c.document, c.family.Husband(), c.visibility)
-	wife := NewIndividualButton(c.document, c.family.Wife(), c.visibility)
+	husband := NewIndividualButton(c.document, c.family.Husband().Individual(), c.visibility)
+	wife := NewIndividualButton(c.document, c.family.Wife().Individual(), c.visibility)
 	svg := NewPlusSVG(false, true, true, true)
 	space := NewSpace()
 

--- a/html/partners_and_children.go
+++ b/html/partners_and_children.go
@@ -97,7 +97,7 @@ func partnerSection(family *gedcom.FamilyNode, c *PartnersAndChildren, columns [
 	children := []*gedcom.IndividualNode{}
 
 	for _, child := range allChildren {
-		if child.IsLiving() {
+		if child.Individual().IsLiving() {
 			switch c.visibility {
 			case LivingVisibilityHide:
 				continue
@@ -107,7 +107,7 @@ func partnerSection(family *gedcom.FamilyNode, c *PartnersAndChildren, columns [
 			}
 		}
 
-		children = append(children, child)
+		children = append(children, child.Individual())
 	}
 
 	numberOfChildren := len(children)

--- a/html/place_event.go
+++ b/html/place_event.go
@@ -29,7 +29,7 @@ func (c *PlaceEvent) WriteTo(w io.Writer) (int64, error) {
 		date = d.Value()
 	}
 
-	individual := individualForNode(c.node)
+	individual := individualForNode(c.document, c.node)
 	var person Component = NewIndividualLink(c.document, individual, c.visibility)
 	isLiving := individual != nil && individual.IsLiving()
 

--- a/html/places.go
+++ b/html/places.go
@@ -11,7 +11,7 @@ var placesMap map[string]*place
 type place struct {
 	PrettyName string
 	country    string
-	nodes      []gedcom.Node
+	nodes      gedcom.Nodes
 }
 
 func prettyPlaceName(s string) string {
@@ -47,7 +47,7 @@ func GetPlaces(document *gedcom.Document) map[string]*place {
 				placesMap[key] = &place{
 					PrettyName: prettyName,
 					country:    country,
-					nodes:      []gedcom.Node{},
+					nodes:      gedcom.Nodes{},
 				}
 			}
 
@@ -78,8 +78,8 @@ func GetPlaces(document *gedcom.Document) map[string]*place {
 				}
 
 				// Individual name.
-				leftIndividual := individualForNode(left)
-				rightIndividual := individualForNode(right)
+				leftIndividual := individualForNode(document, left)
+				rightIndividual := individualForNode(document, right)
 
 				if leftIndividual != nil && rightIndividual != nil {
 					leftName := gedcom.String(leftIndividual.Name())

--- a/html/util.go
+++ b/html/util.go
@@ -196,8 +196,8 @@ func surnameStartsWith(individual *gedcom.IndividualNode, letter rune) bool {
 	return firstLetter == letter
 }
 
-func individualForNode(node gedcom.Node) *gedcom.IndividualNode {
-	for _, individual := range node.Document().Individuals() {
+func individualForNode(doc *gedcom.Document, node gedcom.Node) *gedcom.IndividualNode {
+	for _, individual := range doc.Individuals() {
 		if gedcom.HasNestedNode(individual, node) {
 			return individual
 		}

--- a/husband_node.go
+++ b/husband_node.go
@@ -1,0 +1,56 @@
+package gedcom
+
+import "fmt"
+
+// HusbandNode is the natural, adopted, or sealed (LDS) child of a father and a
+// mother.
+type HusbandNode struct {
+	*SimpleNode
+	family *FamilyNode
+}
+
+func newHusbandNode(family *FamilyNode, value string, children ...Node) *HusbandNode {
+	return &HusbandNode{
+		newSimpleNode(TagHusband, value, "", children...),
+		family,
+	}
+}
+
+func newHusbandNodeWithIndividual(family *FamilyNode, individual *IndividualNode) *HusbandNode {
+	// TODO: check individual belongs to the same document as family
+	return newHusbandNode(family, fmt.Sprintf("@%s@", individual.Pointer()))
+}
+
+func (node *HusbandNode) Family() *FamilyNode {
+	return node.family
+}
+
+func (node *HusbandNode) Individual() *IndividualNode {
+	if node == nil {
+		return nil
+	}
+
+	n := node.family.document.NodeByPointer(valueToPointer(node.value))
+
+	if IsNil(n) {
+		return nil
+	}
+
+	return n.(*IndividualNode)
+}
+
+func (node *HusbandNode) Similarity(other *HusbandNode, options SimilarityOptions) float64 {
+	if node == nil || other == nil {
+		return 0.5
+	}
+
+	return node.Individual().Similarity(other.Individual(), options)
+}
+
+func (node *HusbandNode) IsIndividual(node2 *IndividualNode) bool {
+	if node == nil || node2 == nil {
+		return false
+	}
+
+	return node.Individual().Is(node2)
+}

--- a/individual_node_test.go
+++ b/individual_node_test.go
@@ -16,50 +16,50 @@ var individualTests = []struct {
 	sex   gedcom.Sex
 }{
 	{
-		node:  individual("P1", "", "", ""),
+		node:  individual(gedcom.NewDocument(), "P1", "", "", ""),
 		names: []*gedcom.NameNode{},
 		sex:   gedcom.SexUnknown,
 	},
 	{
-		node:  gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{}),
+		node:  gedcom.NewDocument().AddIndividual("P1"),
 		names: []*gedcom.NameNode{},
 		sex:   gedcom.SexUnknown,
 	},
 	{
-		node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-			gedcom.NewNameNode(nil, "Joe /Bloggs/", "", []gedcom.Node{}),
-		}),
+		node: gedcom.NewDocument().AddIndividual("P1",
+			gedcom.NewNameNode("Joe /Bloggs/"),
+		),
 		names: []*gedcom.NameNode{
-			gedcom.NewNameNode(nil, "Joe /Bloggs/", "", []gedcom.Node{}),
+			gedcom.NewNameNode("Joe /Bloggs/"),
 		},
 		sex: gedcom.SexUnknown,
 	},
 	{
-		node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-			gedcom.NewNameNode(nil, "Joe /Bloggs/", "", []gedcom.Node{}),
-			gedcom.NewNodeWithChildren(nil, gedcom.TagVersion, "", "", []gedcom.Node{}),
-			gedcom.NewNameNode(nil, "John /Doe/", "", []gedcom.Node{}),
-		}),
+		node: gedcom.NewDocument().AddIndividual("P1",
+			gedcom.NewNameNode("Joe /Bloggs/"),
+			gedcom.NewNode(gedcom.TagVersion, "", ""),
+			gedcom.NewNameNode("John /Doe/"),
+		),
 		names: []*gedcom.NameNode{
-			gedcom.NewNameNode(nil, "Joe /Bloggs/", "", []gedcom.Node{}),
-			gedcom.NewNameNode(nil, "John /Doe/", "", []gedcom.Node{}),
+			gedcom.NewNameNode("Joe /Bloggs/"),
+			gedcom.NewNameNode("John /Doe/"),
 		},
 		sex: gedcom.SexUnknown,
 	},
 	{
-		node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-			gedcom.NewNodeWithChildren(nil, gedcom.TagSex, "M", "", []gedcom.Node{}),
-		}),
+		node: gedcom.NewDocument().AddIndividual("P1",
+			gedcom.NewNode(gedcom.TagSex, "M", ""),
+		),
 		names: []*gedcom.NameNode{},
 		sex:   gedcom.SexMale,
 	},
 	{
-		node: gedcom.NewIndividualNode(nil, "", "P2", []gedcom.Node{
-			gedcom.NewNameNode(nil, "Joan /Bloggs/", "", []gedcom.Node{}),
-			gedcom.NewNodeWithChildren(nil, gedcom.TagSex, "F", "", []gedcom.Node{}),
-		}),
+		node: gedcom.NewDocument().AddIndividual("P2",
+			gedcom.NewNameNode("Joan /Bloggs/"),
+			gedcom.NewNode(gedcom.TagSex, "F", ""),
+		),
 		names: []*gedcom.NameNode{
-			gedcom.NewNameNode(nil, "Joan /Bloggs/", "", []gedcom.Node{}),
+			gedcom.NewNameNode("Joan /Bloggs/"),
 		},
 		sex: gedcom.SexFemale,
 	},
@@ -100,39 +100,39 @@ func TestIndividualNode_Births(t *testing.T) {
 			births: nil,
 		},
 		{
-			node:   individual("P1", "", "", ""),
+			node:   individual(gedcom.NewDocument(), "P1", "", "", ""),
 			births: nil,
 		},
 		{
-			node:   gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{}),
+			node:   gedcom.NewDocument().AddIndividual("P1"),
 			births: nil,
 		},
 		{
-			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{}),
-			}),
+			node: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewBirthNode(""),
+			),
 			births: []*gedcom.BirthNode{
-				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{}),
+				gedcom.NewBirthNode(""),
 			},
 		},
 		{
-			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{}),
-				gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
-			}),
+			node: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewBirthNode(""),
+				gedcom.NewNode(gedcom.TagDeath, "", ""),
+			),
 			births: []*gedcom.BirthNode{
-				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{}),
+				gedcom.NewBirthNode(""),
 			},
 		},
 		{
-			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewBirthNode(nil, "foo", "", []gedcom.Node{}),
-				gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
-				gedcom.NewBirthNode(nil, "bar", "", []gedcom.Node{}),
-			}),
+			node: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewBirthNode("foo"),
+				gedcom.NewNode(gedcom.TagDeath, "", ""),
+				gedcom.NewBirthNode("bar"),
+			),
 			births: []*gedcom.BirthNode{
-				gedcom.NewBirthNode(nil, "foo", "", []gedcom.Node{}),
-				gedcom.NewBirthNode(nil, "bar", "", []gedcom.Node{}),
+				gedcom.NewBirthNode("foo"),
+				gedcom.NewBirthNode("bar"),
 			},
 		},
 	}
@@ -155,52 +155,52 @@ func TestIndividualNode_Baptisms(t *testing.T) {
 			baptisms: []*gedcom.BaptismNode{},
 		},
 		{
-			node:     individual("P1", "", "", ""),
+			node:     individual(gedcom.NewDocument(), "P1", "", "", ""),
 			baptisms: []*gedcom.BaptismNode{},
 		},
 		{
-			node:     gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{}),
+			node:     gedcom.NewDocument().AddIndividual("P1"),
 			baptisms: []*gedcom.BaptismNode{},
 		},
 		{
-			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewNodeWithChildren(nil, gedcom.TagBaptism, "", "", []gedcom.Node{}),
-			}),
+			node: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNode(gedcom.TagBaptism, "", ""),
+			),
 			baptisms: []*gedcom.BaptismNode{
-				gedcom.NewBaptismNode(nil, "", "", []gedcom.Node{}),
+				gedcom.NewBaptismNode(""),
 			},
 		},
 		{
-			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewNodeWithChildren(nil, gedcom.TagLDSBaptism, "", "", []gedcom.Node{}),
-			}),
+			node: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNode(gedcom.TagLDSBaptism, "", ""),
+			),
 			baptisms: []*gedcom.BaptismNode{},
 		},
 		{
-			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewNodeWithChildren(nil, gedcom.TagBaptism, "", "", []gedcom.Node{}),
-				gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
-			}),
+			node: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNode(gedcom.TagBaptism, "", ""),
+				gedcom.NewNode(gedcom.TagDeath, "", ""),
+			),
 			baptisms: []*gedcom.BaptismNode{
-				gedcom.NewBaptismNode(nil, "", "", []gedcom.Node{}),
+				gedcom.NewBaptismNode(""),
 			},
 		},
 		{
-			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewNodeWithChildren(nil, gedcom.TagBaptism, "foo", "", []gedcom.Node{}),
-				gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
-				gedcom.NewNodeWithChildren(nil, gedcom.TagBaptism, "bar", "", []gedcom.Node{}),
-			}),
+			node: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNode(gedcom.TagBaptism, "foo", ""),
+				gedcom.NewNode(gedcom.TagDeath, "", ""),
+				gedcom.NewNode(gedcom.TagBaptism, "bar", ""),
+			),
 			baptisms: []*gedcom.BaptismNode{
-				gedcom.NewBaptismNode(nil, "foo", "", []gedcom.Node{}),
-				gedcom.NewBaptismNode(nil, "bar", "", []gedcom.Node{}),
+				gedcom.NewBaptismNode("foo"),
+				gedcom.NewBaptismNode("bar"),
 			},
 		},
 	}
 
 	for _, test := range tests {
 		t.Run("", func(t *testing.T) {
-			assert.Equal(t, test.node.Baptisms(), test.baptisms)
+			assertEqual(t, test.node.Baptisms(), test.baptisms)
 		})
 	}
 }
@@ -216,39 +216,39 @@ func TestIndividualNode_Deaths(t *testing.T) {
 			deaths: []*gedcom.DeathNode{},
 		},
 		{
-			node:   individual("P1", "", "", ""),
+			node:   individual(gedcom.NewDocument(), "P1", "", "", ""),
 			deaths: []*gedcom.DeathNode{},
 		},
 		{
-			node:   gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{}),
+			node:   gedcom.NewDocument().AddIndividual("P1"),
 			deaths: []*gedcom.DeathNode{},
 		},
 		{
-			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
-			}),
+			node: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNode(gedcom.TagDeath, "", ""),
+			),
 			deaths: []*gedcom.DeathNode{
-				gedcom.NewDeathNode(nil, "", "", []gedcom.Node{}),
+				gedcom.NewDeathNode(""),
 			},
 		},
 		{
-			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
-				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{}),
-			}),
+			node: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNode(gedcom.TagDeath, "", ""),
+				gedcom.NewBirthNode(""),
+			),
 			deaths: []*gedcom.DeathNode{
-				gedcom.NewDeathNode(nil, "", "", []gedcom.Node{}),
+				gedcom.NewDeathNode(""),
 			},
 		},
 		{
-			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "foo", "", []gedcom.Node{}),
-				gedcom.NewNodeWithChildren(nil, gedcom.TagBurial, "", "", []gedcom.Node{}),
-				gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "bar", "", []gedcom.Node{}),
-			}),
+			node: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNode(gedcom.TagDeath, "foo", ""),
+				gedcom.NewNode(gedcom.TagBurial, "", ""),
+				gedcom.NewNode(gedcom.TagDeath, "bar", ""),
+			),
 			deaths: []*gedcom.DeathNode{
-				gedcom.NewDeathNode(nil, "foo", "", []gedcom.Node{}),
-				gedcom.NewDeathNode(nil, "bar", "", []gedcom.Node{}),
+				gedcom.NewDeathNode("foo"),
+				gedcom.NewDeathNode("bar"),
 			},
 		},
 	}
@@ -271,39 +271,39 @@ func TestIndividualNode_Burials(t *testing.T) {
 			burials: []*gedcom.BurialNode{},
 		},
 		{
-			node:    individual("P1", "", "", ""),
+			node:    individual(gedcom.NewDocument(), "P1", "", "", ""),
 			burials: []*gedcom.BurialNode{},
 		},
 		{
-			node:    gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{}),
+			node:    gedcom.NewDocument().AddIndividual("P1"),
 			burials: []*gedcom.BurialNode{},
 		},
 		{
-			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewNodeWithChildren(nil, gedcom.TagBurial, "", "", []gedcom.Node{}),
-			}),
+			node: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNode(gedcom.TagBurial, "", ""),
+			),
 			burials: []*gedcom.BurialNode{
-				gedcom.NewBurialNode(nil, "", "", []gedcom.Node{}),
+				gedcom.NewBurialNode(""),
 			},
 		},
 		{
-			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewNodeWithChildren(nil, gedcom.TagBurial, "", "", []gedcom.Node{}),
-				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{}),
-			}),
+			node: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNode(gedcom.TagBurial, "", ""),
+				gedcom.NewBirthNode(""),
+			),
 			burials: []*gedcom.BurialNode{
-				gedcom.NewBurialNode(nil, "", "", []gedcom.Node{}),
+				gedcom.NewBurialNode(""),
 			},
 		},
 		{
-			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewNodeWithChildren(nil, gedcom.TagBurial, "foo", "", []gedcom.Node{}),
-				gedcom.NewNodeWithChildren(nil, gedcom.TagBaptism, "", "", []gedcom.Node{}),
-				gedcom.NewNodeWithChildren(nil, gedcom.TagBurial, "bar", "", []gedcom.Node{}),
-			}),
+			node: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNode(gedcom.TagBurial, "foo", ""),
+				gedcom.NewNode(gedcom.TagBaptism, "", ""),
+				gedcom.NewNode(gedcom.TagBurial, "bar", ""),
+			),
 			burials: []*gedcom.BurialNode{
-				gedcom.NewBurialNode(nil, "foo", "", []gedcom.Node{}),
-				gedcom.NewBurialNode(nil, "bar", "", []gedcom.Node{}),
+				gedcom.NewBurialNode("foo"),
+				gedcom.NewBurialNode("bar"),
 			},
 		},
 	}
@@ -330,187 +330,176 @@ func getDocument() *gedcom.Document {
 	// - P8 does not connect to anything.
 	// - P3 is the alternate mother of P6.
 
-	p1 := individual("P1", "", "", "")
-	p2 := individual("P2", "", "", "")
-	p3 := gedcom.NewIndividualNode(nil, "", "P3", nil)
-	p4 := gedcom.NewIndividualNode(nil, "", "P4", nil)
-	p5 := gedcom.NewIndividualNode(nil, "", "P5", nil)
-	p6 := gedcom.NewIndividualNode(nil, "", "P6", nil)
-	p7 := gedcom.NewIndividualNode(nil, "", "P7", nil)
-	p8 := gedcom.NewIndividualNode(nil, "", "P8", nil)
+	doc := gedcom.NewDocument()
+	p1 := doc.AddIndividual("P1")
+	p2 := doc.AddIndividual("P2")
+	p3 := doc.AddIndividual("P3")
+	p4 := doc.AddIndividual("P4")
+	p5 := doc.AddIndividual("P5")
+	p6 := doc.AddIndividual("P6")
+	p7 := doc.AddIndividual("P7")
+	doc.AddIndividual("P8")
 
 	// P1 - P3
 	//    |
 	//  -----
 	// P4   P5
-	f1 := gedcom.NewFamilyNode(nil, "F1", []gedcom.Node{
-		gedcom.NewNodeWithChildren(nil, gedcom.TagHusband, "@P1@", "", nil),
-		gedcom.NewNodeWithChildren(nil, gedcom.TagWife, "@P3@", "", nil),
-		gedcom.NewNodeWithChildren(nil, gedcom.TagChild, "@P4@", "", nil),
-		gedcom.NewNodeWithChildren(nil, gedcom.TagChild, "@P5@", "", nil),
-	})
+	f1 := doc.AddFamilyWithHusbandAndWife("F1", p1, p3)
+	f1.AddChild(p4)
+	f1.AddChild(p5)
 
 	// P1 - P2
 	//    |
 	//   P6
-	f2 := gedcom.NewFamilyNode(nil, "F2", []gedcom.Node{
-		gedcom.NewNodeWithChildren(nil, gedcom.TagHusband, "@P1@", "", nil),
-		gedcom.NewNodeWithChildren(nil, gedcom.TagWife, "@P2@", "", nil),
-		gedcom.NewNodeWithChildren(nil, gedcom.TagChild, "@P6@", "", nil),
-	})
+	f2 := doc.AddFamilyWithHusbandAndWife("F2", p1, p2)
+	f2.AddChild(p6)
 
 	// P6 - ?
 	//    |
 	//   P7
-	f3 := gedcom.NewFamilyNode(nil, "F3", []gedcom.Node{
-		gedcom.NewNodeWithChildren(nil, gedcom.TagHusband, "@P6@", "", nil),
-		gedcom.NewNodeWithChildren(nil, gedcom.TagChild, "@P7@", "", nil),
-	})
+	f3 := doc.AddFamilyWithHusbandAndWife("F3", p6, nil)
+	f3.AddChild(p7)
 
 	// ? - P3
 	//   |
 	//   P6
-	f4 := gedcom.NewFamilyNode(nil, "F4", []gedcom.Node{
-		gedcom.NewNodeWithChildren(nil, gedcom.TagWife, "@P3@", "", nil),
-		gedcom.NewNodeWithChildren(nil, gedcom.TagChild, "@P6@", "", nil),
-	})
+	f4 := doc.AddFamilyWithHusbandAndWife("F4", nil, p3)
+	f4.AddChild(p6)
 
-	return gedcom.NewDocumentWithNodes([]gedcom.Node{
-		p1, p2, p3, p4, p5, p6, p7, p8,
-		f1, f2, f3, f4,
-	})
+	return doc
 }
 
 func TestIndividualNode_Parents(t *testing.T) {
 	doc := getDocument()
+	individuals := doc.Individuals()
+	families := doc.Families()
 
 	var tests = []struct {
 		node    *gedcom.IndividualNode
-		parents []*gedcom.FamilyNode
+		parents gedcom.FamilyNodes
 	}{
 		{
 			node:    nil,
 			parents: nil,
 		},
 		{
-			node:    doc.Individuals()[0],
-			parents: []*gedcom.FamilyNode{},
+			node:    individuals.ByPointer("P1"),
+			parents: gedcom.FamilyNodes{},
 		},
 		{
-			node:    doc.Individuals()[1],
-			parents: []*gedcom.FamilyNode{},
+			node:    individuals.ByPointer("P2"),
+			parents: gedcom.FamilyNodes{},
 		},
 		{
-			node:    doc.Individuals()[2],
-			parents: []*gedcom.FamilyNode{},
+			node:    individuals.ByPointer("P3"),
+			parents: gedcom.FamilyNodes{},
 		},
 		{
-			node:    doc.Individuals()[3],
-			parents: []*gedcom.FamilyNode{doc.Families()[0]},
+			node:    individuals.ByPointer("P4"),
+			parents: gedcom.FamilyNodes{families.ByPointer("F1")},
 		},
 		{
-			node:    doc.Individuals()[4],
-			parents: []*gedcom.FamilyNode{doc.Families()[0]},
+			node:    individuals.ByPointer("P5"),
+			parents: gedcom.FamilyNodes{families.ByPointer("F1")},
 		},
 		{
-			node:    doc.Individuals()[5],
-			parents: []*gedcom.FamilyNode{doc.Families()[1], doc.Families()[3]},
+			node: individuals.ByPointer("P6"),
+			parents: gedcom.FamilyNodes{
+				families.ByPointer("F2"),
+				families.ByPointer("F4"),
+			},
 		},
 		{
-			node:    doc.Individuals()[6],
-			parents: []*gedcom.FamilyNode{doc.Families()[2]},
+			node:    individuals.ByPointer("P7"),
+			parents: gedcom.FamilyNodes{families.ByPointer("F3")},
 		},
 		{
-			node:    doc.Individuals()[7],
-			parents: []*gedcom.FamilyNode{},
+			node:    individuals.ByPointer("P8"),
+			parents: gedcom.FamilyNodes{},
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(gedcom.Pointer(test.node), func(t *testing.T) {
-			for _, n := range doc.Nodes() {
-				n.SetDocument(doc)
-			}
-			assert.Equal(t, test.node.Parents(), test.parents)
+			assertEqual(t, test.parents, test.node.Parents())
 		})
 	}
 }
 
 func TestIndividualNode_SpouseChildren(t *testing.T) {
 	doc := getDocument()
+	individuals := doc.Individuals()
+	families := doc.Families()
 
-	var tests = []struct {
+	var tests = map[string]struct {
 		node     *gedcom.IndividualNode
 		expected gedcom.SpouseChildren
 	}{
-		{
+		"Nil": {
 			node:     nil,
 			expected: gedcom.SpouseChildren{},
 		},
-		{
-			node: doc.Individuals()[0],
+		"P1": {
+			node: individuals.ByPointer("P1"),
 			expected: gedcom.SpouseChildren{
-				doc.Individuals()[2]: {
-					doc.Individuals()[3],
-					doc.Individuals()[4],
+				individuals.ByPointer("P3"): {
+					families.ByPointer("F1").Children().ByPointer("P4"),
+					families.ByPointer("F1").Children().ByPointer("P5"),
 				},
-				doc.Individuals()[1]: {
-					doc.Individuals()[5],
-				},
-			},
-		},
-		{
-			node: doc.Individuals()[1],
-			expected: gedcom.SpouseChildren{
-				doc.Individuals()[0]: {
-					doc.Individuals()[5],
+				individuals.ByPointer("P2"): {
+					families.ByPointer("F2").Children().ByPointer("P6"),
 				},
 			},
 		},
-		{
-			node: doc.Individuals()[2],
+		"P2": {
+			node: individuals.ByPointer("P2"),
 			expected: gedcom.SpouseChildren{
-				doc.Individuals()[0]: {
-					doc.Individuals()[3],
-					doc.Individuals()[4],
+				individuals.ByPointer("P1"): {
+					families.ByPointer("F2").Children().ByPointer("P6"),
+				},
+			},
+		},
+		"P3": {
+			node: individuals.ByPointer("P3"),
+			expected: gedcom.SpouseChildren{
+				individuals.ByPointer("P1"): {
+					families.ByPointer("F1").Children().ByPointer("P4"),
+					families.ByPointer("F1").Children().ByPointer("P5"),
 				},
 				nil: {
-					doc.Individuals()[5],
+					families.ByPointer("F2").Children().ByPointer("P6"),
 				},
 			},
 		},
-		{
-			node:     doc.Individuals()[3],
+		"P4": {
+			node:     individuals.ByPointer("P4"),
 			expected: gedcom.SpouseChildren{},
 		},
-		{
-			node:     doc.Individuals()[4],
+		"P5": {
+			node:     individuals.ByPointer("P5"),
 			expected: gedcom.SpouseChildren{},
 		},
-		{
-			node: doc.Individuals()[5],
+		"P6": {
+			node: individuals.ByPointer("P6"),
 			expected: gedcom.SpouseChildren{
 				nil: {
-					doc.Individuals()[6],
+					families.ByPointer("F3").Children().ByPointer("P7"),
 				},
 			},
 		},
-		{
-			node:     doc.Individuals()[6],
+		"P7": {
+			node:     individuals.ByPointer("P7"),
 			expected: gedcom.SpouseChildren{},
 		},
-		{
-			node:     doc.Individuals()[7],
+		"P8": {
+			node:     individuals.ByPointer("P8"),
 			expected: gedcom.SpouseChildren{},
 		},
 	}
 
-	for _, test := range tests {
-		t.Run(gedcom.Pointer(test.node), func(t *testing.T) {
-			for _, n := range doc.Nodes() {
-				n.SetDocument(doc)
-			}
-			assert.Equal(t, test.expected, test.node.SpouseChildren())
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			assertEqual(t, test.expected, test.node.SpouseChildren())
 		})
 	}
 }
@@ -519,52 +508,52 @@ func TestIndividualNode_LDSBaptisms(t *testing.T) {
 	// ghost:ignore
 	var tests = []struct {
 		node     *gedcom.IndividualNode
-		baptisms []gedcom.Node
+		baptisms gedcom.Nodes
 	}{
 		{
 			node:     nil,
 			baptisms: nil,
 		},
 		{
-			node:     individual("P1", "", "", ""),
-			baptisms: []gedcom.Node{},
+			node:     individual(gedcom.NewDocument(), "P1", "", "", ""),
+			baptisms: gedcom.Nodes{},
 		},
 		{
-			node:     gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{}),
-			baptisms: []gedcom.Node{},
+			node:     gedcom.NewDocument().AddIndividual("P1"),
+			baptisms: gedcom.Nodes{},
 		},
 		{
-			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewNodeWithChildren(nil, gedcom.TagLDSBaptism, "", "", []gedcom.Node{}),
-			}),
-			baptisms: []gedcom.Node{
-				gedcom.NewNodeWithChildren(nil, gedcom.TagLDSBaptism, "", "", []gedcom.Node{}),
+			node: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNode(gedcom.TagLDSBaptism, "", ""),
+			),
+			baptisms: gedcom.Nodes{
+				gedcom.NewNode(gedcom.TagLDSBaptism, "", ""),
 			},
 		},
 		{
-			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewNodeWithChildren(nil, gedcom.TagBaptism, "", "", []gedcom.Node{}),
-			}),
-			baptisms: []gedcom.Node{},
+			node: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNode(gedcom.TagBaptism, "", ""),
+			),
+			baptisms: gedcom.Nodes{},
 		},
 		{
-			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewNodeWithChildren(nil, gedcom.TagLDSBaptism, "", "", []gedcom.Node{}),
-				gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
-			}),
-			baptisms: []gedcom.Node{
-				gedcom.NewNodeWithChildren(nil, gedcom.TagLDSBaptism, "", "", []gedcom.Node{}),
+			node: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNode(gedcom.TagLDSBaptism, "", ""),
+				gedcom.NewNode(gedcom.TagDeath, "", ""),
+			),
+			baptisms: gedcom.Nodes{
+				gedcom.NewNode(gedcom.TagLDSBaptism, "", ""),
 			},
 		},
 		{
-			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewNodeWithChildren(nil, gedcom.TagLDSBaptism, "foo", "", []gedcom.Node{}),
-				gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
-				gedcom.NewNodeWithChildren(nil, gedcom.TagLDSBaptism, "bar", "", []gedcom.Node{}),
-			}),
-			baptisms: []gedcom.Node{
-				gedcom.NewNodeWithChildren(nil, gedcom.TagLDSBaptism, "foo", "", []gedcom.Node{}),
-				gedcom.NewNodeWithChildren(nil, gedcom.TagLDSBaptism, "bar", "", []gedcom.Node{}),
+			node: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNode(gedcom.TagLDSBaptism, "foo", ""),
+				gedcom.NewNode(gedcom.TagDeath, "", ""),
+				gedcom.NewNode(gedcom.TagLDSBaptism, "bar", ""),
+			),
+			baptisms: gedcom.Nodes{
+				gedcom.NewNode(gedcom.TagLDSBaptism, "foo", ""),
+				gedcom.NewNode(gedcom.TagLDSBaptism, "bar", ""),
 			},
 		},
 	}
@@ -590,87 +579,87 @@ func TestIndividualNode_EstimatedBirthDate(t *testing.T) {
 
 		// No dates
 		{
-			node:     individual("P1", "", "", ""),
+			node:     individual(gedcom.NewDocument(), "P1", "", "", ""),
 			expected: nil,
 		},
 		{
-			node:     gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{}),
+			node:     gedcom.NewDocument().AddIndividual("P1"),
 			expected: nil,
 		},
 
 		// A single date.
 		{
-			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
-					gedcom.NewDateNode(nil, "1 Aug 1980", "", nil),
-				}),
-			}),
-			expected: gedcom.NewDateNode(nil, "1 Aug 1980", "", nil),
+			node: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewBirthNode("",
+					gedcom.NewDateNode("1 Aug 1980"),
+				),
+			),
+			expected: gedcom.NewDateNode("1 Aug 1980"),
 		},
 		{
-			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewNodeWithChildren(nil, gedcom.TagBaptism, "", "", []gedcom.Node{
-					gedcom.NewDateNode(nil, "Abt. Dec 1980", "", nil),
-				}),
-			}),
-			expected: gedcom.NewDateNode(nil, "Abt. Dec 1980", "", nil),
+			node: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNode(gedcom.TagBaptism, "", "",
+					gedcom.NewDateNode("Abt. Dec 1980"),
+				),
+			),
+			expected: gedcom.NewDateNode("Abt. Dec 1980"),
 		},
 		{
-			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewNodeWithChildren(nil, gedcom.TagLDSBaptism, "", "", []gedcom.Node{
-					gedcom.NewDateNode(nil, "Abt. Nov 1980", "", nil),
-				}),
-			}),
-			expected: gedcom.NewDateNode(nil, "Abt. Nov 1980", "", nil),
+			node: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNode(gedcom.TagLDSBaptism, "", "",
+					gedcom.NewDateNode("Abt. Nov 1980"),
+				),
+			),
+			expected: gedcom.NewDateNode("Abt. Nov 1980"),
 		},
 
 		// Multiple dates and other cases.
 		{
-			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
-					gedcom.NewDateNode(nil, "1 Aug 1980", "", nil),
-				}),
-				gedcom.NewNodeWithChildren(nil, gedcom.TagBaptism, "", "", []gedcom.Node{
-					gedcom.NewDateNode(nil, "Abt. Jan 1980", "", nil),
-				}),
-			}),
-			expected: gedcom.NewDateNode(nil, "Abt. Jan 1980", "", nil),
+			node: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewBirthNode("",
+					gedcom.NewDateNode("1 Aug 1980"),
+				),
+				gedcom.NewNode(gedcom.TagBaptism, "", "",
+					gedcom.NewDateNode("Abt. Jan 1980"),
+				),
+			),
+			expected: gedcom.NewDateNode("Abt. Jan 1980"),
 		},
 		{
-			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
-					gedcom.NewDateNode(nil, "1 Aug 1980", "", nil),
-					gedcom.NewDateNode(nil, "23 Mar 1979", "", nil),
-				}),
-			}),
-			expected: gedcom.NewDateNode(nil, "23 Mar 1979", "", nil),
+			node: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewBirthNode("",
+					gedcom.NewDateNode("1 Aug 1980"),
+					gedcom.NewDateNode("23 Mar 1979"),
+				),
+			),
+			expected: gedcom.NewDateNode("23 Mar 1979"),
 		},
 		{
-			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
-					gedcom.NewDateNode(nil, "1 Aug 1980", "", nil),
-				}),
-				gedcom.NewNodeWithChildren(nil, gedcom.TagLDSBaptism, "", "", []gedcom.Node{
-					gedcom.NewDateNode(nil, "23 Mar 1979", "", nil),
-				}),
-			}),
-			expected: gedcom.NewDateNode(nil, "23 Mar 1979", "", nil),
+			node: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewBirthNode("",
+					gedcom.NewDateNode("1 Aug 1980"),
+				),
+				gedcom.NewNode(gedcom.TagLDSBaptism, "", "",
+					gedcom.NewDateNode("23 Mar 1979"),
+				),
+			),
+			expected: gedcom.NewDateNode("23 Mar 1979"),
 		},
 		{
-			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{}),
-				gedcom.NewNodeWithChildren(nil, gedcom.TagLDSBaptism, "", "", []gedcom.Node{}),
-			}),
+			node: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewBirthNode(""),
+				gedcom.NewNode(gedcom.TagLDSBaptism, "", ""),
+			),
 			expected: nil,
 		},
 		{
-			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{}),
-				gedcom.NewNodeWithChildren(nil, gedcom.TagLDSBaptism, "", "", []gedcom.Node{
-					gedcom.NewDateNode(nil, "1 Aug 1980", "", nil),
-				}),
-			}),
-			expected: gedcom.NewDateNode(nil, "1 Aug 1980", "", nil),
+			node: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewBirthNode(""),
+				gedcom.NewNode(gedcom.TagLDSBaptism, "", "",
+					gedcom.NewDateNode("1 Aug 1980"),
+				),
+			),
+			expected: gedcom.NewDateNode("1 Aug 1980"),
 		},
 	}
 
@@ -701,77 +690,77 @@ func TestIndividualNode_EstimatedDeathDate(t *testing.T) {
 
 		// No dates
 		{
-			node:     individual("P1", "", "", ""),
+			node:     individual(gedcom.NewDocument(), "P1", "", "", ""),
 			expected: nil,
 		},
 		{
-			node:     gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{}),
+			node:     gedcom.NewDocument().AddIndividual("P1"),
 			expected: nil,
 		},
 
 		// A single date.
 		{
-			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "", "", []gedcom.Node{
-					gedcom.NewDateNode(nil, "1 Aug 1980", "", nil),
-				}),
-			}),
-			expected: gedcom.NewDateNode(nil, "1 Aug 1980", "", nil),
+			node: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNode(gedcom.TagDeath, "", "",
+					gedcom.NewDateNode("1 Aug 1980"),
+				),
+			),
+			expected: gedcom.NewDateNode("1 Aug 1980"),
 		},
 		{
-			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewNodeWithChildren(nil, gedcom.TagBurial, "", "", []gedcom.Node{
-					gedcom.NewDateNode(nil, "Abt. Dec 1980", "", nil),
-				}),
-			}),
-			expected: gedcom.NewDateNode(nil, "Abt. Dec 1980", "", nil),
+			node: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNode(gedcom.TagBurial, "", "",
+					gedcom.NewDateNode("Abt. Dec 1980"),
+				),
+			),
+			expected: gedcom.NewDateNode("Abt. Dec 1980"),
 		},
 
 		// Multiple dates and other cases.
 		{
 			// Multiple death dates always returns the earliest.
-			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "", "", []gedcom.Node{
-					gedcom.NewDateNode(nil, "1 Aug 1980", "", nil),
-					gedcom.NewDateNode(nil, "Mar 1980", "", nil),
-					gedcom.NewDateNode(nil, "Jun 1980", "", nil),
-				}),
-			}),
-			expected: gedcom.NewDateNode(nil, "Mar 1980", "", nil),
+			node: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNode(gedcom.TagDeath, "", "",
+					gedcom.NewDateNode("1 Aug 1980"),
+					gedcom.NewDateNode("Mar 1980"),
+					gedcom.NewDateNode("Jun 1980"),
+				),
+			),
+			expected: gedcom.NewDateNode("Mar 1980"),
 		},
 		{
 			// Multiple burial dates always returns the earliest.
-			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewNodeWithChildren(nil, gedcom.TagBurial, "", "", []gedcom.Node{
-					gedcom.NewDateNode(nil, "3 Aug 1980", "", nil),
-					gedcom.NewDateNode(nil, "Apr 1980", "", nil),
-				}),
-			}),
-			expected: gedcom.NewDateNode(nil, "Apr 1980", "", nil),
+			node: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNode(gedcom.TagBurial, "", "",
+					gedcom.NewDateNode("3 Aug 1980"),
+					gedcom.NewDateNode("Apr 1980"),
+				),
+			),
+			expected: gedcom.NewDateNode("Apr 1980"),
 		},
 		{
 			// Death is before burial.
-			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "", "", []gedcom.Node{
-					gedcom.NewDateNode(nil, "1 Aug 1980", "", nil),
-				}),
-				gedcom.NewNodeWithChildren(nil, gedcom.TagBurial, "", "", []gedcom.Node{
-					gedcom.NewDateNode(nil, "3 Aug 1980", "", nil),
-				}),
-			}),
-			expected: gedcom.NewDateNode(nil, "1 Aug 1980", "", nil),
+			node: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNode(gedcom.TagDeath, "", "",
+					gedcom.NewDateNode("1 Aug 1980"),
+				),
+				gedcom.NewNode(gedcom.TagBurial, "", "",
+					gedcom.NewDateNode("3 Aug 1980"),
+				),
+			),
+			expected: gedcom.NewDateNode("1 Aug 1980"),
 		},
 		{
 			// Burial is before death.
-			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "", "", []gedcom.Node{
-					gedcom.NewDateNode(nil, "3 Aug 1980", "", nil),
-				}),
-				gedcom.NewNodeWithChildren(nil, gedcom.TagBurial, "", "", []gedcom.Node{
-					gedcom.NewDateNode(nil, "1 Aug 1980", "", nil),
-				}),
-			}),
-			expected: gedcom.NewDateNode(nil, "3 Aug 1980", "", nil),
+			node: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNode(gedcom.TagDeath, "", "",
+					gedcom.NewDateNode("3 Aug 1980"),
+				),
+				gedcom.NewNode(gedcom.TagBurial, "", "",
+					gedcom.NewDateNode("1 Aug 1980"),
+				),
+			),
+			expected: gedcom.NewDateNode("3 Aug 1980"),
 		},
 	}
 
@@ -788,34 +777,6 @@ func TestIndividualNode_EstimatedDeathDate(t *testing.T) {
 	}
 }
 
-func born(value string) *gedcom.BirthNode {
-	return gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
-		gedcom.NewDateNode(nil, value, "", []gedcom.Node{}),
-	})
-}
-
-func died(value string) gedcom.Node {
-	return gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "", "", []gedcom.Node{
-		gedcom.NewDateNode(nil, value, "", []gedcom.Node{}),
-	})
-}
-
-func name(value string) gedcom.Node {
-	return gedcom.NewNameNode(nil, value, "", nil)
-}
-
-func baptised(value string) gedcom.Node {
-	return gedcom.NewNodeWithChildren(nil, gedcom.TagBaptism, "", "", []gedcom.Node{
-		gedcom.NewDateNode(nil, value, "", []gedcom.Node{}),
-	})
-}
-
-func buried(value string) gedcom.Node {
-	return gedcom.NewNodeWithChildren(nil, gedcom.TagBurial, "", "", []gedcom.Node{
-		gedcom.NewDateNode(nil, value, "", []gedcom.Node{}),
-	})
-}
-
 func TestIndividualNode_Similarity(t *testing.T) {
 	// ghost:ignore
 	var tests = []struct {
@@ -830,200 +791,200 @@ func TestIndividualNode_Similarity(t *testing.T) {
 		},
 		{
 			a:        nil,
-			b:        individual("P1", "", "", ""),
+			b:        individual(gedcom.NewDocument(), "P1", "", "", ""),
 			expected: 0.5,
 		},
 		{
-			a:        individual("P1", "", "", ""),
+			a:        individual(gedcom.NewDocument(), "P1", "", "", ""),
 			b:        nil,
 			expected: 0.5,
 		},
 		{
-			a:        individual("P1", "", "", ""),
-			b:        individual("P1", "", "", ""),
+			a:        individual(gedcom.NewDocument(), "P1", "", "", ""),
+			b:        individual(gedcom.NewDocument(), "P1", "", "", ""),
 			expected: 0.25,
 		},
 		{
-			a:        gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{}),
-			b:        gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{}),
+			a:        gedcom.NewDocument().AddIndividual("P1"),
+			b:        gedcom.NewDocument().AddIndividual("P1"),
 			expected: 0.25,
 		},
 
 		// Perfect cases.
 		{
 			// All details match exactly.
-			a: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				name("Elliot Rupert de Peyster /Chance/"),
-				born("4 Jan 1843"),
-				died("17 Mar 1907"),
-			}),
-			b: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				name("Elliot Rupert de Peyster /Chance/"),
-				born("4 Jan 1843"),
-				died("17 Mar 1907"),
-			}),
+			a: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNameNode("Elliot Rupert de Peyster /Chance/"),
+				gedcom.NewBirthNode("", gedcom.NewDateNode("4 Jan 1843")),
+				gedcom.NewDeathNode("", gedcom.NewDateNode("17 Mar 1907")),
+			),
+			b: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNameNode("Elliot Rupert de Peyster /Chance/"),
+				gedcom.NewBirthNode("", gedcom.NewDateNode("4 Jan 1843")),
+				gedcom.NewDeathNode("", gedcom.NewDateNode("17 Mar 1907")),
+			),
 			expected: 1.0,
 		},
 		{
 			// Extra names, but one name is still a perfect match.
-			a: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				name("Elliot Rupert de Peyster /Chance/"),
-				name("Elliot Rupert /Chance/"),
-				born("4 Jan 1843"),
-				died("17 Mar 1907"),
-			}),
-			b: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				name("Elliot R d P /Chance/"),
-				name("Elliot Rupert de Peyster /Chance/"),
-				born("4 Jan 1843"),
-				died("17 Mar 1907"),
-			}),
+			a: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNameNode("Elliot Rupert de Peyster /Chance/"),
+				gedcom.NewNameNode("Elliot Rupert /Chance/"),
+				gedcom.NewBirthNode("", gedcom.NewDateNode("4 Jan 1843")),
+				gedcom.NewDeathNode("", gedcom.NewDateNode("17 Mar 1907")),
+			),
+			b: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNameNode("Elliot R d P /Chance/"),
+				gedcom.NewNameNode("Elliot Rupert de Peyster /Chance/"),
+				gedcom.NewBirthNode("", gedcom.NewDateNode("4 Jan 1843")),
+				gedcom.NewDeathNode("", gedcom.NewDateNode("17 Mar 1907")),
+			),
 			expected: 1.0,
 		},
 		{
 			// Name are not senstive to case or whitespace.
-			a: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				name("Elliot /Chance/"),
-				born("4 Jan 1843"),
-				died("17 Mar 1907"),
-			}),
-			b: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				name("elliot /CHANCE/"),
-				born("4 Jan 1843"),
-				died("17 Mar 1907"),
-			}),
+			a: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNameNode("Elliot /Chance/"),
+				gedcom.NewBirthNode("", gedcom.NewDateNode("4 Jan 1843")),
+				gedcom.NewDeathNode("", gedcom.NewDateNode("17 Mar 1907")),
+			),
+			b: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNameNode("elliot /CHANCE/"),
+				gedcom.NewBirthNode("", gedcom.NewDateNode("4 Jan 1843")),
+				gedcom.NewDeathNode("", gedcom.NewDateNode("17 Mar 1907")),
+			),
 			expected: 1.0,
 		},
 
 		// Almost perfect matches.
 		{
 			// Name is more/less complete.
-			a: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				name("Elliot Rupert de Peyster /Chance/"),
-				born("4 Jan 1843"),
-				died("17 Mar 1907"),
-			}),
-			b: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				name("Elliot Rupert /Chance/"),
-				born("4 Jan 1843"),
-				died("17 Mar 1907"),
-			}),
+			a: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNameNode("Elliot Rupert de Peyster /Chance/"),
+				gedcom.NewBirthNode("", gedcom.NewDateNode("4 Jan 1843")),
+				gedcom.NewDeathNode("", gedcom.NewDateNode("17 Mar 1907")),
+			),
+			b: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNameNode("Elliot Rupert /Chance/"),
+				gedcom.NewBirthNode("", gedcom.NewDateNode("4 Jan 1843")),
+				gedcom.NewDeathNode("", gedcom.NewDateNode("17 Mar 1907")),
+			),
 			expected: 0.9831720430107527,
 		},
 		{
 			// Last name is similar.
-			a: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				name("Elliot Rupert de Peyster /Chance/"),
-				born("4 Jan 1843"),
-				died("17 Mar 1907"),
-			}),
-			b: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				name("Elliot Rupert de Peyster /Chaunce/"),
-				born("4 Jan 1843"),
-				died("17 Mar 1907"),
-			}),
+			a: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNameNode("Elliot Rupert de Peyster /Chance/"),
+				gedcom.NewBirthNode("", gedcom.NewDateNode("4 Jan 1843")),
+				gedcom.NewDeathNode("", gedcom.NewDateNode("17 Mar 1907")),
+			),
+			b: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNameNode("Elliot Rupert de Peyster /Chaunce/"),
+				gedcom.NewBirthNode("", gedcom.NewDateNode("4 Jan 1843")),
+				gedcom.NewDeathNode("", gedcom.NewDateNode("17 Mar 1907")),
+			),
 			expected: 0.997883064516129,
 		},
 		{
 			// Birth date is less specific.
-			a: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				name("Elliot Rupert de Peyster /Chance/"),
-				born("4 Jan 1843"),
-				died("17 Mar 1907"),
-			}),
-			b: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				name("Elliot Rupert de Peyster /Chance/"),
-				born("Jan 1843"),
-				died("17 Mar 1907"),
-			}),
+			a: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNameNode("Elliot Rupert de Peyster /Chance/"),
+				gedcom.NewBirthNode("", gedcom.NewDateNode("4 Jan 1843")),
+				gedcom.NewDeathNode("", gedcom.NewDateNode("17 Mar 1907")),
+			),
+			b: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNameNode("Elliot Rupert de Peyster /Chance/"),
+				gedcom.NewBirthNode("", gedcom.NewDateNode("Jan 1843")),
+				gedcom.NewDeathNode("", gedcom.NewDateNode("17 Mar 1907")),
+			),
 			expected: 0.9999701394487746,
 		},
 		{
 			// Death date is less specific.
-			a: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				name("Elliot Rupert de Peyster /Chance/"),
-				born("4 Jan 1843"),
-				died("17 Mar 1907"),
-			}),
-			b: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				name("Elliot Rupert de Peyster /Chance/"),
-				born("4 Jan 1843"),
-				died("Mar 1907"),
-			}),
+			a: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNameNode("Elliot Rupert de Peyster /Chance/"),
+				gedcom.NewBirthNode("", gedcom.NewDateNode("4 Jan 1843")),
+				gedcom.NewDeathNode("", gedcom.NewDateNode("17 Mar 1907")),
+			),
+			b: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNameNode("Elliot Rupert de Peyster /Chance/"),
+				gedcom.NewBirthNode("", gedcom.NewDateNode("4 Jan 1843")),
+				gedcom.NewDeathNode("", gedcom.NewDateNode("Mar 1907")),
+			),
 			expected: 0.999999792635061,
 		},
 
 		// Estimated birth/death.
 		{
-			a: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				name("Elliot Rupert de Peyster /Chance/"),
-				baptised("Abt. 1843"),
-				died("17 Mar 1907"),
-			}),
-			b: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				name("Elliot Rupert de Peyster /Chance/"),
-				born("4 Jan 1843"),
-				died("Mar 1907"),
-			}),
+			a: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNameNode("Elliot Rupert de Peyster /Chance/"),
+				gedcom.NewBaptismNode("", gedcom.NewDateNode("Abt. 1843")),
+				gedcom.NewDeathNode("", gedcom.NewDateNode("17 Mar 1907")),
+			),
+			b: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNameNode("Elliot Rupert de Peyster /Chance/"),
+				gedcom.NewBirthNode("", gedcom.NewDateNode("4 Jan 1843")),
+				gedcom.NewDeathNode("", gedcom.NewDateNode("Mar 1907")),
+			),
 			expected: 0.9933556126223895,
 		},
 		{
-			a: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				name("Elliot Rupert de Peyster /Chance/"),
-				baptised("Abt. 1843"),
-				died("17 Mar 1907"),
-			}),
-			b: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				name("Elliot Rupert de Peyster /Chance/"),
-				born("4 Jan 1843"),
-				buried("Aft. 20 Mar 1907"),
-			}),
+			a: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNameNode("Elliot Rupert de Peyster /Chance/"),
+				gedcom.NewBaptismNode("", gedcom.NewDateNode("Abt. 1843")),
+				gedcom.NewDeathNode("", gedcom.NewDateNode("17 Mar 1907")),
+			),
+			b: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNameNode("Elliot Rupert de Peyster /Chance/"),
+				gedcom.NewBirthNode("", gedcom.NewDateNode("4 Jan 1843")),
+				gedcom.NewBurialNode("", gedcom.NewDateNode("Aft. 20 Mar 1907")),
+			),
 			expected: 0.9933539537028769,
 		},
 
 		// Missing dates.
 		{
-			a: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				name("Elliot Rupert de Peyster /Chance/"),
-				died("Abt. 1907"),
-			}),
-			b: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				name("Elliot Rupert /Chance/"),
-				died("1909"),
-			}),
+			a: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNameNode("Elliot Rupert de Peyster /Chance/"),
+				gedcom.NewDeathNode("", gedcom.NewDateNode("Abt. 1907")),
+			),
+			b: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNameNode("Elliot Rupert /Chance/"),
+				gedcom.NewDeathNode("", gedcom.NewDateNode("1909")),
+			),
 			expected: 0.7470609318996415,
 		},
 		{
-			a: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				name("Elliot Rupert de Peyster /Chance/"),
-				baptised("after Sep 1823"),
-			}),
-			b: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				name("Elliot Rupert /Chance/"),
-				born("Between 1822 and 1823"),
-			}),
+			a: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNameNode("Elliot Rupert de Peyster /Chance/"),
+				gedcom.NewBaptismNode("", gedcom.NewDateNode("after Sep 1823")),
+			),
+			b: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNameNode("Elliot Rupert /Chance/"),
+				gedcom.NewBirthNode("", gedcom.NewDateNode("Between 1822 and 1823")),
+			),
 			expected: 0.8443154512111212,
 		},
 		{
-			a: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				name("Elliot Rupert de Peyster /Chance/"),
-			}),
-			b: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				name("Elliot Rupert /Chance/"),
-			}),
+			a: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNameNode("Elliot Rupert de Peyster /Chance/"),
+			),
+			b: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNameNode("Elliot Rupert /Chance/"),
+			),
 			expected: 0.7331720430107527,
 		},
 
 		// These ones are way off.
 		{
-			a: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				name("Jane /Doe/"),
-				born("Sep 1845"),
-			}),
-			b: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				name("Bob /Jones/"),
-				born("1627"),
-			}),
+			a: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNameNode("Jane /Doe/"),
+				gedcom.NewBirthNode("", gedcom.NewDateNode("Sep 1845")),
+			),
+			b: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNameNode("Bob /Jones/"),
+				gedcom.NewBirthNode("", gedcom.NewDateNode("1627")),
+			),
 			expected: 0.38125,
 		},
 	}
@@ -1041,14 +1002,14 @@ func TestIndividualNode_Similarity(t *testing.T) {
 func TestIndividualNode_SurroundingSimilarity(t *testing.T) {
 	// ghost:ignore
 	var tests = map[string]struct {
-		doc      *gedcom.Document
+		doc      func(*gedcom.Document)
 		expected *gedcom.SurroundingSimilarity
 	}{
 		"EmptyIndividuals": {
-			doc: gedcom.NewDocumentWithNodes([]gedcom.Node{
-				individual("P1", "", "", ""),
-				individual("P2", "", "", ""),
-			}),
+			doc: func(doc *gedcom.Document) {
+				doc.AddIndividual("P1")
+				doc.AddIndividual("P2")
+			},
 
 			// These are the real values, but they are not calculated because
 			// the weighted similarity would be less than the minimum threshold.
@@ -1072,10 +1033,10 @@ func TestIndividualNode_SurroundingSimilarity(t *testing.T) {
 
 		// Only matching individuals, but they are exact matches.
 		"Matching1": {
-			doc: gedcom.NewDocumentWithNodes([]gedcom.Node{
-				individual("P1", "Elliot /Chance/", "4 Jan 1843", "17 Mar 1907"),
-				individual("P2", "Elliot /Chance/", "4 Jan 1843", "17 Mar 1907"),
-			}),
+			doc: func(doc *gedcom.Document) {
+				individual(doc, "P1", "Elliot /Chance/", "4 Jan 1843", "17 Mar 1907")
+				individual(doc, "P2", "Elliot /Chance/", "4 Jan 1843", "17 Mar 1907")
+			},
 			expected: &gedcom.SurroundingSimilarity{
 				ParentsSimilarity:    0.5,
 				IndividualSimilarity: 1.0,
@@ -1087,10 +1048,10 @@ func TestIndividualNode_SurroundingSimilarity(t *testing.T) {
 
 		// Only matching individuals, but they are similar matches.
 		"Matching2": {
-			doc: gedcom.NewDocumentWithNodes([]gedcom.Node{
-				individual("P1", "Elliot /Chance/", "4 Jan 1843", "17 Mar 1907"),
-				individual("P2", "Elliot /Chance/", "Abt. 1843", "Abt. 1910"),
-			}),
+			doc: func(doc *gedcom.Document) {
+				individual(doc, "P1", "Elliot /Chance/", "4 Jan 1843", "17 Mar 1907")
+				individual(doc, "P2", "Elliot /Chance/", "Abt. 1843", "Abt. 1910")
+			},
 			expected: &gedcom.SurroundingSimilarity{
 				ParentsSimilarity:    0.5,
 				IndividualSimilarity: 0.7433558199873285,
@@ -1102,10 +1063,10 @@ func TestIndividualNode_SurroundingSimilarity(t *testing.T) {
 
 		// Only matching individuals and they are way off.
 		"Matching3": {
-			doc: gedcom.NewDocumentWithNodes([]gedcom.Node{
-				individual("P1", "Elliot /Chance/", "4 Jan 1843", "17 Mar 1907"),
-				individual("P2", "Joe /Bloggs/", "1945", "2000"),
-			}),
+			doc: func(doc *gedcom.Document) {
+				individual(doc, "P1", "Elliot /Chance/", "4 Jan 1843", "17 Mar 1907")
+				individual(doc, "P2", "Joe /Bloggs/", "1945", "2000")
+			},
 
 			// These are the real values, but they are not calculated because
 			// the weighted similarity would be less than the minimum threshold.
@@ -1129,16 +1090,16 @@ func TestIndividualNode_SurroundingSimilarity(t *testing.T) {
 
 		// Parents and individuals match exactly.
 		"Parents1": {
-			doc: gedcom.NewDocumentWithNodes([]gedcom.Node{
-				individual("P1", "Elliot /Chance/", "4 Jan 1843", "17 Mar 1907"),
-				individual("P2", "Elliot /Chance/", "4 Jan 1843", "17 Mar 1907"),
-				individual("P3", "John /Smith/", "4 Jan 1803", "17 Mar 1877"),
-				individual("P4", "Jane /Doe/", "3 Mar 1803", "14 June 1877"),
-				individual("P5", "John /Smith/", "4 Jan 1803", "17 Mar 1877"),
-				individual("P6", "Jane /Doe/", "3 Mar 1803", "14 June 1877"),
-				family("F1", "P3", "P4", "P1"),
-				family("F2", "P5", "P6", "P2"),
-			}),
+			doc: func(doc *gedcom.Document) {
+				individual(doc, "P1", "Elliot /Chance/", "4 Jan 1843", "17 Mar 1907")
+				individual(doc, "P2", "Elliot /Chance/", "4 Jan 1843", "17 Mar 1907")
+				individual(doc, "P3", "John /Smith/", "4 Jan 1803", "17 Mar 1877")
+				individual(doc, "P4", "Jane /Doe/", "3 Mar 1803", "14 June 1877")
+				individual(doc, "P5", "John /Smith/", "4 Jan 1803", "17 Mar 1877")
+				individual(doc, "P6", "Jane /Doe/", "3 Mar 1803", "14 June 1877")
+				family(doc, "F1", "P3", "P4", "P1")
+				family(doc, "F2", "P5", "P6", "P2")
+			},
 			expected: &gedcom.SurroundingSimilarity{
 				ParentsSimilarity:    1.0,
 				IndividualSimilarity: 1.0,
@@ -1150,16 +1111,16 @@ func TestIndividualNode_SurroundingSimilarity(t *testing.T) {
 
 		// Parents and individuals are very similar.
 		"Parents2": {
-			doc: gedcom.NewDocumentWithNodes([]gedcom.Node{
-				individual("P1", "Elliot /Chance/", "4 Jan 1843", "17 Mar 1907"),
-				individual("P2", "Elliot /Chaunce/", "4 Jan 1843", "17 Mar 1907"),
-				individual("P3", "John /Smith/", "4 Jan 1803", "17 Mar 1877"),
-				individual("P4", "Jane /Doey/", "3 Mar 1803", "14 June 1877"),
-				individual("P5", "John /Smith/", "4 Jan 1803", "17 Mar 1877"),
-				individual("P6", "Jane /Doe/", "3 Mar 1803", "14 June 1877"),
-				family("F1", "P3", "P4", "P1"),
-				family("F2", "P5", "P6", "P2"),
-			}),
+			doc: func(doc *gedcom.Document) {
+				individual(doc, "P1", "Elliot /Chance/", "4 Jan 1843", "17 Mar 1907")
+				individual(doc, "P2", "Elliot /Chaunce/", "4 Jan 1843", "17 Mar 1907")
+				individual(doc, "P3", "John /Smith/", "4 Jan 1803", "17 Mar 1877")
+				individual(doc, "P4", "Jane /Doey/", "3 Mar 1803", "14 June 1877")
+				individual(doc, "P5", "John /Smith/", "4 Jan 1803", "17 Mar 1877")
+				individual(doc, "P6", "Jane /Doe/", "3 Mar 1803", "14 June 1877")
+				family(doc, "F1", "P3", "P4", "P1")
+				family(doc, "F2", "P5", "P6", "P2")
+			},
 			expected: &gedcom.SurroundingSimilarity{
 				ParentsSimilarity:    0.9981481481481481,
 				IndividualSimilarity: 0.9950549450549451,
@@ -1171,16 +1132,16 @@ func TestIndividualNode_SurroundingSimilarity(t *testing.T) {
 
 		// One parent is missing, otherwise exactly the same.
 		"Parents3": {
-			doc: gedcom.NewDocumentWithNodes([]gedcom.Node{
-				individual("P1", "Elliot /Chance/", "4 Jan 1843", "17 Mar 1907"),
-				individual("P2", "Elliot /Chaunce/", "4 Jan 1843", "17 Mar 1907"),
-				individual("P3", "John /Smith/", "4 Jan 1803", "17 Mar 1877"),
-				individual("P4", "Jane /Doey/", "3 Mar 1803", "14 June 1877"),
-				individual("P5", "John /Smith/", "4 Jan 1803", "17 Mar 1877"),
-				individual("P6", "Jane /Doe/", "3 Mar 1803", "14 June 1877"),
-				family("F1", "P3", "", "P1"),
-				family("F2", "P5", "P6", "P2"),
-			}),
+			doc: func(doc *gedcom.Document) {
+				individual(doc, "P1", "Elliot /Chance/", "4 Jan 1843", "17 Mar 1907")
+				individual(doc, "P2", "Elliot /Chaunce/", "4 Jan 1843", "17 Mar 1907")
+				individual(doc, "P3", "John /Smith/", "4 Jan 1803", "17 Mar 1877")
+				individual(doc, "P4", "Jane /Doey/", "3 Mar 1803", "14 June 1877")
+				individual(doc, "P5", "John /Smith/", "4 Jan 1803", "17 Mar 1877")
+				individual(doc, "P6", "Jane /Doe/", "3 Mar 1803", "14 June 1877")
+				family(doc, "F1", "P3", "", "P1")
+				family(doc, "F2", "P5", "P6", "P2")
+			},
 			expected: &gedcom.SurroundingSimilarity{
 				ParentsSimilarity:    0.75,
 				IndividualSimilarity: 0.9950549450549451,
@@ -1192,16 +1153,16 @@ func TestIndividualNode_SurroundingSimilarity(t *testing.T) {
 
 		// Both parents are missing on one side, otherwise exactly the same.
 		"Parents4": {
-			doc: gedcom.NewDocumentWithNodes([]gedcom.Node{
-				individual("P1", "Elliot /Chance/", "4 Jan 1843", "17 Mar 1907"),
-				individual("P2", "Elliot /Chaunce/", "4 Jan 1843", "17 Mar 1907"),
-				individual("P3", "John /Smith/", "4 Jan 1803", "17 Mar 1877"),
-				individual("P4", "Jane /Doey/", "3 Mar 1803", "14 June 1877"),
-				individual("P5", "John /Smith/", "4 Jan 1803", "17 Mar 1877"),
-				individual("P6", "Jane /Doe/", "3 Mar 1803", "14 June 1877"),
-				family("F1", "", "", "P1"),
-				family("F2", "P5", "P6", "P2"),
-			}),
+			doc: func(doc *gedcom.Document) {
+				individual(doc, "P1", "Elliot /Chance/", "4 Jan 1843", "17 Mar 1907")
+				individual(doc, "P2", "Elliot /Chaunce/", "4 Jan 1843", "17 Mar 1907")
+				individual(doc, "P3", "John /Smith/", "4 Jan 1803", "17 Mar 1877")
+				individual(doc, "P4", "Jane /Doey/", "3 Mar 1803", "14 June 1877")
+				individual(doc, "P5", "John /Smith/", "4 Jan 1803", "17 Mar 1877")
+				individual(doc, "P6", "Jane /Doe/", "3 Mar 1803", "14 June 1877")
+				family(doc, "F1", "", "", "P1")
+				family(doc, "F2", "P5", "P6", "P2")
+			},
 			expected: &gedcom.SurroundingSimilarity{
 				ParentsSimilarity:    0.5,
 				IndividualSimilarity: 0.9950549450549451,
@@ -1213,20 +1174,20 @@ func TestIndividualNode_SurroundingSimilarity(t *testing.T) {
 
 		// Parents, individual and spouses match exactly.
 		"Parents5": {
-			doc: gedcom.NewDocumentWithNodes([]gedcom.Node{
-				individual("P1", "Elliot /Chance/", "4 Jan 1843", "17 Mar 1907"),
-				individual("P2", "Elliot /Chance/", "4 Jan 1843", "17 Mar 1907"),
-				individual("P3", "John /Smith/", "4 Jan 1803", "17 Mar 1877"),
-				individual("P4", "Jane /Doe/", "3 Mar 1803", "14 June 1877"),
-				individual("P5", "John /Smith/", "4 Jan 1803", "17 Mar 1877"),
-				individual("P6", "Jane /Doe/", "3 Mar 1803", "14 June 1877"),
-				individual("P7", "Jane /Bloggs/", "8 Mar 1803", "14 June 1877"),
-				individual("P8", "Jane /Bloggs/", "8 Mar 1803", "14 June 1877"),
-				family("F1", "P3", "P4", "P1"),
-				family("F2", "P5", "P6", "P2"),
-				family("F3", "P1", "P7"),
-				family("F4", "P2", "P8"),
-			}),
+			doc: func(doc *gedcom.Document) {
+				individual(doc, "P1", "Elliot /Chance/", "4 Jan 1843", "17 Mar 1907")
+				individual(doc, "P2", "Elliot /Chance/", "4 Jan 1843", "17 Mar 1907")
+				individual(doc, "P3", "John /Smith/", "4 Jan 1803", "17 Mar 1877")
+				individual(doc, "P4", "Jane /Doe/", "3 Mar 1803", "14 June 1877")
+				individual(doc, "P5", "John /Smith/", "4 Jan 1803", "17 Mar 1877")
+				individual(doc, "P6", "Jane /Doe/", "3 Mar 1803", "14 June 1877")
+				individual(doc, "P7", "Jane /Bloggs/", "8 Mar 1803", "14 June 1877")
+				individual(doc, "P8", "Jane /Bloggs/", "8 Mar 1803", "14 June 1877")
+				family(doc, "F1", "P3", "P4", "P1")
+				family(doc, "F2", "P5", "P6", "P2")
+				family(doc, "F3", "P1", "P7")
+				family(doc, "F4", "P2", "P8")
+			},
 			expected: &gedcom.SurroundingSimilarity{
 				ParentsSimilarity:    1.0,
 				IndividualSimilarity: 1.0,
@@ -1240,12 +1201,10 @@ func TestIndividualNode_SurroundingSimilarity(t *testing.T) {
 	options := gedcom.NewSimilarityOptions()
 	for testName, test := range tests {
 		t.Run(testName, func(t *testing.T) {
-			for _, n := range test.doc.Nodes() {
-				n.SetDocument(test.doc)
-			}
-
-			a := test.doc.Individuals()[0]
-			b := test.doc.Individuals()[1]
+			doc := gedcom.NewDocument()
+			test.doc(doc)
+			a := doc.Individuals()[0]
+			b := doc.Individuals()[1]
 			s := a.SurroundingSimilarity(b, options, false)
 
 			assert.Equal(t, test.expected, s)
@@ -1253,43 +1212,40 @@ func TestIndividualNode_SurroundingSimilarity(t *testing.T) {
 	}
 }
 
-func individual(pointer, fullName, birth, death string) *gedcom.IndividualNode {
-	nodes := []gedcom.Node{}
+func individual(doc *gedcom.Document, pointer, fullName, birth, death string) *gedcom.IndividualNode {
+	nodes := gedcom.Nodes{}
 
 	if fullName != "" {
-		nodes = append(nodes, name(fullName))
+		nodes = append(nodes, gedcom.NewNameNode(fullName))
 	}
 
 	if birth != "" {
-		nodes = append(nodes, born(birth))
+		nodes = append(nodes, gedcom.NewBirthNode("", gedcom.NewDateNode(birth)))
 	}
 
 	if death != "" {
-		nodes = append(nodes, died(death))
+		nodes = append(nodes, gedcom.NewDeathNode("", gedcom.NewDateNode(death)))
 	}
 
-	return gedcom.NewIndividualNode(nil, "", pointer, nodes)
+	return doc.AddIndividual(pointer, nodes...)
 }
 
-func family(pointer, husband, wife string, children ...string) *gedcom.FamilyNode {
-	nodes := []gedcom.Node{}
+func family(doc *gedcom.Document, pointer, husband, wife string, children ...string) *gedcom.FamilyNode {
+	f := doc.AddFamily(pointer)
 
 	if husband != "" {
-		nodes = append(nodes, gedcom.NewNodeWithChildren(nil,
-			gedcom.TagHusband, "@"+husband+"@", "", nil))
+		f.SetHusband(doc.Individuals().ByPointer(husband))
 	}
 
 	if wife != "" {
-		nodes = append(nodes, gedcom.NewNodeWithChildren(nil,
-			gedcom.TagWife, "@"+wife+"@", "", nil))
+		f.SetWife(doc.Individuals().ByPointer(wife))
 	}
 
 	for _, child := range children {
-		nodes = append(nodes, gedcom.NewNodeWithChildren(nil,
-			gedcom.TagChild, "@"+child+"@", "", nil))
+		f.AddChild(doc.Individuals().ByPointer(child))
 	}
 
-	return gedcom.NewFamilyNode(nil, pointer, nodes)
+	return f
 }
 
 func TestIndividualNode_Name(t *testing.T) {
@@ -1307,7 +1263,7 @@ func TestIndividualNode_Spouses(t *testing.T) {
 func TestIndividualNode_Families(t *testing.T) {
 	Families := tf.Function(t, (*gedcom.IndividualNode).Families)
 
-	Families((*gedcom.IndividualNode)(nil)).Returns(([]*gedcom.FamilyNode)(nil))
+	Families((*gedcom.IndividualNode)(nil)).Returns((gedcom.FamilyNodes)(nil))
 }
 
 func TestIndividualNode_FamilyWithSpouse(t *testing.T) {
@@ -1327,103 +1283,103 @@ func TestIndividualNode_IsLiving(t *testing.T) {
 
 	IsLiving(nil).Returns(false)
 
-	IsLiving(gedcom.NewIndividualNode(nil, "", "", nil)).Returns(true)
+	IsLiving(gedcom.NewDocument().AddIndividual("")).Returns(true)
 
-	IsLiving(gedcom.NewIndividualNode(nil, "", "", []gedcom.Node{
-		gedcom.NewDeathNode(nil, "", "", nil),
-	})).Returns(false)
+	IsLiving(gedcom.NewDocument().AddIndividual("",
+		gedcom.NewDeathNode(""),
+	)).Returns(false)
 
-	IsLiving(gedcom.NewIndividualNode(nil, "", "", []gedcom.Node{
-		gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
-			gedcom.NewDateNode(nil, "3 Sep 1845", "", nil),
-		}),
-	})).Returns(false)
+	IsLiving(gedcom.NewDocument().AddIndividual("",
+		gedcom.NewBirthNode("",
+			gedcom.NewDateNode("3 Sep 1845"),
+		),
+	)).Returns(false)
 
-	IsLiving(gedcom.NewIndividualNode(nil, "", "", []gedcom.Node{
-		gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
-			gedcom.NewDateNode(nil, "3 Sep 1945", "", nil),
-		}),
-	})).Returns(true)
+	IsLiving(gedcom.NewDocument().AddIndividual("",
+		gedcom.NewBirthNode("",
+			gedcom.NewDateNode("3 Sep 1945"),
+		),
+	)).Returns(true)
 
 	doc := gedcom.NewDocument()
-	IsLiving(gedcom.NewIndividualNode(doc, "", "", []gedcom.Node{
-		gedcom.NewBirthNode(doc, "", "", []gedcom.Node{
-			gedcom.NewDateNode(doc, "3 Sep 1945", "", nil),
-		}),
-	})).Returns(true)
+	IsLiving(doc.AddIndividual("",
+		gedcom.NewBirthNode("",
+			gedcom.NewDateNode("3 Sep 1945"),
+		),
+	)).Returns(true)
 
 	doc.MaxLivingAge = 25
-	IsLiving(gedcom.NewIndividualNode(doc, "", "", []gedcom.Node{
-		gedcom.NewBirthNode(doc, "", "", []gedcom.Node{
-			gedcom.NewDateNode(doc, "3 Sep 1945", "", nil),
-		}),
-	})).Returns(false)
+	IsLiving(doc.AddIndividual("",
+		gedcom.NewBirthNode("",
+			gedcom.NewDateNode("3 Sep 1945"),
+		),
+	)).Returns(false)
 
 	doc.MaxLivingAge = 0
-	IsLiving(gedcom.NewIndividualNode(doc, "", "", []gedcom.Node{
-		gedcom.NewBirthNode(doc, "", "", []gedcom.Node{
-			gedcom.NewDateNode(doc, "3 Sep 1945", "", nil),
-		}),
-	})).Returns(true)
+	IsLiving(doc.AddIndividual("",
+		gedcom.NewBirthNode("",
+			gedcom.NewDateNode("3 Sep 1945"),
+		),
+	)).Returns(true)
 }
 
 func TestIndividualNode_Children(t *testing.T) {
 	Children := tf.Function(t, (*gedcom.IndividualNode).Children)
 
-	Children((*gedcom.IndividualNode)(nil)).Returns(gedcom.IndividualNodes{})
+	Children((*gedcom.IndividualNode)(nil)).Returns(gedcom.ChildNodes{})
 }
 
 func TestIndividualNode_AllEvents(t *testing.T) {
 	// ghost:ignore
 	var tests = []struct {
 		node   *gedcom.IndividualNode
-		events []gedcom.Node
+		events gedcom.Nodes
 	}{
 		{
-			node:   individual("P1", "", "", ""),
+			node:   individual(gedcom.NewDocument(), "P1", "", "", ""),
 			events: nil,
 		},
 		{
-			node:   gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{}),
+			node:   gedcom.NewDocument().AddIndividual("P1"),
 			events: nil,
 		},
 		{
-			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{}),
-			}),
-			events: []gedcom.Node{
-				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{}),
+			node: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewBirthNode(""),
+			),
+			events: gedcom.Nodes{
+				gedcom.NewBirthNode(""),
 			},
 		},
 		{
-			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{}),
-				gedcom.NewNodeWithChildren(nil, gedcom.TagNote, "", "", []gedcom.Node{}),
-			}),
-			events: []gedcom.Node{
-				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{}),
+			node: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewBirthNode(""),
+				gedcom.NewNode(gedcom.TagNote, "", ""),
+			),
+			events: gedcom.Nodes{
+				gedcom.NewBirthNode(""),
 			},
 		},
 		{
-			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{}),
-				gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
-			}),
-			events: []gedcom.Node{
-				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{}),
-				gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
+			node: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewBirthNode(""),
+				gedcom.NewNode(gedcom.TagDeath, "", ""),
+			),
+			events: gedcom.Nodes{
+				gedcom.NewBirthNode(""),
+				gedcom.NewNode(gedcom.TagDeath, "", ""),
 			},
 		},
 		{
-			node: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewBirthNode(nil, "foo", "", []gedcom.Node{}),
-				gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
-				gedcom.NewBirthNode(nil, "bar", "", []gedcom.Node{}),
-			}),
-			events: []gedcom.Node{
-				gedcom.NewBirthNode(nil, "foo", "", []gedcom.Node{}),
-				gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
-				gedcom.NewBirthNode(nil, "bar", "", []gedcom.Node{}),
+			node: gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewBirthNode("foo"),
+				gedcom.NewNode(gedcom.TagDeath, "", ""),
+				gedcom.NewBirthNode("bar"),
+			),
+			events: gedcom.Nodes{
+				gedcom.NewBirthNode("foo"),
+				gedcom.NewNode(gedcom.TagDeath, "", ""),
+				gedcom.NewBirthNode("bar"),
 			},
 		},
 	}
@@ -1436,20 +1392,20 @@ func TestIndividualNode_AllEvents(t *testing.T) {
 }
 
 func TestIndividualNode_Birth(t *testing.T) {
-	date3Sep1953 := gedcom.NewDateNode(nil, "3 Sep 1953", "", nil)
-	place1 := gedcom.NewPlaceNode(nil, "Australia", "", nil)
+	date3Sep1953 := gedcom.NewDateNode("3 Sep 1953")
+	place1 := gedcom.NewPlaceNode("Australia")
 
-	individual := gedcom.NewIndividualNode(nil, "", "", []gedcom.Node{
-		gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
+	individual := gedcom.NewDocument().AddIndividual("",
+		gedcom.NewBirthNode("",
 			date3Sep1953,
-		}),
-		gedcom.NewDeathNode(nil, "", "", []gedcom.Node{
-			gedcom.NewPlaceNode(nil, "United Kingdom", "", nil),
-		}),
-		gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
+		),
+		gedcom.NewDeathNode("",
+			gedcom.NewPlaceNode("United Kingdom"),
+		),
+		gedcom.NewBirthNode("",
 			place1,
-		}),
-	})
+		),
+	)
 
 	date, place := individual.Birth()
 
@@ -1458,20 +1414,20 @@ func TestIndividualNode_Birth(t *testing.T) {
 }
 
 func TestIndividualNode_Death(t *testing.T) {
-	date3Sep1953 := gedcom.NewDateNode(nil, "3 Sep 1953", "", nil)
-	place1 := gedcom.NewPlaceNode(nil, "Australia", "", nil)
+	date3Sep1953 := gedcom.NewDateNode("3 Sep 1953")
+	place1 := gedcom.NewPlaceNode("Australia")
 
-	individual := gedcom.NewIndividualNode(nil, "", "", []gedcom.Node{
-		gedcom.NewDeathNode(nil, "", "", []gedcom.Node{
+	individual := gedcom.NewDocument().AddIndividual("",
+		gedcom.NewDeathNode("",
 			date3Sep1953,
-		}),
-		gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
-			gedcom.NewPlaceNode(nil, "United Kingdom", "", nil),
-		}),
-		gedcom.NewDeathNode(nil, "", "", []gedcom.Node{
+		),
+		gedcom.NewBirthNode("",
+			gedcom.NewPlaceNode("United Kingdom"),
+		),
+		gedcom.NewDeathNode("",
 			place1,
-		}),
-	})
+		),
+	)
 
 	date, place := individual.Death()
 
@@ -1480,20 +1436,16 @@ func TestIndividualNode_Death(t *testing.T) {
 }
 
 func TestIndividualNode_Baptism(t *testing.T) {
-	date3Sep1953 := gedcom.NewDateNode(nil, "3 Sep 1953", "", nil)
-	place1 := gedcom.NewPlaceNode(nil, "Australia", "", nil)
+	date3Sep1953 := gedcom.NewDateNode("3 Sep 1953")
+	place1 := gedcom.NewPlaceNode("Australia")
 
-	individual := gedcom.NewIndividualNode(nil, "", "", []gedcom.Node{
-		gedcom.NewBaptismNode(nil, "", "", []gedcom.Node{
-			date3Sep1953,
-		}),
-		gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
-			gedcom.NewPlaceNode(nil, "United Kingdom", "", nil),
-		}),
-		gedcom.NewBaptismNode(nil, "", "", []gedcom.Node{
-			place1,
-		}),
-	})
+	individual := gedcom.NewDocument().AddIndividual("",
+		gedcom.NewBaptismNode("", date3Sep1953),
+		gedcom.NewBirthNode("",
+			gedcom.NewPlaceNode("United Kingdom"),
+		),
+		gedcom.NewBaptismNode("", place1),
+	)
 
 	date, place := individual.Baptism()
 
@@ -1502,20 +1454,20 @@ func TestIndividualNode_Baptism(t *testing.T) {
 }
 
 func TestIndividualNode_Burial(t *testing.T) {
-	date3Sep1953 := gedcom.NewDateNode(nil, "3 Sep 1953", "", nil)
-	place1 := gedcom.NewPlaceNode(nil, "Australia", "", nil)
+	date3Sep1953 := gedcom.NewDateNode("3 Sep 1953")
+	place1 := gedcom.NewPlaceNode("Australia")
 
-	individual := gedcom.NewIndividualNode(nil, "", "", []gedcom.Node{
-		gedcom.NewBurialNode(nil, "", "", []gedcom.Node{
+	individual := gedcom.NewDocument().AddIndividual("",
+		gedcom.NewBurialNode("",
 			date3Sep1953,
-		}),
-		gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
-			gedcom.NewPlaceNode(nil, "United Kingdom", "", nil),
-		}),
-		gedcom.NewBurialNode(nil, "", "", []gedcom.Node{
+		),
+		gedcom.NewBirthNode("",
+			gedcom.NewPlaceNode("United Kingdom"),
+		),
+		gedcom.NewBurialNode("",
 			place1,
-		}),
-	})
+		),
+	)
 
 	date, place := individual.Burial()
 
@@ -1608,24 +1560,24 @@ func TestIndividualNode_AgeAt(t *testing.T) {
 	for _, test := range tests {
 		t.Run("", func(t *testing.T) {
 			individualParts := strings.Split(test.individual, "-")
-			individual := gedcom.NewIndividualNode(nil, "", "", []gedcom.Node{
-				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
-					gedcom.NewDateNode(nil, individualParts[0], "", nil),
-				}),
-				gedcom.NewDeathNode(nil, "", "", []gedcom.Node{
-					gedcom.NewDateNode(nil, individualParts[1], "", nil),
-				}),
-			})
+			individual := gedcom.NewDocument().AddIndividual("",
+				gedcom.NewBirthNode("",
+					gedcom.NewDateNode(individualParts[0]),
+				),
+				gedcom.NewDeathNode("",
+					gedcom.NewDateNode(individualParts[1]),
+				),
+			)
 
-			eventDates := []gedcom.Node{}
+			eventDates := gedcom.Nodes{}
 			if test.event != "" {
 				for _, dateString := range strings.Split(test.event, ",") {
-					dateNode := gedcom.NewDateNode(nil, dateString, "", nil)
+					dateNode := gedcom.NewDateNode(dateString)
 					eventDates = append(eventDates, dateNode)
 				}
 			}
 
-			event := gedcom.NewResidenceNode(nil, "", "", eventDates)
+			event := gedcom.NewResidenceNode("", eventDates...)
 
 			startYears, startIsEstimate, startIsKnown := parseAgeYears(test.start)
 			endYears, endIsEstimate, endIsKnown := parseAgeYears(test.end)
@@ -1670,138 +1622,138 @@ func parseAgeYears(s string) (years float64, isEstimate, isKnown bool) {
 func TestIndividualNode_String(t *testing.T) {
 	String := tf.NamedFunction(t, "IndividualNode_String", (*gedcom.IndividualNode).String)
 
-	String(gedcom.NewIndividualNode(nil, "", "", nil)).
+	String(gedcom.NewDocument().AddIndividual("")).
 		Returns("(no name)")
 
-	String(gedcom.NewIndividualNode(nil, "", "", []gedcom.Node{
-		gedcom.NewNameNode(nil, "", "", nil),
-	})).Returns("(no name)")
+	String(gedcom.NewDocument().AddIndividual("",
+		gedcom.NewNameNode(""),
+	)).Returns("(no name)")
 
-	String(gedcom.NewIndividualNode(nil, "", "", []gedcom.Node{
-		gedcom.NewNameNode(nil, "Elliot /Chance/", "", nil),
-	})).Returns("Elliot Chance")
+	String(gedcom.NewDocument().AddIndividual("",
+		gedcom.NewNameNode("Elliot /Chance/"),
+	)).Returns("Elliot Chance")
 
-	String(gedcom.NewIndividualNode(nil, "", "", []gedcom.Node{
-		gedcom.NewNameNode(nil, "Elliot /Chance/", "", nil),
-		gedcom.NewBirthNode(nil, "", "", nil),
-	})).Returns("Elliot Chance")
+	String(gedcom.NewDocument().AddIndividual("",
+		gedcom.NewNameNode("Elliot /Chance/"),
+		gedcom.NewBirthNode(""),
+	)).Returns("Elliot Chance")
 
-	String(gedcom.NewIndividualNode(nil, "", "", []gedcom.Node{
-		gedcom.NewNameNode(nil, "Elliot /Chance/", "", nil),
-		gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
-			gedcom.NewDateNode(nil, "3 Apr 1983", "", nil),
-		}),
-	})).Returns("Elliot Chance (b. 3 Apr 1983)")
+	String(gedcom.NewDocument().AddIndividual("",
+		gedcom.NewNameNode("Elliot /Chance/"),
+		gedcom.NewBirthNode("",
+			gedcom.NewDateNode("3 Apr 1983"),
+		),
+	)).Returns("Elliot Chance (b. 3 Apr 1983)")
 
-	String(gedcom.NewIndividualNode(nil, "", "", []gedcom.Node{
-		gedcom.NewNameNode(nil, "Elliot /Chance/", "", nil),
-		gedcom.NewDeathNode(nil, "", "", nil),
-	})).Returns("Elliot Chance")
+	String(gedcom.NewDocument().AddIndividual("",
+		gedcom.NewNameNode("Elliot /Chance/"),
+		gedcom.NewDeathNode(""),
+	)).Returns("Elliot Chance")
 
-	String(gedcom.NewIndividualNode(nil, "", "", []gedcom.Node{
-		gedcom.NewNameNode(nil, "Elliot /Chance/", "", nil),
-		gedcom.NewDeathNode(nil, "", "", []gedcom.Node{
-			gedcom.NewDateNode(nil, "19 Nov 2007", "", nil),
-		}),
-	})).Returns("Elliot Chance (d. 19 Nov 2007)")
+	String(gedcom.NewDocument().AddIndividual("",
+		gedcom.NewNameNode("Elliot /Chance/"),
+		gedcom.NewDeathNode("",
+			gedcom.NewDateNode("19 Nov 2007"),
+		),
+	)).Returns("Elliot Chance (d. 19 Nov 2007)")
 
-	String(gedcom.NewIndividualNode(nil, "", "", []gedcom.Node{
-		gedcom.NewNameNode(nil, "John /Smith/", "", nil),
-		gedcom.NewDeathNode(nil, "", "", nil),
-		gedcom.NewBirthNode(nil, "", "", nil),
-	})).Returns("John Smith")
+	String(gedcom.NewDocument().AddIndividual("",
+		gedcom.NewNameNode("John /Smith/"),
+		gedcom.NewDeathNode(""),
+		gedcom.NewBirthNode(""),
+	)).Returns("John Smith")
 
-	String(gedcom.NewIndividualNode(nil, "", "", []gedcom.Node{
-		gedcom.NewNameNode(nil, "John /Smith/", "", nil),
-		gedcom.NewDeathNode(nil, "", "", []gedcom.Node{
-			gedcom.NewDateNode(nil, "19 Nov 2007", "", nil),
-		}),
-		gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
-			gedcom.NewDateNode(nil, "7 Aug 1971", "", nil),
-		}),
-	})).Returns("John Smith (b. 7 Aug 1971, d. 19 Nov 2007)")
+	String(gedcom.NewDocument().AddIndividual("",
+		gedcom.NewNameNode("John /Smith/"),
+		gedcom.NewDeathNode("",
+			gedcom.NewDateNode("19 Nov 2007"),
+		),
+		gedcom.NewBirthNode("",
+			gedcom.NewDateNode("7 Aug 1971"),
+		),
+	)).Returns("John Smith (b. 7 Aug 1971, d. 19 Nov 2007)")
 
-	String(gedcom.NewIndividualNode(nil, "", "", []gedcom.Node{
-		gedcom.NewNameNode(nil, "Jane /Doe/", "", nil),
-		gedcom.NewBaptismNode(nil, "", "", []gedcom.Node{
-			gedcom.NewDateNode(nil, "14 Jun 2007", "", nil),
-		}),
-	})).Returns("Jane Doe (bap. 14 Jun 2007)")
+	String(gedcom.NewDocument().AddIndividual("",
+		gedcom.NewNameNode("Jane /Doe/"),
+		gedcom.NewBaptismNode("",
+			gedcom.NewDateNode("14 Jun 2007"),
+		),
+	)).Returns("Jane Doe (bap. 14 Jun 2007)")
 
-	String(gedcom.NewIndividualNode(nil, "", "", []gedcom.Node{
-		gedcom.NewNameNode(nil, "Jane /Doe/", "", nil),
-		gedcom.NewBaptismNode(nil, "", "", []gedcom.Node{
-			gedcom.NewDateNode(nil, "14 Jun 2007", "", nil),
-		}),
-		gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
-			gedcom.NewDateNode(nil, "7 Jun 2007", "", nil),
-		}),
-	})).Returns("Jane Doe (b. 7 Jun 2007)")
+	String(gedcom.NewDocument().AddIndividual("",
+		gedcom.NewNameNode("Jane /Doe/"),
+		gedcom.NewBaptismNode("",
+			gedcom.NewDateNode("14 Jun 2007"),
+		),
+		gedcom.NewBirthNode("",
+			gedcom.NewDateNode("7 Jun 2007"),
+		),
+	)).Returns("Jane Doe (b. 7 Jun 2007)")
 
-	String(gedcom.NewIndividualNode(nil, "", "", []gedcom.Node{
-		gedcom.NewNameNode(nil, "Jane /Doe/", "", nil),
-		gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
-			gedcom.NewDateNode(nil, "7 Jun 2007", "", nil),
-		}),
-		gedcom.NewBaptismNode(nil, "", "", []gedcom.Node{
-			gedcom.NewDateNode(nil, "14 Jun 2007", "", nil),
-		}),
-	})).Returns("Jane Doe (b. 7 Jun 2007)")
+	String(gedcom.NewDocument().AddIndividual("",
+		gedcom.NewNameNode("Jane /Doe/"),
+		gedcom.NewBirthNode("",
+			gedcom.NewDateNode("7 Jun 2007"),
+		),
+		gedcom.NewBaptismNode("",
+			gedcom.NewDateNode("14 Jun 2007"),
+		),
+	)).Returns("Jane Doe (b. 7 Jun 2007)")
 
-	String(gedcom.NewIndividualNode(nil, "", "", []gedcom.Node{
-		gedcom.NewNameNode(nil, "Jane /Doe/", "", nil),
-		gedcom.NewBurialNode(nil, "", "", []gedcom.Node{
-			gedcom.NewDateNode(nil, "14 Jun 2007", "", nil),
-		}),
-	})).Returns("Jane Doe (bur. 14 Jun 2007)")
+	String(gedcom.NewDocument().AddIndividual("",
+		gedcom.NewNameNode("Jane /Doe/"),
+		gedcom.NewBurialNode("",
+			gedcom.NewDateNode("14 Jun 2007"),
+		),
+	)).Returns("Jane Doe (bur. 14 Jun 2007)")
 
-	String(gedcom.NewIndividualNode(nil, "", "", []gedcom.Node{
-		gedcom.NewNameNode(nil, "Jane /Doe/", "", nil),
-		gedcom.NewBurialNode(nil, "", "", []gedcom.Node{
-			gedcom.NewDateNode(nil, "14 Jun 2007", "", nil),
-		}),
-		gedcom.NewDeathNode(nil, "", "", []gedcom.Node{
-			gedcom.NewDateNode(nil, "7 Jun 2007", "", nil),
-		}),
-	})).Returns("Jane Doe (d. 7 Jun 2007)")
+	String(gedcom.NewDocument().AddIndividual("",
+		gedcom.NewNameNode("Jane /Doe/"),
+		gedcom.NewBurialNode("",
+			gedcom.NewDateNode("14 Jun 2007"),
+		),
+		gedcom.NewDeathNode("",
+			gedcom.NewDateNode("7 Jun 2007"),
+		),
+	)).Returns("Jane Doe (d. 7 Jun 2007)")
 
-	String(gedcom.NewIndividualNode(nil, "", "", []gedcom.Node{
-		gedcom.NewNameNode(nil, "Jane /Doe/", "", nil),
-		gedcom.NewDeathNode(nil, "", "", []gedcom.Node{
-			gedcom.NewDateNode(nil, "7 Jun 2007", "", nil),
-		}),
-		gedcom.NewBurialNode(nil, "", "", []gedcom.Node{
-			gedcom.NewDateNode(nil, "14 Jun 2007", "", nil),
-		}),
-	})).Returns("Jane Doe (d. 7 Jun 2007)")
+	String(gedcom.NewDocument().AddIndividual("",
+		gedcom.NewNameNode("Jane /Doe/"),
+		gedcom.NewDeathNode("",
+			gedcom.NewDateNode("7 Jun 2007"),
+		),
+		gedcom.NewBurialNode("",
+			gedcom.NewDateNode("14 Jun 2007"),
+		),
+	)).Returns("Jane Doe (d. 7 Jun 2007)")
 }
 
 func TestIndividualNode_FamilySearchIDs(t *testing.T) {
 	FamilySearchIDs := tf.NamedFunction(t, "IndividualNode_FamilySearchIDs",
 		(*gedcom.IndividualNode).FamilySearchIDs)
 
-	FamilySearchIDs(gedcom.NewIndividualNode(nil, "", "", nil)).
+	FamilySearchIDs(gedcom.NewDocument().AddIndividual("")).
 		Returns(nil)
 
-	FamilySearchIDs(gedcom.NewIndividualNode(nil, "", "", []gedcom.Node{
-		gedcom.NewNameNode(nil, "", "", nil),
-	})).Returns(nil)
+	FamilySearchIDs(gedcom.NewDocument().AddIndividual("",
+		gedcom.NewNameNode(""),
+	)).Returns(nil)
 
-	FamilySearchIDs(gedcom.NewIndividualNode(nil, "", "", []gedcom.Node{
-		gedcom.NewNameNode(nil, "", "", nil),
-		gedcom.NewFamilySearchIDNode(nil, gedcom.UnofficialTagFamilySearchID1, "LZDP-V7V"),
-	})).Returns([]*gedcom.FamilySearchIDNode{
-		gedcom.NewFamilySearchIDNode(nil, gedcom.UnofficialTagFamilySearchID1, "LZDP-V7V"),
+	FamilySearchIDs(gedcom.NewDocument().AddIndividual("",
+		gedcom.NewNameNode(""),
+		gedcom.NewFamilySearchIDNode(gedcom.UnofficialTagFamilySearchID1, "LZDP-V7V"),
+	)).Returns([]*gedcom.FamilySearchIDNode{
+		gedcom.NewFamilySearchIDNode(gedcom.UnofficialTagFamilySearchID1, "LZDP-V7V"),
 	})
 
-	FamilySearchIDs(gedcom.NewIndividualNode(nil, "", "", []gedcom.Node{
-		gedcom.NewFamilySearchIDNode(nil, gedcom.UnofficialTagFamilySearchID2, "AZDP-V7V"),
-		gedcom.NewFamilySearchIDNode(nil, gedcom.UnofficialTagFamilySearchID1, "BZDP-V7V"),
-		gedcom.NewFamilySearchIDNode(nil, gedcom.UnofficialTagFamilySearchID2, "CZDP-V7V"),
-	})).Returns([]*gedcom.FamilySearchIDNode{
-		gedcom.NewFamilySearchIDNode(nil, gedcom.UnofficialTagFamilySearchID1, "BZDP-V7V"),
-		gedcom.NewFamilySearchIDNode(nil, gedcom.UnofficialTagFamilySearchID2, "AZDP-V7V"),
-		gedcom.NewFamilySearchIDNode(nil, gedcom.UnofficialTagFamilySearchID2, "CZDP-V7V"),
+	FamilySearchIDs(gedcom.NewDocument().AddIndividual("",
+		gedcom.NewFamilySearchIDNode(gedcom.UnofficialTagFamilySearchID2, "AZDP-V7V"),
+		gedcom.NewFamilySearchIDNode(gedcom.UnofficialTagFamilySearchID1, "BZDP-V7V"),
+		gedcom.NewFamilySearchIDNode(gedcom.UnofficialTagFamilySearchID2, "CZDP-V7V"),
+	)).Returns([]*gedcom.FamilySearchIDNode{
+		gedcom.NewFamilySearchIDNode(gedcom.UnofficialTagFamilySearchID1, "BZDP-V7V"),
+		gedcom.NewFamilySearchIDNode(gedcom.UnofficialTagFamilySearchID2, "AZDP-V7V"),
+		gedcom.NewFamilySearchIDNode(gedcom.UnofficialTagFamilySearchID2, "CZDP-V7V"),
 	})
 }
 
@@ -1809,26 +1761,26 @@ func TestIndividualNode_UniqueIDs(t *testing.T) {
 	UniqueIDs := tf.NamedFunction(t, "IndividualNode_UniqueIDs",
 		(*gedcom.IndividualNode).UniqueIDs)
 
-	UniqueIDs(gedcom.NewIndividualNode(nil, "", "", nil)).
+	UniqueIDs(gedcom.NewDocument().AddIndividual("")).
 		Returns(nil)
 
-	UniqueIDs(gedcom.NewIndividualNode(nil, "", "", []gedcom.Node{
-		gedcom.NewNameNode(nil, "", "", nil),
-	})).Returns(nil)
+	UniqueIDs(gedcom.NewDocument().AddIndividual("",
+		gedcom.NewNameNode(""),
+	)).Returns(nil)
 
-	UniqueIDs(gedcom.NewIndividualNode(nil, "", "", []gedcom.Node{
-		gedcom.NewNameNode(nil, "", "", nil),
-		gedcom.NewUniqueIDNode(nil, "LZDP-V7V", "", nil),
-	})).Returns([]*gedcom.UniqueIDNode{
-		gedcom.NewUniqueIDNode(nil, "LZDP-V7V", "", nil),
+	UniqueIDs(gedcom.NewDocument().AddIndividual("",
+		gedcom.NewNameNode(""),
+		gedcom.NewUniqueIDNode("LZDP-V7V"),
+	)).Returns([]*gedcom.UniqueIDNode{
+		gedcom.NewUniqueIDNode("LZDP-V7V"),
 	})
 
-	UniqueIDs(gedcom.NewIndividualNode(nil, "", "", []gedcom.Node{
-		gedcom.NewUniqueIDNode(nil, "AZDP-V7V", "", nil),
-		gedcom.NewNameNode(nil, "", "", nil),
-		gedcom.NewUniqueIDNode(nil, "BZDP-V7V", "", nil),
-	})).Returns([]*gedcom.UniqueIDNode{
-		gedcom.NewUniqueIDNode(nil, "AZDP-V7V", "", nil),
-		gedcom.NewUniqueIDNode(nil, "BZDP-V7V", "", nil),
+	UniqueIDs(gedcom.NewDocument().AddIndividual("",
+		gedcom.NewUniqueIDNode("AZDP-V7V"),
+		gedcom.NewNameNode(""),
+		gedcom.NewUniqueIDNode("BZDP-V7V"),
+	)).Returns([]*gedcom.UniqueIDNode{
+		gedcom.NewUniqueIDNode("AZDP-V7V"),
+		gedcom.NewUniqueIDNode("BZDP-V7V"),
 	})
 }

--- a/individual_nodes.go
+++ b/individual_nodes.go
@@ -665,7 +665,7 @@ func (nodes IndividualNodes) Merge(other IndividualNodes, options *IndividualNod
 // Nodes returns a slice containing the same individuals.
 //
 // Individuals that are manipulated will affect the original individuals.
-func (nodes IndividualNodes) Nodes() (ns []Node) {
+func (nodes IndividualNodes) Nodes() (ns Nodes) {
 	for _, individual := range nodes {
 		ns = append(ns, individual)
 	}

--- a/individual_nodes_test.go
+++ b/individual_nodes_test.go
@@ -13,11 +13,11 @@ import (
 var (
 	// John and Jane share the same pointer on purpose. They will be used for
 	// pointer comparisons.
-	elliot = individual("P1", "Elliot /Chance/", "4 Jan 1843", "17 Mar 1907")
-	john   = individual("P2", "John /Smith/", "4 Jan 1803", "17 Mar 1877")
-	jane   = individual("P2", "Jane /Doe/", "3 Mar 1803", "14 June 1877")
-	bob    = individual("P4", "Bob /Jones/", "1749", "1810")
-	harry  = individual("P5", "Harry /Gold/", "1889", "1936")
+	elliot = individual(gedcom.NewDocument(), "P1", "Elliot /Chance/", "4 Jan 1843", "17 Mar 1907")
+	john   = individual(gedcom.NewDocument(), "P2", "John /Smith/", "4 Jan 1803", "17 Mar 1877")
+	jane   = individual(gedcom.NewDocument(), "P2", "Jane /Doe/", "3 Mar 1803", "14 June 1877")
+	bob    = individual(gedcom.NewDocument(), "P4", "Bob /Jones/", "1749", "1810")
+	harry  = individual(gedcom.NewDocument(), "P5", "Harry /Gold/", "1889", "1936")
 )
 
 var individualNodesTests = map[string]struct {
@@ -37,7 +37,7 @@ var individualNodesTests = map[string]struct {
 		WantCompare:               gedcom.IndividualComparisons{},
 	},
 	"Doc2Empty": {
-		Doc1: gedcom.NewDocumentWithNodes([]gedcom.Node{elliot}),
+		Doc1: gedcom.NewDocumentWithNodes(gedcom.Nodes{elliot}),
 		Doc2: gedcom.NewDocument(),
 		MinimumWeightedSimilarity: 0.0,
 		PreferPointerAbove:        1.0,
@@ -50,7 +50,7 @@ var individualNodesTests = map[string]struct {
 	},
 	"Doc1Empty": {
 		Doc1: gedcom.NewDocument(),
-		Doc2: gedcom.NewDocumentWithNodes([]gedcom.Node{elliot}),
+		Doc2: gedcom.NewDocumentWithNodes(gedcom.Nodes{elliot}),
 		MinimumWeightedSimilarity: 0.0,
 		PreferPointerAbove:        1.0,
 		WantCompare: gedcom.IndividualComparisons{
@@ -61,8 +61,8 @@ var individualNodesTests = map[string]struct {
 		},
 	},
 	"SameIndividualInBothDocuments": {
-		Doc1: gedcom.NewDocumentWithNodes([]gedcom.Node{elliot}),
-		Doc2: gedcom.NewDocumentWithNodes([]gedcom.Node{elliot}),
+		Doc1: gedcom.NewDocumentWithNodes(gedcom.Nodes{elliot}),
+		Doc2: gedcom.NewDocumentWithNodes(gedcom.Nodes{elliot}),
 		MinimumWeightedSimilarity: 0.0,
 		PreferPointerAbove:        1.0,
 		WantCompare: gedcom.IndividualComparisons{
@@ -73,8 +73,8 @@ var individualNodesTests = map[string]struct {
 		},
 	},
 	"SameIndividualsInDifferentOrder": {
-		Doc1: gedcom.NewDocumentWithNodes([]gedcom.Node{elliot, john, jane}),
-		Doc2: gedcom.NewDocumentWithNodes([]gedcom.Node{jane, elliot, john}),
+		Doc1: gedcom.NewDocumentWithNodes(gedcom.Nodes{elliot, john, jane}),
+		Doc2: gedcom.NewDocumentWithNodes(gedcom.Nodes{jane, elliot, john}),
 		MinimumWeightedSimilarity: 0.0,
 		PreferPointerAbove:        1.0,
 		WantCompare: gedcom.IndividualComparisons{
@@ -89,8 +89,8 @@ var individualNodesTests = map[string]struct {
 		},
 	},
 	"ZeroMinimumSimilarity": {
-		Doc1: gedcom.NewDocumentWithNodes([]gedcom.Node{elliot, jane}),
-		Doc2: gedcom.NewDocumentWithNodes([]gedcom.Node{jane, john}),
+		Doc1: gedcom.NewDocumentWithNodes(gedcom.Nodes{elliot, jane}),
+		Doc2: gedcom.NewDocumentWithNodes(gedcom.Nodes{jane, john}),
 		MinimumWeightedSimilarity: 0.0,
 		PreferPointerAbove:        1.0,
 		WantCompare: gedcom.IndividualComparisons{
@@ -101,23 +101,23 @@ var individualNodesTests = map[string]struct {
 		},
 		WantMerge: gedcom.IndividualNodes{
 			jane,
-			gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewNameNode(nil, "Elliot /Chance/", "", nil),
-				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
-					gedcom.NewDateNode(nil, "4 Jan 1803", "", nil), // john
-					gedcom.NewDateNode(nil, "4 Jan 1843", "", nil), // elliot
-				}),
-				gedcom.NewDeathNode(nil, "", "", []gedcom.Node{
-					gedcom.NewDateNode(nil, "17 Mar 1877", "", nil), // john
-					gedcom.NewDateNode(nil, "17 Mar 1907", "", nil), // elliot
-				}),
-				gedcom.NewNameNode(nil, "John /Smith/", "", nil),
-			}),
+			gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNameNode("Elliot /Chance/"),
+				gedcom.NewBirthNode("",
+					gedcom.NewDateNode("4 Jan 1803"), // john
+					gedcom.NewDateNode("4 Jan 1843"), // elliot
+				),
+				gedcom.NewDeathNode("",
+					gedcom.NewDateNode("17 Mar 1877"), // john
+					gedcom.NewDateNode("17 Mar 1907"), // elliot
+				),
+				gedcom.NewNameNode("John /Smith/"),
+			),
 		},
 	},
 	"OneMatch": {
-		Doc1: gedcom.NewDocumentWithNodes([]gedcom.Node{elliot, jane}),
-		Doc2: gedcom.NewDocumentWithNodes([]gedcom.Node{jane, john}),
+		Doc1: gedcom.NewDocumentWithNodes(gedcom.Nodes{elliot, jane}),
+		Doc2: gedcom.NewDocumentWithNodes(gedcom.Nodes{jane, john}),
 		MinimumWeightedSimilarity: 0.75,
 		PreferPointerAbove:        1.0,
 		WantCompare: gedcom.IndividualComparisons{
@@ -132,8 +132,8 @@ var individualNodesTests = map[string]struct {
 		},
 	},
 	"NoMatches": {
-		Doc1: gedcom.NewDocumentWithNodes([]gedcom.Node{elliot, jane}),
-		Doc2: gedcom.NewDocumentWithNodes([]gedcom.Node{bob, john}),
+		Doc1: gedcom.NewDocumentWithNodes(gedcom.Nodes{elliot, jane}),
+		Doc2: gedcom.NewDocumentWithNodes(gedcom.Nodes{bob, john}),
 		MinimumWeightedSimilarity: 0.9,
 		PreferPointerAbove:        1.0,
 		WantCompare: gedcom.IndividualComparisons{
@@ -152,8 +152,8 @@ var individualNodesTests = map[string]struct {
 	"AlwaysUsePointer": {
 		// John and Jane are both P2. Even though they are completely different
 		// we force pointers to match with a prefer value of 0.0.
-		Doc1: gedcom.NewDocumentWithNodes([]gedcom.Node{elliot, jane}),
-		Doc2: gedcom.NewDocumentWithNodes([]gedcom.Node{bob, john}),
+		Doc1: gedcom.NewDocumentWithNodes(gedcom.Nodes{elliot, jane}),
+		Doc2: gedcom.NewDocumentWithNodes(gedcom.Nodes{bob, john}),
 		MinimumWeightedSimilarity: 0.9,
 		PreferPointerAbove:        0.0,
 		WantCompare: gedcom.IndividualComparisons{
@@ -162,18 +162,18 @@ var individualNodesTests = map[string]struct {
 			gedcom.NewIndividualComparison(nil, bob, nil),
 		},
 		WantMerge: gedcom.IndividualNodes{
-			gedcom.NewIndividualNode(nil, "", "P2", []gedcom.Node{
-				gedcom.NewNameNode(nil, "Jane /Doe/", "", nil),
-				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
-					gedcom.NewDateNode(nil, "4 Jan 1803", "", nil), // john
-					gedcom.NewDateNode(nil, "3 Mar 1803", "", nil), // jane
-				}),
-				gedcom.NewDeathNode(nil, "", "", []gedcom.Node{
-					gedcom.NewDateNode(nil, "17 Mar 1877", "", nil),  // john
-					gedcom.NewDateNode(nil, "14 June 1877", "", nil), // jane
-				}),
-				gedcom.NewNameNode(nil, "John /Smith/", "", nil),
-			}),
+			gedcom.NewDocument().AddIndividual("P2",
+				gedcom.NewNameNode("Jane /Doe/"),
+				gedcom.NewBirthNode("",
+					gedcom.NewDateNode("4 Jan 1803"), // john
+					gedcom.NewDateNode("3 Mar 1803"), // jane
+				),
+				gedcom.NewDeathNode("",
+					gedcom.NewDateNode("17 Mar 1877"),  // john
+					gedcom.NewDateNode("14 June 1877"), // jane
+				),
+				gedcom.NewNameNode("John /Smith/"),
+			),
 			elliot,
 			bob,
 		},
@@ -181,13 +181,13 @@ var individualNodesTests = map[string]struct {
 	"AlwaysUseUID1": {
 		// Harry and John will always match because of the shared unique
 		// identifier.
-		Doc1: gedcom.NewDocumentWithNodes([]gedcom.Node{
+		Doc1: gedcom.NewDocumentWithNodes(gedcom.Nodes{
 			elliot,
-			setUID(individual("P5", "Harry /Gold/", "1889", "1936"), "EE13561DDB204985BFFDEEBF82A5226C"),
+			setUID(individual(gedcom.NewDocument(), "P5", "Harry /Gold/", "1889", "1936"), "EE13561DDB204985BFFDEEBF82A5226C"),
 		}),
-		Doc2: gedcom.NewDocumentWithNodes([]gedcom.Node{
+		Doc2: gedcom.NewDocumentWithNodes(gedcom.Nodes{
 			bob,
-			setUID(individual("P2", "John /Smith/", "4 Jan 1803", "17 Mar 1877"), "EE13561DDB204985BFFDEEBF82A5226C5B2E"),
+			setUID(individual(gedcom.NewDocument(), "P2", "John /Smith/", "4 Jan 1803", "17 Mar 1877"), "EE13561DDB204985BFFDEEBF82A5226C5B2E"),
 		}),
 		MinimumWeightedSimilarity: 0.9,
 		PreferPointerAbove:        0.0,
@@ -197,19 +197,19 @@ var individualNodesTests = map[string]struct {
 			gedcom.NewIndividualComparison(nil, bob, nil),
 		},
 		WantMerge: gedcom.IndividualNodes{
-			gedcom.NewIndividualNode(nil, "", "P5", []gedcom.Node{ // P5 = harry
-				gedcom.NewNameNode(nil, "Harry /Gold/", "", nil),
-				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
-					gedcom.NewDateNode(nil, "4 Jan 1803", "", nil), // john
-					gedcom.NewDateNode(nil, "1889", "", nil),       // harry
-				}),
-				gedcom.NewDeathNode(nil, "", "", []gedcom.Node{
-					gedcom.NewDateNode(nil, "17 Mar 1877", "", nil), // john
-					gedcom.NewDateNode(nil, "1936", "", nil),        // harry
-				}),
-				gedcom.NewUniqueIDNode(nil, "EE13561DDB204985BFFDEEBF82A5226C", "", nil),
-				gedcom.NewNameNode(nil, "John /Smith/", "", nil),
-			}),
+			gedcom.NewDocument().AddIndividual("P5", // P5 = harry
+				gedcom.NewNameNode("Harry /Gold/"),
+				gedcom.NewBirthNode("",
+					gedcom.NewDateNode("4 Jan 1803"), // john
+					gedcom.NewDateNode("1889"),       // harry
+				),
+				gedcom.NewDeathNode("",
+					gedcom.NewDateNode("17 Mar 1877"), // john
+					gedcom.NewDateNode("1936"),        // harry
+				),
+				gedcom.NewUniqueIDNode("EE13561DDB204985BFFDEEBF82A5226C"),
+				gedcom.NewNameNode("John /Smith/"),
+			),
 			elliot,
 			bob,
 		},
@@ -217,13 +217,13 @@ var individualNodesTests = map[string]struct {
 	"AlwaysUseUID2": {
 		// This is the same as above, but we use the opposite PreferPointerAbove
 		// value to prove that it doesn't affect unique identifier matches.
-		Doc1: gedcom.NewDocumentWithNodes([]gedcom.Node{
+		Doc1: gedcom.NewDocumentWithNodes(gedcom.Nodes{
 			elliot,
-			setUID(individual("P5", "Harry /Gold/", "1889", "1936"), "EE13561DDB204985BFFDEEBF82A5226C"),
+			setUID(individual(gedcom.NewDocument(), "P5", "Harry /Gold/", "1889", "1936"), "EE13561DDB204985BFFDEEBF82A5226C"),
 		}),
-		Doc2: gedcom.NewDocumentWithNodes([]gedcom.Node{
+		Doc2: gedcom.NewDocumentWithNodes(gedcom.Nodes{
 			bob,
-			setUID(individual("P2", "John /Smith/", "4 Jan 1803", "17 Mar 1877"), "EE13561DDB204985BFFDEEBF82A5226C5B2E"),
+			setUID(individual(gedcom.NewDocument(), "P2", "John /Smith/", "4 Jan 1803", "17 Mar 1877"), "EE13561DDB204985BFFDEEBF82A5226C5B2E"),
 		}),
 		MinimumWeightedSimilarity: 0.9,
 		PreferPointerAbove:        1.0,
@@ -233,19 +233,19 @@ var individualNodesTests = map[string]struct {
 			gedcom.NewIndividualComparison(nil, bob, nil),
 		},
 		WantMerge: gedcom.IndividualNodes{
-			gedcom.NewIndividualNode(nil, "", "P5", []gedcom.Node{ // P5 = harry
-				gedcom.NewNameNode(nil, "Harry /Gold/", "", nil),
-				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
-					gedcom.NewDateNode(nil, "4 Jan 1803", "", nil), // john
-					gedcom.NewDateNode(nil, "1889", "", nil),       // harry
-				}),
-				gedcom.NewDeathNode(nil, "", "", []gedcom.Node{
-					gedcom.NewDateNode(nil, "17 Mar 1877", "", nil), // john
-					gedcom.NewDateNode(nil, "1936", "", nil),        // harry
-				}),
-				gedcom.NewUniqueIDNode(nil, "EE13561DDB204985BFFDEEBF82A5226C", "", nil),
-				gedcom.NewNameNode(nil, "John /Smith/", "", nil),
-			}),
+			gedcom.NewDocument().AddIndividual("P5", // P5 = harry
+				gedcom.NewNameNode("Harry /Gold/"),
+				gedcom.NewBirthNode("",
+					gedcom.NewDateNode("4 Jan 1803"), // john
+					gedcom.NewDateNode("1889"),       // harry
+				),
+				gedcom.NewDeathNode("",
+					gedcom.NewDateNode("17 Mar 1877"), // john
+					gedcom.NewDateNode("1936"),        // harry
+				),
+				gedcom.NewUniqueIDNode("EE13561DDB204985BFFDEEBF82A5226C"),
+				gedcom.NewNameNode("John /Smith/"),
+			),
 			elliot,
 			bob,
 		},
@@ -268,46 +268,46 @@ func TestIndividualNodes_Similarity(t *testing.T) {
 		},
 		{
 			a: gedcom.IndividualNodes{
-				gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-					name("John /Smith/"),
-					born("4 Jan 1843"),
-					died("17 Mar 1907"),
-				}),
+				gedcom.NewDocument().AddIndividual("P1",
+					gedcom.NewNameNode("John /Smith/"),
+					gedcom.NewBirthNode("", gedcom.NewDateNode("4 Jan 1843")),
+					gedcom.NewDeathNode("", gedcom.NewDateNode("17 Mar 1907")),
+				),
 			},
 			b: gedcom.IndividualNodes{
-				gedcom.NewIndividualNode(nil, "", "P2", []gedcom.Node{
-					name("John /Smith/"),
-					born("4 Jan 1843"),
-					died("17 Mar 1907"),
-				}),
+				gedcom.NewDocument().AddIndividual("P2",
+					gedcom.NewNameNode("John /Smith/"),
+					gedcom.NewBirthNode("", gedcom.NewDateNode("4 Jan 1843")),
+					gedcom.NewDeathNode("", gedcom.NewDateNode("17 Mar 1907")),
+				),
 			},
 			minSimilarity: gedcom.DefaultMinimumSimilarity,
 			expected:      1.0,
 		},
 		{
 			a: gedcom.IndividualNodes{
-				gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-					name("John /Smith/"),
-					born("4 Jan 1843"),
-					died("17 Mar 1907"),
-				}),
-				gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-					name("Jane /Doe/"),
-					born("Sep 1843"),
-					died("Apr 1907"),
-				}),
+				gedcom.NewDocument().AddIndividual("P1",
+					gedcom.NewNameNode("John /Smith/"),
+					gedcom.NewBirthNode("", gedcom.NewDateNode("4 Jan 1843")),
+					gedcom.NewDeathNode("", gedcom.NewDateNode("17 Mar 1907")),
+				),
+				gedcom.NewDocument().AddIndividual("P1",
+					gedcom.NewNameNode("Jane /Doe/"),
+					gedcom.NewBirthNode("", gedcom.NewDateNode("Sep 1843")),
+					gedcom.NewDeathNode("", gedcom.NewDateNode("Apr 1907")),
+				),
 			},
 			b: gedcom.IndividualNodes{
-				gedcom.NewIndividualNode(nil, "", "P2", []gedcom.Node{
-					name("John /Smith/"),
-					born("4 Jan 1843"),
-					died("17 Mar 1907"),
-				}),
-				gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-					name("Jane /DOE/"),
-					born("Sep 1843"),
-					died("Apr 1907"),
-				}),
+				gedcom.NewDocument().AddIndividual("P2",
+					gedcom.NewNameNode("John /Smith/"),
+					gedcom.NewBirthNode("", gedcom.NewDateNode("4 Jan 1843")),
+					gedcom.NewDeathNode("", gedcom.NewDateNode("17 Mar 1907")),
+				),
+				gedcom.NewDocument().AddIndividual("P1",
+					gedcom.NewNameNode("Jane /DOE/"),
+					gedcom.NewBirthNode("", gedcom.NewDateNode("Sep 1843")),
+					gedcom.NewDeathNode("", gedcom.NewDateNode("Apr 1907")),
+				),
 			},
 			minSimilarity: gedcom.DefaultMinimumSimilarity,
 			expected:      1.0,
@@ -318,30 +318,30 @@ func TestIndividualNodes_Similarity(t *testing.T) {
 		// similarities. See the docs for explanation.
 		{
 			a: gedcom.IndividualNodes{
-				gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-					name("John /Smith/"),
-					died("Apr 1907"),
-				}),
+				gedcom.NewDocument().AddIndividual("P1",
+					gedcom.NewNameNode("John /Smith/"),
+					gedcom.NewDeathNode("", gedcom.NewDateNode("Apr 1907")),
+				),
 			},
 			b: gedcom.IndividualNodes{
-				gedcom.NewIndividualNode(nil, "", "P2", []gedcom.Node{
-					name("John /Smith/"),
-					died("Apr 1907"),
-				}),
+				gedcom.NewDocument().AddIndividual("P2",
+					gedcom.NewNameNode("John /Smith/"),
+					gedcom.NewDeathNode("", gedcom.NewDateNode("Apr 1907")),
+				),
 			},
 			minSimilarity: gedcom.DefaultMinimumSimilarity,
 			expected:      0.875,
 		},
 		{
 			a: gedcom.IndividualNodes{
-				gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-					name("John /Smith/"),
-				}),
+				gedcom.NewDocument().AddIndividual("P1",
+					gedcom.NewNameNode("John /Smith/"),
+				),
 			},
 			b: gedcom.IndividualNodes{
-				gedcom.NewIndividualNode(nil, "", "P2", []gedcom.Node{
-					name("John /Smith/"),
-				}),
+				gedcom.NewDocument().AddIndividual("P2",
+					gedcom.NewNameNode("John /Smith/"),
+				),
 			},
 			minSimilarity: gedcom.DefaultMinimumSimilarity,
 			expected:      0.75,
@@ -350,34 +350,34 @@ func TestIndividualNodes_Similarity(t *testing.T) {
 		// Similar matches but the same sized slice on both sides.
 		{
 			a: gedcom.IndividualNodes{
-				gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-					name("John /Smith/"),
-					born("4 Jan 1843"),
-					died("17 Mar 1907"),
-				}),
-				gedcom.NewIndividualNode(nil, "", "P2", []gedcom.Node{
-					name("Jane /Doe/"),
-					born("Sep 1845"),
-				}),
-				gedcom.NewIndividualNode(nil, "", "P3", []gedcom.Node{
-					name("Bob /Jones/"),
-					buried("1927"),
-				}),
+				gedcom.NewDocument().AddIndividual("P1",
+					gedcom.NewNameNode("John /Smith/"),
+					gedcom.NewBirthNode("", gedcom.NewDateNode("4 Jan 1843")),
+					gedcom.NewDeathNode("", gedcom.NewDateNode("17 Mar 1907")),
+				),
+				gedcom.NewDocument().AddIndividual("P2",
+					gedcom.NewNameNode("Jane /Doe/"),
+					gedcom.NewBirthNode("", gedcom.NewDateNode("Sep 1845")),
+				),
+				gedcom.NewDocument().AddIndividual("P3",
+					gedcom.NewNameNode("Bob /Jones/"),
+					gedcom.NewBurialNode("", gedcom.NewDateNode("1927")),
+				),
 			},
 			b: gedcom.IndividualNodes{
-				gedcom.NewIndividualNode(nil, "", "P4", []gedcom.Node{
-					name("John /Smith/"),
-					born("Abt. Jan 1843"),
-					died("1907"),
-				}),
-				gedcom.NewIndividualNode(nil, "", "P5", []gedcom.Node{
-					name("Jane /Doe/"),
-					born("Bef. 1846"),
-				}),
-				gedcom.NewIndividualNode(nil, "", "P6", []gedcom.Node{
-					name("Bob Thomas /Jones/"),
-					buried("1927"),
-				}),
+				gedcom.NewDocument().AddIndividual("P4",
+					gedcom.NewNameNode("John /Smith/"),
+					gedcom.NewBirthNode("", gedcom.NewDateNode("Abt. Jan 1843")),
+					gedcom.NewDeathNode("", gedcom.NewDateNode("1907")),
+				),
+				gedcom.NewDocument().AddIndividual("P5",
+					gedcom.NewNameNode("Jane /Doe/"),
+					gedcom.NewBirthNode("", gedcom.NewDateNode("Bef. 1846")),
+				),
+				gedcom.NewDocument().AddIndividual("P6",
+					gedcom.NewNameNode("Bob Thomas /Jones/"),
+					gedcom.NewBurialNode("", gedcom.NewDateNode("1927")),
+				),
 			},
 			minSimilarity: gedcom.DefaultMinimumSimilarity,
 			expected:      0.872532146404072,
@@ -387,60 +387,60 @@ func TestIndividualNodes_Similarity(t *testing.T) {
 		// when different sizes slices are swapped.
 		{
 			a: gedcom.IndividualNodes{
-				gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-					name("John /Smith/"),
-					born("4 Jan 1843"),
-					died("17 Mar 1907"),
-				}),
-				gedcom.NewIndividualNode(nil, "", "P2", []gedcom.Node{
-					name("Jane /Doe/"),
-					born("Sep 1845"),
-				}),
-				gedcom.NewIndividualNode(nil, "", "P3", []gedcom.Node{
-					name("Bob /Jones/"),
-					buried("1927"),
-				}),
+				gedcom.NewDocument().AddIndividual("P1",
+					gedcom.NewNameNode("John /Smith/"),
+					gedcom.NewBirthNode("", gedcom.NewDateNode("4 Jan 1843")),
+					gedcom.NewDeathNode("", gedcom.NewDateNode("17 Mar 1907")),
+				),
+				gedcom.NewDocument().AddIndividual("P2",
+					gedcom.NewNameNode("Jane /Doe/"),
+					gedcom.NewBirthNode("", gedcom.NewDateNode("Sep 1845")),
+				),
+				gedcom.NewDocument().AddIndividual("P3",
+					gedcom.NewNameNode("Bob /Jones/"),
+					gedcom.NewBurialNode("", gedcom.NewDateNode("1927")),
+				),
 			},
 			b: gedcom.IndividualNodes{
-				gedcom.NewIndividualNode(nil, "", "P4", []gedcom.Node{
-					name("Jane /Doe/"),
-					born("Between 1845 and 1846"),
-				}),
-				gedcom.NewIndividualNode(nil, "", "P5", []gedcom.Node{
-					name("John /Smith/"),
-					born("Bef. 10 Jan 1843"),
-					died("Abt. 1908"),
-				}),
+				gedcom.NewDocument().AddIndividual("P4",
+					gedcom.NewNameNode("Jane /Doe/"),
+					gedcom.NewBirthNode("", gedcom.NewDateNode("Between 1845 and 1846")),
+				),
+				gedcom.NewDocument().AddIndividual("P5",
+					gedcom.NewNameNode("John /Smith/"),
+					gedcom.NewBirthNode("", gedcom.NewDateNode("Bef. 10 Jan 1843")),
+					gedcom.NewDeathNode("", gedcom.NewDateNode("Abt. 1908")),
+				),
 			},
 			minSimilarity: gedcom.DefaultMinimumSimilarity,
 			expected:      0.7754008744441251,
 		},
 		{
 			a: gedcom.IndividualNodes{
-				gedcom.NewIndividualNode(nil, "", "P4", []gedcom.Node{
-					name("Jane /Doe/"),
-					born("Between 1845 and 1846"),
-				}),
-				gedcom.NewIndividualNode(nil, "", "P5", []gedcom.Node{
-					name("John /Smith/"),
-					born("Bef. 10 Jan 1843"),
-					died("Abt. 1908"),
-				}),
+				gedcom.NewDocument().AddIndividual("P4",
+					gedcom.NewNameNode("Jane /Doe/"),
+					gedcom.NewBirthNode("", gedcom.NewDateNode("Between 1845 and 1846")),
+				),
+				gedcom.NewDocument().AddIndividual("P5",
+					gedcom.NewNameNode("John /Smith/"),
+					gedcom.NewBirthNode("", gedcom.NewDateNode("Bef. 10 Jan 1843")),
+					gedcom.NewDeathNode("", gedcom.NewDateNode("Abt. 1908")),
+				),
 			},
 			b: gedcom.IndividualNodes{
-				gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-					name("John /Smith/"),
-					born("4 Jan 1843"),
-					died("17 Mar 1907"),
-				}),
-				gedcom.NewIndividualNode(nil, "", "P2", []gedcom.Node{
-					name("Jane /Doe/"),
-					born("Sep 1845"),
-				}),
-				gedcom.NewIndividualNode(nil, "", "P3", []gedcom.Node{
-					name("Bob /Jones/"),
-					buried("1927"),
-				}),
+				gedcom.NewDocument().AddIndividual("P1",
+					gedcom.NewNameNode("John /Smith/"),
+					gedcom.NewBirthNode("", gedcom.NewDateNode("4 Jan 1843")),
+					gedcom.NewDeathNode("", gedcom.NewDateNode("17 Mar 1907")),
+				),
+				gedcom.NewDocument().AddIndividual("P2",
+					gedcom.NewNameNode("Jane /Doe/"),
+					gedcom.NewBirthNode("", gedcom.NewDateNode("Sep 1845")),
+				),
+				gedcom.NewDocument().AddIndividual("P3",
+					gedcom.NewNameNode("Bob /Jones/"),
+					gedcom.NewBurialNode("", gedcom.NewDateNode("1927")),
+				),
 			},
 			minSimilarity: gedcom.DefaultMinimumSimilarity,
 			expected:      0.7754008744441251,
@@ -450,38 +450,38 @@ func TestIndividualNodes_Similarity(t *testing.T) {
 		{
 			a: gedcom.IndividualNodes{},
 			b: gedcom.IndividualNodes{
-				gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-					name("John /Smith/"),
-					born("4 Jan 1843"),
-					died("17 Mar 1907"),
-				}),
-				gedcom.NewIndividualNode(nil, "", "P2", []gedcom.Node{
-					name("Jane /Doe/"),
-					born("Sep 1845"),
-				}),
-				gedcom.NewIndividualNode(nil, "", "P3", []gedcom.Node{
-					name("Bob /Jones/"),
-					buried("1927"),
-				}),
+				gedcom.NewDocument().AddIndividual("P1",
+					gedcom.NewNameNode("John /Smith/"),
+					gedcom.NewBirthNode("", gedcom.NewDateNode("4 Jan 1843")),
+					gedcom.NewDeathNode("", gedcom.NewDateNode("17 Mar 1907")),
+				),
+				gedcom.NewDocument().AddIndividual("P2",
+					gedcom.NewNameNode("Jane /Doe/"),
+					gedcom.NewBirthNode("", gedcom.NewDateNode("Sep 1845")),
+				),
+				gedcom.NewDocument().AddIndividual("P3",
+					gedcom.NewNameNode("Bob /Jones/"),
+					gedcom.NewBurialNode("", gedcom.NewDateNode("1927")),
+				),
 			},
 			minSimilarity: gedcom.DefaultMinimumSimilarity,
 			expected:      0.5,
 		},
 		{
 			a: gedcom.IndividualNodes{
-				gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-					name("John /Smith/"),
-					born("4 Jan 1843"),
-					died("17 Mar 1907"),
-				}),
-				gedcom.NewIndividualNode(nil, "", "P2", []gedcom.Node{
-					name("Jane /Doe/"),
-					born("Sep 1845"),
-				}),
-				gedcom.NewIndividualNode(nil, "", "P3", []gedcom.Node{
-					name("Bob /Jones/"),
-					buried("1927"),
-				}),
+				gedcom.NewDocument().AddIndividual("P1",
+					gedcom.NewNameNode("John /Smith/"),
+					gedcom.NewBirthNode("", gedcom.NewDateNode("4 Jan 1843")),
+					gedcom.NewDeathNode("", gedcom.NewDateNode("17 Mar 1907")),
+				),
+				gedcom.NewDocument().AddIndividual("P2",
+					gedcom.NewNameNode("Jane /Doe/"),
+					gedcom.NewBirthNode("", gedcom.NewDateNode("Sep 1845")),
+				),
+				gedcom.NewDocument().AddIndividual("P3",
+					gedcom.NewNameNode("Bob /Jones/"),
+					gedcom.NewBurialNode("", gedcom.NewDateNode("1927")),
+				),
 			},
 			b:             gedcom.IndividualNodes{},
 			minSimilarity: gedcom.DefaultMinimumSimilarity,
@@ -491,38 +491,38 @@ func TestIndividualNodes_Similarity(t *testing.T) {
 		// These ones are just way off and should not be considered matches.
 		{
 			a: gedcom.IndividualNodes{
-				gedcom.NewIndividualNode(nil, "", "P4", []gedcom.Node{
-					name("Jane /Doe/"),
-					born("Between 1845 and 1846"),
-				}),
+				gedcom.NewDocument().AddIndividual("P4",
+					gedcom.NewNameNode("Jane /Doe/"),
+					gedcom.NewBirthNode("", gedcom.NewDateNode("Between 1845 and 1846")),
+				),
 			},
 			b: gedcom.IndividualNodes{
-				gedcom.NewIndividualNode(nil, "", "P5", []gedcom.Node{
-					name("John /Smith/"),
-					born("Bef. 10 Jan 1943"),
-					died("Abt. 2008"),
-				}),
+				gedcom.NewDocument().AddIndividual("P5",
+					gedcom.NewNameNode("John /Smith/"),
+					gedcom.NewBirthNode("", gedcom.NewDateNode("Bef. 10 Jan 1943")),
+					gedcom.NewDeathNode("", gedcom.NewDateNode("Abt. 2008")),
+				),
 			},
 			minSimilarity: gedcom.DefaultMinimumSimilarity,
 			expected:      0.5,
 		},
 		{
 			a: gedcom.IndividualNodes{
-				gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-					name("John /Smith/"),
-					born("4 Jan 1843"),
-					died("17 Mar 1907"),
-				}),
-				gedcom.NewIndividualNode(nil, "", "P2", []gedcom.Node{
-					name("Jane /Doe/"),
-					born("Sep 1845"),
-				}),
+				gedcom.NewDocument().AddIndividual("P1",
+					gedcom.NewNameNode("John /Smith/"),
+					gedcom.NewBirthNode("", gedcom.NewDateNode("4 Jan 1843")),
+					gedcom.NewDeathNode("", gedcom.NewDateNode("17 Mar 1907")),
+				),
+				gedcom.NewDocument().AddIndividual("P2",
+					gedcom.NewNameNode("Jane /Doe/"),
+					gedcom.NewBirthNode("", gedcom.NewDateNode("Sep 1845")),
+				),
 			},
 			b: gedcom.IndividualNodes{
-				gedcom.NewIndividualNode(nil, "", "P3", []gedcom.Node{
-					name("Bob /Jones/"),
-					born("1627"),
-				}),
+				gedcom.NewDocument().AddIndividual("P3",
+					gedcom.NewNameNode("Bob /Jones/"),
+					gedcom.NewBirthNode("", gedcom.NewDateNode("1627")),
+				),
 			},
 			minSimilarity: gedcom.DefaultMinimumSimilarity,
 			expected:      0.5,
@@ -531,42 +531,42 @@ func TestIndividualNodes_Similarity(t *testing.T) {
 		// Different values for minimumSimilarity.
 		{
 			a: gedcom.IndividualNodes{
-				gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-					name("John /Smith/"),
-					born("4 Jan 1843"),
-					died("17 Mar 1907"),
-				}),
-				gedcom.NewIndividualNode(nil, "", "P2", []gedcom.Node{
-					name("Jane /Doe/"),
-					born("Sep 1845"),
-				}),
+				gedcom.NewDocument().AddIndividual("P1",
+					gedcom.NewNameNode("John /Smith/"),
+					gedcom.NewBirthNode("", gedcom.NewDateNode("4 Jan 1843")),
+					gedcom.NewDeathNode("", gedcom.NewDateNode("17 Mar 1907")),
+				),
+				gedcom.NewDocument().AddIndividual("P2",
+					gedcom.NewNameNode("Jane /Doe/"),
+					gedcom.NewBirthNode("", gedcom.NewDateNode("Sep 1845")),
+				),
 			},
 			b: gedcom.IndividualNodes{
-				gedcom.NewIndividualNode(nil, "", "P3", []gedcom.Node{
-					name("Bob /Jones/"),
-					born("1627"),
-				}),
+				gedcom.NewDocument().AddIndividual("P3",
+					gedcom.NewNameNode("Bob /Jones/"),
+					gedcom.NewBirthNode("", gedcom.NewDateNode("1627")),
+				),
 			},
 			minSimilarity: 0.95,
 			expected:      0.5,
 		},
 		{
 			a: gedcom.IndividualNodes{
-				gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-					name("John /Smith/"),
-					born("4 Jan 1843"),
-					died("17 Mar 1907"),
-				}),
-				gedcom.NewIndividualNode(nil, "", "P2", []gedcom.Node{
-					name("Jane /Doe/"),
-					born("Sep 1845"),
-				}),
+				gedcom.NewDocument().AddIndividual("P1",
+					gedcom.NewNameNode("John /Smith/"),
+					gedcom.NewBirthNode("", gedcom.NewDateNode("4 Jan 1843")),
+					gedcom.NewDeathNode("", gedcom.NewDateNode("17 Mar 1907")),
+				),
+				gedcom.NewDocument().AddIndividual("P2",
+					gedcom.NewNameNode("Jane /Doe/"),
+					gedcom.NewBirthNode("", gedcom.NewDateNode("Sep 1845")),
+				),
 			},
 			b: gedcom.IndividualNodes{
-				gedcom.NewIndividualNode(nil, "", "P3", []gedcom.Node{
-					name("Bob /Jones/"),
-					born("1627"),
-				}),
+				gedcom.NewDocument().AddIndividual("P3",
+					gedcom.NewNameNode("Bob /Jones/"),
+					gedcom.NewBirthNode("", gedcom.NewDateNode("1627")),
+				),
 			},
 			minSimilarity: 0.0,
 			expected:      0.45708333333333334,
@@ -587,14 +587,6 @@ func TestIndividualNodes_Similarity(t *testing.T) {
 func TestIndividualNodes_Compare(t *testing.T) {
 	for testName, test := range individualNodesTests {
 		t.Run(testName, func(t *testing.T) {
-			for _, n := range test.Doc1.Nodes() {
-				n.SetDocument(test.Doc1)
-			}
-
-			for _, n := range test.Doc2.Nodes() {
-				n.SetDocument(test.Doc2)
-			}
-
 			similarityOptions := gedcom.NewSimilarityOptions()
 			similarityOptions.MinimumWeightedSimilarity = test.MinimumWeightedSimilarity
 			similarityOptions.PreferPointerAbove = test.PreferPointerAbove
@@ -629,6 +621,9 @@ func assertEqual(t *testing.T, expected, actual interface{}) bool {
 		gedcom.SimpleNode{},
 		gedcom.IndividualNode{},
 		gedcom.IndividualComparison{},
+		gedcom.FamilyNode{},
+		gedcom.DateNode{},
+		gedcom.ChildNode{},
 	))
 	if diff != "" {
 		assert.Fail(t, diff)
@@ -646,25 +641,17 @@ func TestNewIndividualNodesCompareOptions(t *testing.T) {
 func TestIndividualNodes_Nodes(t *testing.T) {
 	Nodes := tf.Function(t, gedcom.IndividualNodes.Nodes)
 
-	i1 := individual("P1", "Elliot /Chance/", "", "")
-	i2 := individual("P2", "Joe /Bloggs/", "", "")
+	i1 := individual(gedcom.NewDocument(), "P1", "Elliot /Chance/", "", "")
+	i2 := individual(gedcom.NewDocument(), "P2", "Joe /Bloggs/", "", "")
 
 	Nodes(nil).Returns(nil)
 	Nodes(gedcom.IndividualNodes{}).Returns(nil)
-	Nodes(gedcom.IndividualNodes{i1, i2}).Returns([]gedcom.Node{i1, i2})
+	Nodes(gedcom.IndividualNodes{i1, i2}).Returns(gedcom.Nodes{i1, i2})
 }
 
 func TestIndividualNodes_Merge(t *testing.T) {
 	for testName, test := range individualNodesTests {
 		t.Run(testName, func(t *testing.T) {
-			for _, n := range test.Doc1.Nodes() {
-				n.SetDocument(test.Doc1)
-			}
-
-			for _, n := range test.Doc2.Nodes() {
-				n.SetDocument(test.Doc2)
-			}
-
 			similarityOptions := gedcom.NewSimilarityOptions()
 			similarityOptions.MinimumWeightedSimilarity = test.MinimumWeightedSimilarity
 			similarityOptions.PreferPointerAbove = test.PreferPointerAbove
@@ -687,7 +674,7 @@ func assertIndividualNodes(t *testing.T, expected, actual gedcom.IndividualNodes
 }
 
 func setUID(i *gedcom.IndividualNode, uid string) *gedcom.IndividualNode {
-	i.AddNode(gedcom.NewUniqueIDNode(i.Document(), uid, "", nil))
+	i.AddNode(gedcom.NewUniqueIDNode(uid))
 
 	return i
 }

--- a/latitude_node.go
+++ b/latitude_node.go
@@ -9,8 +9,8 @@ type LatitudeNode struct {
 }
 
 // NewLatitudeNode creates a new LATI node.
-func NewLatitudeNode(document *Document, value, pointer string, children []Node) *LatitudeNode {
+func NewLatitudeNode(value string, children ...Node) *LatitudeNode {
 	return &LatitudeNode{
-		newSimpleNode(document, TagLatitude, value, pointer, children),
+		newSimpleNode(TagLatitude, value, "", children...),
 	}
 }

--- a/latitude_node_test.go
+++ b/latitude_node_test.go
@@ -7,15 +7,13 @@ import (
 )
 
 func TestNewLatitudeNode(t *testing.T) {
-	doc := gedcom.NewDocument()
-	child := gedcom.NewNameNode(doc, "", "", nil)
-	node := gedcom.NewLatitudeNode(doc, "foo", "bar", []gedcom.Node{child})
+	child := gedcom.NewNameNode("")
+	node := gedcom.NewLatitudeNode("foo", child)
 
 	assert.NotNil(t, node)
 	assert.IsType(t, node, (*gedcom.LatitudeNode)(nil))
 	assert.Equal(t, gedcom.TagLatitude, node.Tag())
-	assert.Equal(t, []gedcom.Node{child}, node.Nodes())
-	assert.Equal(t, doc, node.Document())
+	assert.Equal(t, gedcom.Nodes{child}, node.Nodes())
 	assert.Equal(t, "foo", node.Value())
-	assert.Equal(t, "bar", node.Pointer())
+	assert.Equal(t, "", node.Pointer())
 }

--- a/longitude_node.go
+++ b/longitude_node.go
@@ -9,8 +9,8 @@ type LongitudeNode struct {
 }
 
 // NewLongitudeNode creates a new LONG node.
-func NewLongitudeNode(document *Document, value, pointer string, children []Node) *LongitudeNode {
+func NewLongitudeNode(value string, children ...Node) *LongitudeNode {
 	return &LongitudeNode{
-		newSimpleNode(document, TagLongitude, value, pointer, children),
+		newSimpleNode(TagLongitude, value, "", children...),
 	}
 }

--- a/longitude_node_test.go
+++ b/longitude_node_test.go
@@ -7,15 +7,13 @@ import (
 )
 
 func TestNewLongitudeNode(t *testing.T) {
-	doc := gedcom.NewDocument()
-	child := gedcom.NewNameNode(doc, "", "", nil)
-	node := gedcom.NewLongitudeNode(doc, "foo", "bar", []gedcom.Node{child})
+	child := gedcom.NewNameNode("")
+	node := gedcom.NewLongitudeNode("foo", child)
 
 	assert.NotNil(t, node)
 	assert.IsType(t, node, (*gedcom.LongitudeNode)(nil))
 	assert.Equal(t, gedcom.TagLongitude, node.Tag())
-	assert.Equal(t, []gedcom.Node{child}, node.Nodes())
-	assert.Equal(t, doc, node.Document())
+	assert.Equal(t, gedcom.Nodes{child}, node.Nodes())
 	assert.Equal(t, "foo", node.Value())
-	assert.Equal(t, "bar", node.Pointer())
+	assert.Equal(t, "", node.Pointer())
 }

--- a/map_node.go
+++ b/map_node.go
@@ -9,9 +9,9 @@ type MapNode struct {
 }
 
 // NewMapNode creates a new MAP node.
-func NewMapNode(document *Document, value, pointer string, children []Node) *MapNode {
+func NewMapNode(value string, children ...Node) *MapNode {
 	return &MapNode{
-		newSimpleNode(document, TagMap, value, pointer, children),
+		newSimpleNode(TagMap, value, "", children...),
 	}
 }
 

--- a/map_node_test.go
+++ b/map_node_test.go
@@ -7,17 +7,15 @@ import (
 )
 
 func TestNewMapNode(t *testing.T) {
-	doc := gedcom.NewDocument()
-	child := gedcom.NewNameNode(doc, "", "", nil)
-	node := gedcom.NewMapNode(doc, "foo", "bar", []gedcom.Node{child})
+	child := gedcom.NewNameNode("")
+	node := gedcom.NewMapNode("foo", child)
 
 	assert.NotNil(t, node)
 	assert.IsType(t, node, (*gedcom.MapNode)(nil))
 	assert.Equal(t, gedcom.TagMap, node.Tag())
-	assert.Equal(t, []gedcom.Node{child}, node.Nodes())
-	assert.Equal(t, doc, node.Document())
+	assert.Equal(t, gedcom.Nodes{child}, node.Nodes())
 	assert.Equal(t, "foo", node.Value())
-	assert.Equal(t, "bar", node.Pointer())
+	assert.Equal(t, "", node.Pointer())
 }
 
 func TestPlaceNode_Latitude(t *testing.T) {
@@ -31,32 +29,32 @@ func TestPlaceNode_Latitude(t *testing.T) {
 			expected: nil,
 		},
 		{
-			node:     gedcom.NewMapNode(nil, "", "", nil),
+			node:     gedcom.NewMapNode(""),
 			expected: nil,
 		},
 		{
-			node:     gedcom.NewMapNode(nil, "", "", []gedcom.Node{}),
+			node:     gedcom.NewMapNode(""),
 			expected: nil,
 		},
 		{
-			node: gedcom.NewMapNode(nil, "", "", []gedcom.Node{
-				gedcom.NewLatitudeNode(nil, "", "", []gedcom.Node{}),
-			}),
-			expected: gedcom.NewLatitudeNode(nil, "", "", []gedcom.Node{}),
+			node: gedcom.NewMapNode("",
+				gedcom.NewLatitudeNode(""),
+			),
+			expected: gedcom.NewLatitudeNode(""),
 		},
 		{
-			node: gedcom.NewMapNode(nil, "", "", []gedcom.Node{
-				gedcom.NewNameNode(nil, "", "", []gedcom.Node{}),
-			}),
+			node: gedcom.NewMapNode("",
+				gedcom.NewNameNode(""),
+			),
 			expected: nil,
 		},
 		{
-			node: gedcom.NewMapNode(nil, "", "", []gedcom.Node{
-				gedcom.NewNameNode(nil, "", "", []gedcom.Node{}),
-				gedcom.NewLatitudeNode(nil, "1", "", []gedcom.Node{}),
-				gedcom.NewLatitudeNode(nil, "2", "", []gedcom.Node{}),
-			}),
-			expected: gedcom.NewLatitudeNode(nil, "1", "", []gedcom.Node{}),
+			node: gedcom.NewMapNode("",
+				gedcom.NewNameNode(""),
+				gedcom.NewLatitudeNode("1"),
+				gedcom.NewLatitudeNode("2"),
+			),
+			expected: gedcom.NewLatitudeNode("1"),
 		},
 	}
 
@@ -78,32 +76,32 @@ func TestPlaceNode_Longitude(t *testing.T) {
 			expected: nil,
 		},
 		{
-			node:     gedcom.NewMapNode(nil, "", "", nil),
+			node:     gedcom.NewMapNode(""),
 			expected: nil,
 		},
 		{
-			node:     gedcom.NewMapNode(nil, "", "", []gedcom.Node{}),
+			node:     gedcom.NewMapNode(""),
 			expected: nil,
 		},
 		{
-			node: gedcom.NewMapNode(nil, "", "", []gedcom.Node{
-				gedcom.NewLongitudeNode(nil, "", "", []gedcom.Node{}),
-			}),
-			expected: gedcom.NewLongitudeNode(nil, "", "", []gedcom.Node{}),
+			node: gedcom.NewMapNode("",
+				gedcom.NewLongitudeNode(""),
+			),
+			expected: gedcom.NewLongitudeNode(""),
 		},
 		{
-			node: gedcom.NewMapNode(nil, "", "", []gedcom.Node{
-				gedcom.NewNameNode(nil, "", "", []gedcom.Node{}),
-			}),
+			node: gedcom.NewMapNode("",
+				gedcom.NewNameNode(""),
+			),
 			expected: nil,
 		},
 		{
-			node: gedcom.NewMapNode(nil, "", "", []gedcom.Node{
-				gedcom.NewNameNode(nil, "", "", []gedcom.Node{}),
-				gedcom.NewLongitudeNode(nil, "1", "", []gedcom.Node{}),
-				gedcom.NewLongitudeNode(nil, "2", "", []gedcom.Node{}),
-			}),
-			expected: gedcom.NewLongitudeNode(nil, "1", "", []gedcom.Node{}),
+			node: gedcom.NewMapNode("",
+				gedcom.NewNameNode(""),
+				gedcom.NewLongitudeNode("1"),
+				gedcom.NewLongitudeNode("2"),
+			),
+			expected: gedcom.NewLongitudeNode("1"),
 		},
 	}
 

--- a/merge.go
+++ b/merge.go
@@ -5,7 +5,7 @@
 // - MergeNodes(left, right Node) Node: returns a new node that merges children
 // from both nodes.
 //
-// - MergeNodeSlices(left, right []Node, mergeFn MergeFunction) []Node: merges
+// - MergeNodeSlices(left, right Nodes, mergeFn MergeFunction) Nodes: merges
 // two slices based on the mergeFn. This allows more advanced merging when
 // dealing with slices of nodes.
 //
@@ -118,13 +118,13 @@ func MergeNodes(left, right Node) (Node, error) {
 // 5. Merges can only happen between a node on the left with a node on the
 // right. Even if two nodes in the left could be merged they will not be. The
 // same goes for all of the elements in the right slice.
-func MergeNodeSlices(left, right []Node, mergeFn MergeFunction) []Node {
-	newSlice := []Node{}
+func MergeNodeSlices(left, right Nodes, mergeFn MergeFunction) Nodes {
+	newSlice := Nodes{}
 
 	// Be careful to duplicate the right slice. I'm not sure why this is
 	// necessary but the unit tests that reuse mergeDocumentsTests will fail if
 	// we do not have this.
-	newRight := make([]Node, len(right))
+	newRight := make(Nodes, len(right))
 	copy(newRight, right)
 	right = newRight
 
@@ -215,8 +215,16 @@ func MergeNodeSlices(left, right []Node, mergeFn MergeFunction) []Node {
 // Individuals will not be merged amongst each other, only appended to the final
 // document. To merge similar individuals see MergeDocumentsAndIndividuals.
 func MergeDocuments(left, right *Document, mergeFn MergeFunction) *Document {
-	leftNodes := Nodes(left)
-	rightNodes := Nodes(right)
+	var leftNodes, rightNodes Nodes
+
+	if left != nil {
+		leftNodes = left.Nodes()
+	}
+
+	if right != nil {
+		rightNodes = right.Nodes()
+	}
+
 	newNodes := MergeNodeSlices(leftNodes, rightNodes, mergeFn)
 
 	return NewDocumentWithNodes(newNodes)

--- a/merge_test.go
+++ b/merge_test.go
@@ -16,77 +16,77 @@ func TestMergeNodes(t *testing.T) {
 		error                 string
 	}{
 		"1": {
-			left: gedcom.NewBirthNode(doc1, "", "P1", []gedcom.Node{
-				gedcom.NewDateNode(doc1, "3 Sep 1943", "", nil),
-			}),
-			right: gedcom.NewBirthNode(doc2, "", "P2", []gedcom.Node{
-				gedcom.NewDateNode(doc2, "14 Apr 1947", "", nil),
-			}),
-			expected: gedcom.NewBirthNode(doc1, "", "P1", []gedcom.Node{
-				gedcom.NewDateNode(doc1, "3 Sep 1943", "", nil),
-				gedcom.NewDateNode(doc2, "14 Apr 1947", "", nil),
-			}),
+			left: gedcom.NewNode(gedcom.TagBirth, "", "P1",
+				gedcom.NewDateNode("3 Sep 1943"),
+			),
+			right: gedcom.NewNode(gedcom.TagBirth, "", "P2",
+				gedcom.NewDateNode("14 Apr 1947"),
+			),
+			expected: gedcom.NewNode(gedcom.TagBirth, "", "P1",
+				gedcom.NewDateNode("3 Sep 1943"),
+				gedcom.NewDateNode("14 Apr 1947"),
+			),
 		},
 		"2": {
-			left: gedcom.NewBirthNode(doc1, "", "P1", []gedcom.Node{
-				gedcom.NewDateNode(doc1, "3 Sep 1943", "", nil),
-			}),
-			right: gedcom.NewBirthNode(doc1, "", "P1", []gedcom.Node{
-				gedcom.NewDateNode(doc1, "3 Sep 1943", "", nil),
-			}),
-			expected: gedcom.NewBirthNode(doc1, "", "P1", []gedcom.Node{
-				gedcom.NewDateNode(doc1, "3 Sep 1943", "", nil),
-			}),
+			left: gedcom.NewNode(gedcom.TagBirth, "", "P1",
+				gedcom.NewDateNode("3 Sep 1943"),
+			),
+			right: gedcom.NewNode(gedcom.TagBirth, "", "P1",
+				gedcom.NewDateNode("3 Sep 1943"),
+			),
+			expected: gedcom.NewNode(gedcom.TagBirth, "", "P1",
+				gedcom.NewDateNode("3 Sep 1943"),
+			),
 		},
 		"3": {
-			left: gedcom.NewBirthNode(doc1, "", "P1", []gedcom.Node{
-				gedcom.NewDateNode(doc1, "3 Sep 1943", "", nil),
-			}),
-			right: gedcom.NewDateNode(doc1, "3 Sep 1943", "", nil),
+			left: gedcom.NewNode(gedcom.TagBirth, "", "P1",
+				gedcom.NewDateNode("3 Sep 1943"),
+			),
+			right: gedcom.NewDateNode("3 Sep 1943"),
 			error: "cannot merge BIRT and DATE nodes",
 		},
 		"4": {
-			left: gedcom.NewIndividualNode(doc1, "", "P1", []gedcom.Node{
-				gedcom.NewBirthNode(doc1, "", "", []gedcom.Node{
-					gedcom.NewDateNode(doc1, "3 Sep 1943", "", nil),
-				}),
-				gedcom.NewResidenceNode(nil, "", "", []gedcom.Node{
-					gedcom.NewPlaceNode(doc1, "Sydney, Australia", "", nil),
-					gedcom.NewDateNode(doc1, "3 Sep 1943", "", nil),
-				}),
-			}),
-			right: gedcom.NewIndividualNode(doc2, "", "P2", []gedcom.Node{
-				gedcom.NewBirthNode(doc2, "", "", []gedcom.Node{
-					gedcom.NewDateNode(doc2, "14 Apr 1947", "", nil),
-				}),
-				gedcom.NewResidenceNode(nil, "", "", []gedcom.Node{
-					gedcom.NewPlaceNode(doc2, "Queensland, Australia", "", nil),
-				}),
-			}),
-			expected: gedcom.NewIndividualNode(doc1, "", "P1", []gedcom.Node{
-				gedcom.NewBirthNode(doc1, "", "", []gedcom.Node{
-					gedcom.NewDateNode(doc2, "14 Apr 1947", "", nil),
-					gedcom.NewDateNode(doc1, "3 Sep 1943", "", nil),
-				}),
-				gedcom.NewResidenceNode(nil, "", "", []gedcom.Node{
-					gedcom.NewPlaceNode(doc1, "Sydney, Australia", "", nil),
-					gedcom.NewDateNode(doc1, "3 Sep 1943", "", nil),
-				}),
-				gedcom.NewResidenceNode(nil, "", "", []gedcom.Node{
-					gedcom.NewPlaceNode(doc2, "Queensland, Australia", "", nil),
-				}),
-			}),
+			left: doc1.AddIndividual("P1",
+				gedcom.NewBirthNode("",
+					gedcom.NewDateNode("3 Sep 1943"),
+				),
+				gedcom.NewResidenceNode("",
+					gedcom.NewPlaceNode("Sydney, Australia"),
+					gedcom.NewDateNode("3 Sep 1943"),
+				),
+			),
+			right: doc2.AddIndividual("P2",
+				gedcom.NewBirthNode("",
+					gedcom.NewDateNode("14 Apr 1947"),
+				),
+				gedcom.NewResidenceNode("",
+					gedcom.NewPlaceNode("Queensland, Australia"),
+				),
+			),
+			expected: doc1.AddIndividual("P1",
+				gedcom.NewBirthNode("",
+					gedcom.NewDateNode("14 Apr 1947"),
+					gedcom.NewDateNode("3 Sep 1943"),
+				),
+				gedcom.NewResidenceNode("",
+					gedcom.NewPlaceNode("Sydney, Australia"),
+					gedcom.NewDateNode("3 Sep 1943"),
+				),
+				gedcom.NewResidenceNode("",
+					gedcom.NewPlaceNode("Queensland, Australia"),
+				),
+			),
 		},
 		"NilLeft": {
-			right: gedcom.NewBirthNode(doc2, "", "P2", []gedcom.Node{
-				gedcom.NewDateNode(doc2, "14 Apr 1947", "", nil),
-			}),
+			right: gedcom.NewNode(gedcom.TagBirth, "", "P2",
+				gedcom.NewDateNode("14 Apr 1947"),
+			),
 			error: "left is nil",
 		},
 		"NilRight": {
-			left: gedcom.NewBirthNode(doc2, "", "P2", []gedcom.Node{
-				gedcom.NewDateNode(doc2, "14 Apr 1947", "", nil),
-			}),
+			left: gedcom.NewNode(gedcom.TagBirth, "", "P2",
+				gedcom.NewDateNode("14 Apr 1947"),
+			),
 			error: "right is nil",
 		},
 		"NilBoth": {
@@ -98,15 +98,15 @@ func TestMergeNodes(t *testing.T) {
 			expected: elliot,
 		},
 		"EqualNodes": {
-			left: gedcom.NewBirthNode(doc1, "", "P1", []gedcom.Node{
-				gedcom.NewUniqueIDNode(doc1, "EE13561DDB204985BFFDEEBF82A5226C", "", nil),
-			}),
-			right: gedcom.NewBirthNode(doc2, "", "P2", []gedcom.Node{
-				gedcom.NewUniqueIDNode(doc2, "EE13561DDB204985BFFDEEBF82A5226C5B2E", "", nil),
-			}),
-			expected: gedcom.NewBirthNode(doc1, "", "P1", []gedcom.Node{
-				gedcom.NewUniqueIDNode(doc1, "EE13561DDB204985BFFDEEBF82A5226C", "", nil),
-			}),
+			left: gedcom.NewNode(gedcom.TagBirth, "", "P1",
+				gedcom.NewUniqueIDNode("EE13561DDB204985BFFDEEBF82A5226C"),
+			),
+			right: gedcom.NewNode(gedcom.TagBirth, "", "P2",
+				gedcom.NewUniqueIDNode("EE13561DDB204985BFFDEEBF82A5226C5B2E"),
+			),
+			expected: gedcom.NewNode(gedcom.TagBirth, "", "P1",
+				gedcom.NewUniqueIDNode("EE13561DDB204985BFFDEEBF82A5226C"),
+			),
 		},
 	} {
 		t.Run(testName, func(t *testing.T) {
@@ -125,63 +125,60 @@ func TestMergeNodes(t *testing.T) {
 }
 
 func TestMergeNodeSlices(t *testing.T) {
-	doc1 := gedcom.NewDocument()
-	doc2 := gedcom.NewDocument()
-
 	for testName, test := range map[string]struct {
-		left, right, expected []gedcom.Node
+		left, right, expected gedcom.Nodes
 		mergeFn               gedcom.MergeFunction
 	}{
 		"1": {
-			left:  []gedcom.Node{},
-			right: []gedcom.Node{},
+			left:  gedcom.Nodes{},
+			right: gedcom.Nodes{},
 			mergeFn: func(left, right gedcom.Node) gedcom.Node {
 				return nil
 			},
-			expected: []gedcom.Node{},
+			expected: gedcom.Nodes{},
 		},
 		"2": {
-			left: []gedcom.Node{
-				gedcom.NewDateNode(doc1, "3 Sep 1943", "", nil),
+			left: gedcom.Nodes{
+				gedcom.NewDateNode("3 Sep 1943"),
 			},
-			right: []gedcom.Node{
-				gedcom.NewDateNode(doc2, "14 Apr 1947", "", nil),
+			right: gedcom.Nodes{
+				gedcom.NewDateNode("14 Apr 1947"),
 			},
 			mergeFn: func(left, right gedcom.Node) gedcom.Node {
 				return nil
 			},
-			expected: []gedcom.Node{
-				gedcom.NewDateNode(doc1, "3 Sep 1943", "", nil),
-				gedcom.NewDateNode(doc2, "14 Apr 1947", "", nil),
+			expected: gedcom.Nodes{
+				gedcom.NewDateNode("3 Sep 1943"),
+				gedcom.NewDateNode("14 Apr 1947"),
 			},
 		},
 		"3": {
-			left: []gedcom.Node{
-				gedcom.NewDateNode(doc1, "3 Sep 1943", "", nil),
-				gedcom.NewPlaceNode(doc1, "Sydney, Australia", "", nil),
+			left: gedcom.Nodes{
+				gedcom.NewDateNode("3 Sep 1943"),
+				gedcom.NewPlaceNode("Sydney, Australia"),
 			},
-			right: []gedcom.Node{
-				gedcom.NewPlaceNode(doc1, "Queensland, Australia", "", nil),
-				gedcom.NewDateNode(doc2, "14 Apr 1947", "", nil),
+			right: gedcom.Nodes{
+				gedcom.NewPlaceNode("Queensland, Australia"),
+				gedcom.NewDateNode("14 Apr 1947"),
 			},
 			mergeFn: func(left, right gedcom.Node) gedcom.Node {
 				return nil
 			},
-			expected: []gedcom.Node{
-				gedcom.NewDateNode(doc1, "3 Sep 1943", "", nil),
-				gedcom.NewPlaceNode(doc1, "Sydney, Australia", "", nil),
-				gedcom.NewPlaceNode(doc1, "Queensland, Australia", "", nil),
-				gedcom.NewDateNode(doc2, "14 Apr 1947", "", nil),
+			expected: gedcom.Nodes{
+				gedcom.NewDateNode("3 Sep 1943"),
+				gedcom.NewPlaceNode("Sydney, Australia"),
+				gedcom.NewPlaceNode("Queensland, Australia"),
+				gedcom.NewDateNode("14 Apr 1947"),
 			},
 		},
 		"4": {
-			left: []gedcom.Node{
-				gedcom.NewDateNode(doc1, "3 Sep 1943", "", nil),
-				gedcom.NewPlaceNode(doc1, "Sydney, Australia", "", nil),
+			left: gedcom.Nodes{
+				gedcom.NewDateNode("3 Sep 1943"),
+				gedcom.NewPlaceNode("Sydney, Australia"),
 			},
-			right: []gedcom.Node{
-				gedcom.NewPlaceNode(doc1, "Queensland, Australia", "", nil),
-				gedcom.NewDateNode(doc2, "14 Apr 1947", "", nil),
+			right: gedcom.Nodes{
+				gedcom.NewPlaceNode("Queensland, Australia"),
+				gedcom.NewDateNode("14 Apr 1947"),
 			},
 			mergeFn: func(left, right gedcom.Node) gedcom.Node {
 				if left.Tag().Is(right.Tag()) {
@@ -190,63 +187,63 @@ func TestMergeNodeSlices(t *testing.T) {
 
 				return nil
 			},
-			expected: []gedcom.Node{
-				gedcom.NewDateNode(doc2, "3 Sep 1943", "", nil),
-				gedcom.NewPlaceNode(doc1, "Sydney, Australia", "", nil),
+			expected: gedcom.Nodes{
+				gedcom.NewDateNode("3 Sep 1943"),
+				gedcom.NewPlaceNode("Sydney, Australia"),
 			},
 		},
 		"5": {
 			// This test is to make sure the nodes from the right are not merged
 			// more than into either a left node or a node already placed from
 			// the right.
-			left: []gedcom.Node{
-				gedcom.NewDateNode(doc1, "3 Sep 1943", "", nil),
+			left: gedcom.Nodes{
+				gedcom.NewDateNode("3 Sep 1943"),
 			},
-			right: []gedcom.Node{
-				gedcom.NewDateNode(doc2, "14 Apr 1947", "", nil),
-				gedcom.NewDateNode(doc2, "15 Apr 1947", "", nil),
-				gedcom.NewDateNode(doc2, "16 Apr 1947", "", nil),
+			right: gedcom.Nodes{
+				gedcom.NewDateNode("14 Apr 1947"),
+				gedcom.NewDateNode("15 Apr 1947"),
+				gedcom.NewDateNode("16 Apr 1947"),
 			},
 			mergeFn: func(left, right gedcom.Node) gedcom.Node {
 				// Always consider it a merge.
 				return left.ShallowCopy()
 			},
-			expected: []gedcom.Node{
+			expected: gedcom.Nodes{
 				// 14 Apr 1947 was merged into 3 Sep 1943. The rest would be
 				// appended.
-				gedcom.NewDateNode(doc2, "3 Sep 1943", "", nil),
-				gedcom.NewDateNode(doc2, "15 Apr 1947", "", nil),
-				gedcom.NewDateNode(doc2, "16 Apr 1947", "", nil),
+				gedcom.NewDateNode("3 Sep 1943"),
+				gedcom.NewDateNode("15 Apr 1947"),
+				gedcom.NewDateNode("16 Apr 1947"),
 			},
 		},
 		"LeftNil": {
-			right: []gedcom.Node{
-				gedcom.NewDateNode(doc2, "14 Apr 1947", "", nil),
-				gedcom.NewDateNode(doc2, "15 Apr 1947", "", nil),
-				gedcom.NewDateNode(doc2, "16 Apr 1947", "", nil),
+			right: gedcom.Nodes{
+				gedcom.NewDateNode("14 Apr 1947"),
+				gedcom.NewDateNode("15 Apr 1947"),
+				gedcom.NewDateNode("16 Apr 1947"),
 			},
 			mergeFn: func(left, right gedcom.Node) gedcom.Node {
 				return nil
 			},
-			expected: []gedcom.Node{
-				gedcom.NewDateNode(doc2, "14 Apr 1947", "", nil),
-				gedcom.NewDateNode(doc2, "15 Apr 1947", "", nil),
-				gedcom.NewDateNode(doc2, "16 Apr 1947", "", nil),
+			expected: gedcom.Nodes{
+				gedcom.NewDateNode("14 Apr 1947"),
+				gedcom.NewDateNode("15 Apr 1947"),
+				gedcom.NewDateNode("16 Apr 1947"),
 			},
 		},
 		"RightNil": {
-			left: []gedcom.Node{
-				gedcom.NewDateNode(doc2, "14 Apr 1947", "", nil),
-				gedcom.NewDateNode(doc2, "15 Apr 1947", "", nil),
-				gedcom.NewDateNode(doc2, "16 Apr 1947", "", nil),
+			left: gedcom.Nodes{
+				gedcom.NewDateNode("14 Apr 1947"),
+				gedcom.NewDateNode("15 Apr 1947"),
+				gedcom.NewDateNode("16 Apr 1947"),
 			},
 			mergeFn: func(left, right gedcom.Node) gedcom.Node {
 				return nil
 			},
-			expected: []gedcom.Node{
-				gedcom.NewDateNode(doc2, "14 Apr 1947", "", nil),
-				gedcom.NewDateNode(doc2, "15 Apr 1947", "", nil),
-				gedcom.NewDateNode(doc2, "16 Apr 1947", "", nil),
+			expected: gedcom.Nodes{
+				gedcom.NewDateNode("14 Apr 1947"),
+				gedcom.NewDateNode("15 Apr 1947"),
+				gedcom.NewDateNode("16 Apr 1947"),
 			},
 		},
 		"BothNil": {
@@ -297,38 +294,38 @@ var mergeDocumentsTests = map[string]struct {
 		expectedDocAndIndividuals: gedcom.NewDocument(),
 	},
 	"Merge1": {
-		left: gedcom.NewDocumentWithNodes([]gedcom.Node{
-			gedcom.NewDateNode(nil, "3 Sep 1943", "", nil),
-			gedcom.NewPlaceNode(nil, "Sydney, Australia", "", nil),
+		left: gedcom.NewDocumentWithNodes(gedcom.Nodes{
+			gedcom.NewDateNode("3 Sep 1943"),
+			gedcom.NewPlaceNode("Sydney, Australia"),
 		}),
-		right: gedcom.NewDocumentWithNodes([]gedcom.Node{
-			gedcom.NewPlaceNode(nil, "Queensland, Australia", "", nil),
-			gedcom.NewDateNode(nil, "14 Apr 1947", "", nil),
+		right: gedcom.NewDocumentWithNodes(gedcom.Nodes{
+			gedcom.NewPlaceNode("Queensland, Australia"),
+			gedcom.NewDateNode("14 Apr 1947"),
 		}),
 		mergeFn: func(left, right gedcom.Node) gedcom.Node {
 			return nil
 		},
-		expectedDoc: gedcom.NewDocumentWithNodes([]gedcom.Node{
-			gedcom.NewDateNode(nil, "3 Sep 1943", "", nil),
-			gedcom.NewPlaceNode(nil, "Sydney, Australia", "", nil),
-			gedcom.NewPlaceNode(nil, "Queensland, Australia", "", nil),
-			gedcom.NewDateNode(nil, "14 Apr 1947", "", nil),
+		expectedDoc: gedcom.NewDocumentWithNodes(gedcom.Nodes{
+			gedcom.NewDateNode("3 Sep 1943"),
+			gedcom.NewPlaceNode("Sydney, Australia"),
+			gedcom.NewPlaceNode("Queensland, Australia"),
+			gedcom.NewDateNode("14 Apr 1947"),
 		}),
-		expectedDocAndIndividuals: gedcom.NewDocumentWithNodes([]gedcom.Node{
-			gedcom.NewDateNode(nil, "3 Sep 1943", "", nil),
-			gedcom.NewPlaceNode(nil, "Sydney, Australia", "", nil),
-			gedcom.NewPlaceNode(nil, "Queensland, Australia", "", nil),
-			gedcom.NewDateNode(nil, "14 Apr 1947", "", nil),
+		expectedDocAndIndividuals: gedcom.NewDocumentWithNodes(gedcom.Nodes{
+			gedcom.NewDateNode("3 Sep 1943"),
+			gedcom.NewPlaceNode("Sydney, Australia"),
+			gedcom.NewPlaceNode("Queensland, Australia"),
+			gedcom.NewDateNode("14 Apr 1947"),
 		}),
 	},
 	"Merge2": {
-		left: gedcom.NewDocumentWithNodes([]gedcom.Node{
-			gedcom.NewDateNode(nil, "3 Sep 1943", "", nil),
-			gedcom.NewPlaceNode(nil, "Sydney, Australia", "", nil),
+		left: gedcom.NewDocumentWithNodes(gedcom.Nodes{
+			gedcom.NewDateNode("3 Sep 1943"),
+			gedcom.NewPlaceNode("Sydney, Australia"),
 		}),
-		right: gedcom.NewDocumentWithNodes([]gedcom.Node{
-			gedcom.NewPlaceNode(nil, "Queensland, Australia", "", nil),
-			gedcom.NewDateNode(nil, "14 Apr 1947", "", nil),
+		right: gedcom.NewDocumentWithNodes(gedcom.Nodes{
+			gedcom.NewPlaceNode("Queensland, Australia"),
+			gedcom.NewDateNode("14 Apr 1947"),
 		}),
 		mergeFn: func(left, right gedcom.Node) gedcom.Node {
 			if left.Tag().Is(right.Tag()) {
@@ -337,83 +334,83 @@ var mergeDocumentsTests = map[string]struct {
 
 			return nil
 		},
-		expectedDoc: gedcom.NewDocumentWithNodes([]gedcom.Node{
-			gedcom.NewDateNode(nil, "3 Sep 1943", "", nil),
-			gedcom.NewPlaceNode(nil, "Sydney, Australia", "", nil),
+		expectedDoc: gedcom.NewDocumentWithNodes(gedcom.Nodes{
+			gedcom.NewDateNode("3 Sep 1943"),
+			gedcom.NewPlaceNode("Sydney, Australia"),
 		}),
-		expectedDocAndIndividuals: gedcom.NewDocumentWithNodes([]gedcom.Node{
-			gedcom.NewDateNode(nil, "3 Sep 1943", "", nil),
-			gedcom.NewPlaceNode(nil, "Sydney, Australia", "", nil),
+		expectedDocAndIndividuals: gedcom.NewDocumentWithNodes(gedcom.Nodes{
+			gedcom.NewDateNode("3 Sep 1943"),
+			gedcom.NewPlaceNode("Sydney, Australia"),
 		}),
 	},
 	"Merge3": {
-		left: gedcom.NewDocumentWithNodes([]gedcom.Node{
+		left: gedcom.NewDocumentWithNodes(gedcom.Nodes{
 			elliot,
-			gedcom.NewDateNode(nil, "3 Sep 1943", "", nil),
-			gedcom.NewPlaceNode(nil, "Sydney, Australia", "", nil),
+			gedcom.NewDateNode("3 Sep 1943"),
+			gedcom.NewPlaceNode("Sydney, Australia"),
 			jane,
 		}),
-		right: gedcom.NewDocumentWithNodes([]gedcom.Node{
-			gedcom.NewPlaceNode(nil, "Sydney, Australia", "", nil),
+		right: gedcom.NewDocumentWithNodes(gedcom.Nodes{
+			gedcom.NewPlaceNode("Sydney, Australia"),
 			jane,
 			john,
-			gedcom.NewDateNode(nil, "3 Sep 1943", "", nil),
+			gedcom.NewDateNode("3 Sep 1943"),
 		}),
 		mergeFn: gedcom.EqualityMergeFunction,
-		expectedDoc: gedcom.NewDocumentWithNodes([]gedcom.Node{
+		expectedDoc: gedcom.NewDocumentWithNodes(gedcom.Nodes{
 			elliot,
-			gedcom.NewDateNode(nil, "3 Sep 1943", "", nil),
+			gedcom.NewDateNode("3 Sep 1943"),
 			jane,
-			gedcom.NewPlaceNode(nil, "Sydney, Australia", "", nil),
+			gedcom.NewPlaceNode("Sydney, Australia"),
 			john,
 		}),
 		minimumSimilarity: 0.1,
-		expectedDocAndIndividuals: gedcom.NewDocumentWithNodes([]gedcom.Node{
+		expectedDocAndIndividuals: gedcom.NewDocumentWithNodes(gedcom.Nodes{
 			jane,
-			gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewNameNode(nil, "Elliot /Chance/", "", nil),
-				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{
-					gedcom.NewDateNode(nil, "4 Jan 1803", "", nil), // john
-					gedcom.NewDateNode(nil, "4 Jan 1843", "", nil), // elliot
-				}),
-				gedcom.NewDeathNode(nil, "", "", []gedcom.Node{
-					gedcom.NewDateNode(nil, "17 Mar 1877", "", nil), // john
-					gedcom.NewDateNode(nil, "17 Mar 1907", "", nil), // elliot
-				}),
-				gedcom.NewNameNode(nil, "John /Smith/", "", nil),
-			}),
-			gedcom.NewDateNode(nil, "3 Sep 1943", "", nil),
-			gedcom.NewPlaceNode(nil, "Sydney, Australia", "", nil),
+			gedcom.NewDocument().AddIndividual("P1",
+				gedcom.NewNameNode("Elliot /Chance/"),
+				gedcom.NewBirthNode("",
+					gedcom.NewDateNode("4 Jan 1803"), // john
+					gedcom.NewDateNode("4 Jan 1843"), // elliot
+				),
+				gedcom.NewDeathNode("",
+					gedcom.NewDateNode("17 Mar 1877"), // john
+					gedcom.NewDateNode("17 Mar 1907"), // elliot
+				),
+				gedcom.NewNameNode("John /Smith/"),
+			),
+			gedcom.NewDateNode("3 Sep 1943"),
+			gedcom.NewPlaceNode("Sydney, Australia"),
 		}),
 	},
 	"Merge4": {
-		left: gedcom.NewDocumentWithNodes([]gedcom.Node{
+		left: gedcom.NewDocumentWithNodes(gedcom.Nodes{
 			elliot,
-			gedcom.NewDateNode(nil, "3 Sep 1943", "", nil),
-			gedcom.NewPlaceNode(nil, "Sydney, Australia", "", nil),
+			gedcom.NewDateNode("3 Sep 1943"),
+			gedcom.NewPlaceNode("Sydney, Australia"),
 			jane,
 		}),
-		right: gedcom.NewDocumentWithNodes([]gedcom.Node{
-			gedcom.NewPlaceNode(nil, "Sydney, Australia", "", nil),
+		right: gedcom.NewDocumentWithNodes(gedcom.Nodes{
+			gedcom.NewPlaceNode("Sydney, Australia"),
 			jane,
 			john,
-			gedcom.NewDateNode(nil, "3 Sep 1943", "", nil),
+			gedcom.NewDateNode("3 Sep 1943"),
 		}),
 		mergeFn:           gedcom.EqualityMergeFunction,
 		minimumSimilarity: 0.9,
-		expectedDoc: gedcom.NewDocumentWithNodes([]gedcom.Node{
+		expectedDoc: gedcom.NewDocumentWithNodes(gedcom.Nodes{
 			elliot,
-			gedcom.NewDateNode(nil, "3 Sep 1943", "", nil),
+			gedcom.NewDateNode("3 Sep 1943"),
 			jane,
-			gedcom.NewPlaceNode(nil, "Sydney, Australia", "", nil),
+			gedcom.NewPlaceNode("Sydney, Australia"),
 			john,
 		}),
-		expectedDocAndIndividuals: gedcom.NewDocumentWithNodes([]gedcom.Node{
+		expectedDocAndIndividuals: gedcom.NewDocumentWithNodes(gedcom.Nodes{
 			jane,
 			elliot,
 			john,
-			gedcom.NewDateNode(nil, "3 Sep 1943", "", nil),
-			gedcom.NewPlaceNode(nil, "Sydney, Australia", "", nil),
+			gedcom.NewDateNode("3 Sep 1943"),
+			gedcom.NewPlaceNode("Sydney, Australia"),
 		}),
 	},
 }
@@ -447,46 +444,46 @@ func TestIndividualBySurroundingSimilarityMergeFunction(t *testing.T) {
 		similarity float64
 	}{
 		"LeftIsNotIndividual": {
-			left:  gedcom.NewPlaceNode(nil, "Queensland, Australia", "", nil),
-			right: gedcom.NewIndividualNode(nil, "", "", nil),
+			left:  gedcom.NewPlaceNode("Queensland, Australia"),
+			right: gedcom.NewDocument().AddIndividual(""),
 		},
 		"RightIsNotIndividual": {
-			left:  gedcom.NewIndividualNode(nil, "", "", nil),
-			right: gedcom.NewPlaceNode(nil, "Queensland, Australia", "", nil),
+			left:  gedcom.NewDocument().AddIndividual(""),
+			right: gedcom.NewPlaceNode("Queensland, Australia"),
 		},
 		"BothAreNotIndividuals": {
-			left:  gedcom.NewPlaceNode(nil, "Queensland, Australia", "", nil),
-			right: gedcom.NewPlaceNode(nil, "Queensland, Australia", "", nil),
+			left:  gedcom.NewPlaceNode("Queensland, Australia"),
+			right: gedcom.NewPlaceNode("Queensland, Australia"),
 		},
 		"MergeAlmostExact": {
-			left: gedcom.NewIndividualNode(doc, "", "", []gedcom.Node{
-				gedcom.NewNameNode(doc, "Elliot /Chance/", "", nil),
-				gedcom.NewBirthNode(doc, "", "", []gedcom.Node{
-					gedcom.NewDateNode(doc, "3 Sep 1943", "", nil),
-				}),
-			}),
-			right: gedcom.NewIndividualNode(doc, "", "", []gedcom.Node{
-				gedcom.NewNameNode(doc, "Elliot /Chance/", "", nil),
-				gedcom.NewBirthNode(doc, "", "", []gedcom.Node{
-					gedcom.NewDateNode(doc, "7 Sep 1943", "", nil),
-				}),
-			}),
+			left: doc.AddIndividual("",
+				gedcom.NewNameNode("Elliot /Chance/"),
+				gedcom.NewBirthNode("",
+					gedcom.NewDateNode("3 Sep 1943"),
+				),
+			),
+			right: doc.AddIndividual("",
+				gedcom.NewNameNode("Elliot /Chance/"),
+				gedcom.NewBirthNode("",
+					gedcom.NewDateNode("7 Sep 1943"),
+				),
+			),
 			similarity: 0.8666640123954465,
-			expected: gedcom.NewIndividualNode(doc, "", "", []gedcom.Node{
-				gedcom.NewNameNode(doc, "Elliot /Chance/", "", nil),
-				gedcom.NewBirthNode(doc, "", "", []gedcom.Node{
-					gedcom.NewDateNode(doc, "3 Sep 1943", "", nil),
-					gedcom.NewDateNode(doc, "7 Sep 1943", "", nil),
-				}),
-			}),
+			expected: doc.AddIndividual("",
+				gedcom.NewNameNode("Elliot /Chance/"),
+				gedcom.NewBirthNode("",
+					gedcom.NewDateNode("3 Sep 1943"),
+					gedcom.NewDateNode("7 Sep 1943"),
+				),
+			),
 		},
 		"MergeNotSimilar": {
-			left: gedcom.NewIndividualNode(doc, "", "", []gedcom.Node{
-				gedcom.NewNameNode(doc, "John /Smith/", "", nil),
-			}),
-			right: gedcom.NewIndividualNode(doc, "", "", []gedcom.Node{
-				gedcom.NewNameNode(doc, "Jane /Doe/", "", nil),
-			}),
+			left: doc.AddIndividual("",
+				gedcom.NewNameNode("John /Smith/"),
+			),
+			right: doc.AddIndividual("",
+				gedcom.NewNameNode("Jane /Doe/"),
+			),
 
 			// It would be 0.6253333333333334. However, because its below the
 			// minimum threshold it doesn't bother calculating the real value.
@@ -515,24 +512,10 @@ func TestIndividualBySurroundingSimilarityMergeFunction(t *testing.T) {
 }
 
 func TestMergeDocumentsAndIndividuals(t *testing.T) {
-	doc := gedcom.NewDocument()
-
 	for testName, test := range mergeDocumentsTests {
 		t.Run(testName, func(t *testing.T) {
 			beforeLeft := test.left.String()
 			beforeRight := test.right.String()
-
-			if test.left != nil {
-				for _, n := range test.left.Nodes() {
-					n.SetDocument(doc)
-				}
-			}
-
-			if test.right != nil {
-				for _, n := range test.right.Nodes() {
-					n.SetDocument(doc)
-				}
-			}
 
 			options := gedcom.NewIndividualNodesCompareOptions()
 			options.SimilarityOptions.MinimumWeightedSimilarity = test.minimumSimilarity

--- a/name_node.go
+++ b/name_node.go
@@ -12,9 +12,9 @@ type NameNode struct {
 	*SimpleNode
 }
 
-func NewNameNode(document *Document, value, pointer string, children []Node) *NameNode {
+func NewNameNode(value string, children ...Node) *NameNode {
 	return &NameNode{
-		newSimpleNode(document, TagName, value, pointer, children),
+		newSimpleNode(TagName, value, "", children...),
 	}
 }
 

--- a/name_node_test.go
+++ b/name_node_test.go
@@ -31,7 +31,7 @@ var nameTests = []struct {
 		gedcomName:    "",
 	},
 	{
-		node:          gedcom.NewNameNode(nil, "", "", nil),
+		node:          gedcom.NewNameNode(""),
 		title:         "",
 		prefix:        "",
 		givenName:     "",
@@ -42,7 +42,7 @@ var nameTests = []struct {
 		gedcomName:    "",
 	},
 	{
-		node:          gedcom.NewNameNode(nil, "/Double  Last/", "", nil),
+		node:          gedcom.NewNameNode("/Double  Last/"),
 		title:         "",
 		prefix:        "",
 		givenName:     "",
@@ -53,7 +53,7 @@ var nameTests = []struct {
 		gedcomName:    "/Double Last/",
 	},
 	{
-		node:          gedcom.NewNameNode(nil, "//", "", nil),
+		node:          gedcom.NewNameNode("//"),
 		title:         "",
 		prefix:        "",
 		givenName:     "",
@@ -66,7 +66,7 @@ var nameTests = []struct {
 	{
 		// This is an invalid case. I don't mind that the data returned seems
 		// garbled. It's better than nothing.
-		node:          gedcom.NewNameNode(nil, "a / b", "", nil),
+		node:          gedcom.NewNameNode("a / b"),
 		title:         "",
 		prefix:        "",
 		givenName:     "a",
@@ -77,7 +77,7 @@ var nameTests = []struct {
 		gedcomName:    "a / b",
 	},
 	{
-		node:          gedcom.NewNameNode(nil, "Double First", "", nil),
+		node:          gedcom.NewNameNode("Double First"),
 		title:         "",
 		prefix:        "",
 		givenName:     "Double First",
@@ -88,7 +88,7 @@ var nameTests = []struct {
 		gedcomName:    "Double First",
 	},
 	{
-		node:          gedcom.NewNameNode(nil, "First /Last/", "", nil),
+		node:          gedcom.NewNameNode("First /Last/"),
 		title:         "",
 		prefix:        "",
 		givenName:     "First",
@@ -99,7 +99,7 @@ var nameTests = []struct {
 		gedcomName:    "First /Last/",
 	},
 	{
-		node:          gedcom.NewNameNode(nil, "First   Middle /Last/", "", nil),
+		node:          gedcom.NewNameNode("First   Middle /Last/"),
 		title:         "",
 		prefix:        "",
 		givenName:     "First Middle",
@@ -110,7 +110,7 @@ var nameTests = []struct {
 		gedcomName:    "First Middle /Last/",
 	},
 	{
-		node:          gedcom.NewNameNode(nil, "First /Last/  Suffix ", "", nil),
+		node:          gedcom.NewNameNode("First /Last/  Suffix "),
 		title:         "",
 		prefix:        "",
 		givenName:     "First",
@@ -121,7 +121,7 @@ var nameTests = []struct {
 		gedcomName:    "First /Last/ Suffix",
 	},
 	{
-		node:          gedcom.NewNameNode(nil, "   /Last/ Suffix", "", nil),
+		node:          gedcom.NewNameNode("   /Last/ Suffix"),
 		title:         "",
 		prefix:        "",
 		givenName:     "",
@@ -134,10 +134,10 @@ var nameTests = []struct {
 	{
 		// The GivenName overrides the givenName name if provided. When multiple
 		// GivenNames are provided then it will always use the first one.
-		node: gedcom.NewNameNode(nil, "First /Last/ II", "", []gedcom.Node{
-			gedcom.NewNodeWithChildren(nil, gedcom.TagGivenName, " Other  Name ", "", nil),
-			gedcom.NewNodeWithChildren(nil, gedcom.TagGivenName, "Uh-oh", "", nil),
-		}),
+		node: gedcom.NewNameNode("First /Last/ II",
+			gedcom.NewNode(gedcom.TagGivenName, " Other  Name ", ""),
+			gedcom.NewNode(gedcom.TagGivenName, "Uh-oh", ""),
+		),
 		title:         "",
 		prefix:        "",
 		givenName:     "Other Name",
@@ -150,10 +150,10 @@ var nameTests = []struct {
 	{
 		// The Surname overrides the surname name if provided. When multiple
 		// Surnames are provided then it will always use the first one.
-		node: gedcom.NewNameNode(nil, "First /Last/ II", "", []gedcom.Node{
-			gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, " Other  name ", "", nil),
-			gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, "uh-oh", "", nil),
-		}),
+		node: gedcom.NewNameNode("First /Last/ II",
+			gedcom.NewNode(gedcom.TagSurname, " Other  name ", ""),
+			gedcom.NewNode(gedcom.TagSurname, "uh-oh", ""),
+		),
 		title:         "",
 		prefix:        "",
 		givenName:     "First",
@@ -164,10 +164,10 @@ var nameTests = []struct {
 		gedcomName:    "First /Other name/ II",
 	},
 	{
-		node: gedcom.NewNameNode(nil, "First /Last/ Esq.", "", []gedcom.Node{
-			gedcom.NewNodeWithChildren(nil, gedcom.TagNamePrefix, " Mr ", "", nil),
-			gedcom.NewNodeWithChildren(nil, gedcom.TagNamePrefix, "Dr", "", nil),
-		}),
+		node: gedcom.NewNameNode("First /Last/ Esq.",
+			gedcom.NewNode(gedcom.TagNamePrefix, " Mr ", ""),
+			gedcom.NewNode(gedcom.TagNamePrefix, "Dr", ""),
+		),
 		title:         "",
 		prefix:        "Mr",
 		givenName:     "First",
@@ -181,11 +181,11 @@ var nameTests = []struct {
 		// The NameSuffix overrides the suffix in the name if provided.
 		// When multiple name suffixes are provided then it will always use the
 		// first one.
-		node: gedcom.NewNameNode(nil, "First /Last/ Suffix", "", []gedcom.Node{
-			gedcom.NewNodeWithChildren(nil, gedcom.TagNameSuffix, " Esq. ", "", nil),
-			gedcom.NewNodeWithChildren(nil, gedcom.TagNameSuffix, "Dr", "", nil),
-			gedcom.NewNodeWithChildren(nil, gedcom.TagNamePrefix, "Sir", "", nil),
-		}),
+		node: gedcom.NewNameNode("First /Last/ Suffix",
+			gedcom.NewNode(gedcom.TagNameSuffix, " Esq. ", ""),
+			gedcom.NewNode(gedcom.TagNameSuffix, "Dr", ""),
+			gedcom.NewNode(gedcom.TagNamePrefix, "Sir", ""),
+		),
 		title:         "",
 		prefix:        "Sir",
 		givenName:     "First",
@@ -196,10 +196,10 @@ var nameTests = []struct {
 		gedcomName:    "Sir First /Last/ Esq.",
 	},
 	{
-		node: gedcom.NewNameNode(nil, "First /Last/ Esq.", "", []gedcom.Node{
-			gedcom.NewNodeWithChildren(nil, gedcom.TagSurnamePrefix, " Foo ", "", nil),
-			gedcom.NewNodeWithChildren(nil, gedcom.TagSurnamePrefix, "Bar", "", nil),
-		}),
+		node: gedcom.NewNameNode("First /Last/ Esq.",
+			gedcom.NewNode(gedcom.TagSurnamePrefix, " Foo ", ""),
+			gedcom.NewNode(gedcom.TagSurnamePrefix, "Bar", ""),
+		),
 		title:         "",
 		prefix:        "",
 		givenName:     "First",
@@ -210,10 +210,10 @@ var nameTests = []struct {
 		gedcomName:    "First Foo /Last/ Esq.",
 	},
 	{
-		node: gedcom.NewNameNode(nil, "First /Last/ Esq.", "", []gedcom.Node{
-			gedcom.NewNodeWithChildren(nil, gedcom.TagTitle, " Grand  Duke ", "", nil),
-			gedcom.NewNodeWithChildren(nil, gedcom.TagTitle, "Nobody", "", nil),
-		}),
+		node: gedcom.NewNameNode("First /Last/ Esq.",
+			gedcom.NewNode(gedcom.TagTitle, " Grand  Duke ", ""),
+			gedcom.NewNode(gedcom.TagTitle, "Nobody", ""),
+		),
 		title:         "Grand Duke",
 		prefix:        "",
 		givenName:     "First",
@@ -301,14 +301,14 @@ func TestNameNode_Format(t *testing.T) {
 	Format(nil, "").Returns("")
 	Format(nil, "%f %l").Returns("")
 
-	name := gedcom.NewNameNode(nil, "", "", []gedcom.Node{
-		gedcom.NewNodeWithChildren(nil, gedcom.TagGivenName, "Given", "", nil),
-		gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, "Surname", "", nil),
-		gedcom.NewNodeWithChildren(nil, gedcom.TagNamePrefix, "Prefix", "", nil),
-		gedcom.NewNodeWithChildren(nil, gedcom.TagNameSuffix, "Suffix", "", nil),
-		gedcom.NewNodeWithChildren(nil, gedcom.TagSurnamePrefix, "SurnamePrefix", "", nil),
-		gedcom.NewNodeWithChildren(nil, gedcom.TagTitle, "Title", "", nil),
-	})
+	name := gedcom.NewNameNode("",
+		gedcom.NewNode(gedcom.TagGivenName, "Given", ""),
+		gedcom.NewNode(gedcom.TagSurname, "Surname", ""),
+		gedcom.NewNode(gedcom.TagNamePrefix, "Prefix", ""),
+		gedcom.NewNode(gedcom.TagNameSuffix, "Suffix", ""),
+		gedcom.NewNode(gedcom.TagSurnamePrefix, "SurnamePrefix", ""),
+		gedcom.NewNode(gedcom.TagTitle, "Title", ""),
+	)
 
 	Format(name, "").Returns("")
 	Format(name, "%").Returns("%")
@@ -338,7 +338,7 @@ func TestNameNode_Format(t *testing.T) {
 	Format(name, gedcom.NameFormatGEDCOM).Returns("Title Prefix Given SurnamePrefix /Surname/ Suffix")
 	Format(name, gedcom.NameFormatIndex).Returns("SurnamePrefix Surname, Title Prefix Given Suffix")
 
-	name = gedcom.NewNameNode(nil, "Bob /Smith/", "", nil)
+	name = gedcom.NewNameNode("Bob /Smith/")
 
 	Format(name, "%f %L").Returns("Bob SMITH")
 	Format(name, "%f%L").Returns("BobSMITH")

--- a/nickname_node.go
+++ b/nickname_node.go
@@ -7,8 +7,8 @@ type NicknameNode struct {
 }
 
 // NewNicknameNode creates a new NICK node.
-func NewNicknameNode(document *Document, value, pointer string, children []Node) *NicknameNode {
+func NewNicknameNode(value string, children ...Node) *NicknameNode {
 	return &NicknameNode{
-		newSimpleNode(document, TagNickname, value, pointer, children),
+		newSimpleNode(TagNickname, value, "", children...),
 	}
 }

--- a/nickname_node_test.go
+++ b/nickname_node_test.go
@@ -7,15 +7,13 @@ import (
 )
 
 func TestNewNicknameNode(t *testing.T) {
-	doc := gedcom.NewDocument()
-	child := gedcom.NewNameNode(doc, "", "", nil)
-	node := gedcom.NewNicknameNode(doc, "foo", "bar", []gedcom.Node{child})
+	child := gedcom.NewNameNode("")
+	node := gedcom.NewNicknameNode("foo", child)
 
 	assert.NotNil(t, node)
 	assert.IsType(t, node, (*gedcom.NicknameNode)(nil))
 	assert.Equal(t, gedcom.TagNickname, node.Tag())
-	assert.Equal(t, []gedcom.Node{child}, node.Nodes())
-	assert.Equal(t, doc, node.Document())
+	assert.Equal(t, gedcom.Nodes{child}, node.Nodes())
 	assert.Equal(t, "foo", node.Value())
-	assert.Equal(t, "bar", node.Pointer())
+	assert.Equal(t, "", node.Pointer())
 }

--- a/node.go
+++ b/node.go
@@ -24,13 +24,10 @@ type Node interface {
 	GEDCOMStringer
 
 	// The node itself.
+	RawSimpleNode() *SimpleNode
 	Tag() Tag
 	Value() string
 	Pointer() string
-
-	// Document.
-	Document() *Document
-	SetDocument(document *Document)
 
 	// Equals performs a shallow comparison between two nodes.
 	//

--- a/node_diff_test.go
+++ b/node_diff_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func parse(s ...string) []gedcom.Node {
+func parse(s ...string) gedcom.Nodes {
 	doc, err := gedcom.NewDocumentFromString(strings.Join(s, "\n"))
 	if err != nil {
 		panic(err)
@@ -273,8 +273,8 @@ func TestCompareNodes(t *testing.T) {
 
 func TestNodeDiff_IsDeepEqual(t *testing.T) {
 	d := &gedcom.NodeDiff{
-		Left:  parse("0 INDI @P3@")[0],
-		Right: parse("0 INDI @P3@")[0],
+		Left:  parse("0 @P3@ INDI")[0],
+		Right: parse("0 @P3@ INDI")[0],
 		Children: []*gedcom.NodeDiff{
 			{
 				Left:  parse("0 NAME John /Smith/")[0],
@@ -313,7 +313,7 @@ func TestNodeDiff_IsDeepEqual(t *testing.T) {
 	}
 
 	assert.Equal(t, strings.TrimSpace(`
-LR 0 INDI @P3@
+LR 0 @P3@ INDI
 LR 1 NAME John /Smith/
 LR 1 BIRT
 L  2 DATE Abt. Oct 1943
@@ -329,7 +329,7 @@ LR 2 PLAC England
 		nd       *gedcom.NodeDiff
 		expected bool
 	}{
-		{"LR 0 INDI @P3@", d, false},
+		{"LR 0 @P3@ INDI", d, false},
 		{"LR 0 NAME John /Smith/", d.Children[0], true},
 
 		{"LR 0 BIRT", d.Children[1], false},
@@ -354,8 +354,8 @@ LR 2 PLAC England
 
 func TestNodeDiff_Sort(t *testing.T) {
 	d := &gedcom.NodeDiff{
-		Left:  parse("0 INDI @P3@")[0],
-		Right: parse("0 INDI @P3@")[0],
+		Left:  parse("0 @P3@ INDI")[0],
+		Right: parse("0 @P3@ INDI")[0],
 		Children: []*gedcom.NodeDiff{
 			{
 				Left:  parse("0 BURI")[0],
@@ -421,7 +421,7 @@ func TestNodeDiff_Sort(t *testing.T) {
 	}
 
 	assert.Equal(t, strings.TrimSpace(`
-LR 0 INDI @P3@
+LR 0 @P3@ INDI
 LR 1 BURI
 L  2 DATE Abt. 1943
 L  1 NAME John /Smith/
@@ -441,7 +441,7 @@ L  2 DATE Aft. Sep 1920`), d.String())
 	d.Sort()
 
 	assert.Equal(t, strings.TrimSpace(`
-LR 0 INDI @P3@
+LR 0 @P3@ INDI
 L  1 NAME John /Smith/
  R 1 NAME John R /Smith/
 L  1 SEX M
@@ -461,8 +461,8 @@ L  2 DATE Abt. 1943`), d.String())
 
 func TestNodeDiff_LeftNode(t *testing.T) {
 	d := &gedcom.NodeDiff{
-		Left:  parse("0 INDI @P3@")[0],
-		Right: parse("0 INDI @P4@")[0],
+		Left:  parse("0 @P3@ INDI")[0],
+		Right: parse("0 @P4@ INDI")[0],
 		Children: []*gedcom.NodeDiff{
 			{
 				Left: parse("0 BURI")[0],
@@ -479,7 +479,7 @@ func TestNodeDiff_LeftNode(t *testing.T) {
 		},
 	}
 
-	assert.Equal(t, `0 INDI @P3@
+	assert.Equal(t, `0 @P3@ INDI
 1 BURI
 2 DATE 1943
 1 NAME John /Smith/
@@ -488,8 +488,8 @@ func TestNodeDiff_LeftNode(t *testing.T) {
 
 func TestNodeDiff_RightNode(t *testing.T) {
 	d := &gedcom.NodeDiff{
-		Left:  parse("0 INDI @P3@")[0],
-		Right: parse("0 INDI @P4@")[0],
+		Left:  parse("0 @P3@ INDI")[0],
+		Right: parse("0 @P4@ INDI")[0],
 		Children: []*gedcom.NodeDiff{
 			{
 				Left: parse("0 BURI")[0],
@@ -507,7 +507,7 @@ func TestNodeDiff_RightNode(t *testing.T) {
 		},
 	}
 
-	assert.Equal(t, `0 INDI @P4@
+	assert.Equal(t, `0 @P4@ INDI
 1 BURI
 2 DATE Abt. 1943
 1 NAME John /Smith/

--- a/node_set_test.go
+++ b/node_set_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestNodeSet_Add(t *testing.T) {
 	ns := gedcom.NodeSet{}
-	nameNode := gedcom.NewNameNode(nil, "", "", nil)
+	nameNode := gedcom.NewNameNode("")
 
 	assert.False(t, ns.Has(nameNode))
 	ns.Add(nameNode)
@@ -17,8 +17,8 @@ func TestNodeSet_Add(t *testing.T) {
 
 func TestNodeSet_Has(t *testing.T) {
 	ns := gedcom.NodeSet{}
-	nameNode1 := gedcom.NewNameNode(nil, "", "", nil)
-	nameNode2 := gedcom.NewNameNode(nil, "", "", nil)
+	nameNode1 := gedcom.NewNameNode("")
+	nameNode2 := gedcom.NewNameNode("")
 
 	assert.False(t, ns.Has(nameNode1))
 	assert.False(t, ns.Has(nameNode2))

--- a/noder.go
+++ b/noder.go
@@ -1,0 +1,22 @@
+package gedcom
+
+// Noder allows an instance to have child nodes.
+type Noder interface {
+	// Nodes returns any child nodes.
+	Nodes() Nodes
+
+	// AddNode will add a child to this node.
+	//
+	// There is no restriction on whether a node is not allow to have children
+	// so you can expect that no error can occur.
+	//
+	// AddNode will always append the child at the end, even if there is is an
+	// exact child that already exists. However, the order of node in a GEDCOM
+	// file is almost always irrelevant.
+	AddNode(node Node)
+
+	// SetNodes replaces all of the child nodes.
+	SetNodes(nodes Nodes)
+
+	DeleteNode(node Node) bool
+}

--- a/nodes_test.go
+++ b/nodes_test.go
@@ -11,45 +11,45 @@ import (
 var nodesWithTagTests = []struct {
 	node gedcom.Node
 	tag  gedcom.Tag
-	want []gedcom.Node
+	want gedcom.Nodes
 }{
 	{nil, gedcom.TagHeader, nil},
-	{gedcom.NewNameNode(nil, "", "", nil), gedcom.TagHeader, []gedcom.Node{}},
+	{gedcom.NewNameNode(""), gedcom.TagHeader, gedcom.Nodes{}},
 	{
-		gedcom.NewNameNode(nil, "", "", []gedcom.Node{
-			gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, "", "", nil),
-		}),
+		gedcom.NewNameNode("",
+			gedcom.NewNode(gedcom.TagSurname, "", ""),
+		),
 		gedcom.TagHeader,
-		[]gedcom.Node{},
+		gedcom.Nodes{},
 	},
 	{
-		gedcom.NewNameNode(nil, "", "", []gedcom.Node{
-			gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, "", "", nil),
-		}),
+		gedcom.NewNameNode("",
+			gedcom.NewNode(gedcom.TagSurname, "", ""),
+		),
 		gedcom.TagSurname,
-		[]gedcom.Node{
-			gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, "", "", nil),
+		gedcom.Nodes{
+			gedcom.NewNode(gedcom.TagSurname, "", ""),
 		},
 	},
 	{
-		gedcom.NewNameNode(nil, "", "", []gedcom.Node{
-			gedcom.NewNodeWithChildren(nil, gedcom.TagHeader, "", "", nil),
-			gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, "", "", nil),
-		}),
+		gedcom.NewNameNode("",
+			gedcom.NewNode(gedcom.TagHeader, "", ""),
+			gedcom.NewNode(gedcom.TagSurname, "", ""),
+		),
 		gedcom.TagSurname,
-		[]gedcom.Node{
-			gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, "", "", nil),
+		gedcom.Nodes{
+			gedcom.NewNode(gedcom.TagSurname, "", ""),
 		},
 	},
 	{
-		gedcom.NewNameNode(nil, "", "", []gedcom.Node{
-			gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, "", "", nil),
-			gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, "", "", nil),
-		}),
+		gedcom.NewNameNode("",
+			gedcom.NewNode(gedcom.TagSurname, "", ""),
+			gedcom.NewNode(gedcom.TagSurname, "", ""),
+		),
 		gedcom.TagSurname,
-		[]gedcom.Node{
-			gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, "", "", nil),
-			gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, "", "", nil),
+		gedcom.Nodes{
+			gedcom.NewNode(gedcom.TagSurname, "", ""),
+			gedcom.NewNode(gedcom.TagSurname, "", ""),
 		},
 	},
 }
@@ -67,93 +67,93 @@ func TestNodesWithTagPath(t *testing.T) {
 	tests := []struct {
 		node    gedcom.Node
 		tagPath []gedcom.Tag
-		want    []gedcom.Node
+		want    gedcom.Nodes
 	}{
 		{
-			gedcom.NewNameNode(nil, "", "", []gedcom.Node{
-				gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, "", "", nil),
-			}),
+			gedcom.NewNameNode("",
+				gedcom.NewNode(gedcom.TagSurname, "", ""),
+			),
 			[]gedcom.Tag{},
-			[]gedcom.Node{},
+			gedcom.Nodes{},
 		},
 		{
-			gedcom.NewNameNode(nil, "", "", []gedcom.Node{
-				gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, "", "", []gedcom.Node{
-					gedcom.NewNodeWithChildren(nil, gedcom.TagText, "", "", nil),
-				}),
-			}),
+			gedcom.NewNameNode("",
+				gedcom.NewNode(gedcom.TagSurname, "", "",
+					gedcom.NewNode(gedcom.TagText, "", ""),
+				),
+			),
 			[]gedcom.Tag{gedcom.TagSurname},
-			[]gedcom.Node{
-				gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, "", "", []gedcom.Node{
-					gedcom.NewNodeWithChildren(nil, gedcom.TagText, "", "", nil),
-				}),
+			gedcom.Nodes{
+				gedcom.NewNode(gedcom.TagSurname, "", "",
+					gedcom.NewNode(gedcom.TagText, "", ""),
+				),
 			},
 		},
 		{
-			gedcom.NewNameNode(nil, "", "", []gedcom.Node{
-				gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, "", "", []gedcom.Node{
-					gedcom.NewNodeWithChildren(nil, gedcom.TagText, "", "", nil),
-				}),
-			}),
+			gedcom.NewNameNode("",
+				gedcom.NewNode(gedcom.TagSurname, "", "",
+					gedcom.NewNode(gedcom.TagText, "", ""),
+				),
+			),
 			[]gedcom.Tag{gedcom.TagSurname, gedcom.TagText},
-			[]gedcom.Node{
-				gedcom.NewNodeWithChildren(nil, gedcom.TagText, "", "", nil),
+			gedcom.Nodes{
+				gedcom.NewNode(gedcom.TagText, "", ""),
 			},
 		},
 		{
-			gedcom.NewNameNode(nil, "", "", []gedcom.Node{
-				gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, "", "", []gedcom.Node{
-					gedcom.NewNodeWithChildren(nil, gedcom.TagText, "", "1", nil),
-				}),
-				gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, "", "", []gedcom.Node{
-					gedcom.NewNodeWithChildren(nil, gedcom.TagText, "", "2", nil),
-				}),
-			}),
+			gedcom.NewNameNode("",
+				gedcom.NewNode(gedcom.TagSurname, "", "",
+					gedcom.NewNode(gedcom.TagText, "", "1"),
+				),
+				gedcom.NewNode(gedcom.TagSurname, "", "",
+					gedcom.NewNode(gedcom.TagText, "", "2"),
+				),
+			),
 			[]gedcom.Tag{gedcom.TagSurname, gedcom.TagText},
-			[]gedcom.Node{
-				gedcom.NewNodeWithChildren(nil, gedcom.TagText, "", "1", nil),
-				gedcom.NewNodeWithChildren(nil, gedcom.TagText, "", "2", nil),
+			gedcom.Nodes{
+				gedcom.NewNode(gedcom.TagText, "", "1"),
+				gedcom.NewNode(gedcom.TagText, "", "2"),
 			},
 		},
 		{
-			gedcom.NewNameNode(nil, "", "", []gedcom.Node{
-				gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, "", "", []gedcom.Node{
-					gedcom.NewNodeWithChildren(nil, gedcom.TagText, "", "1", nil),
-					gedcom.NewNodeWithChildren(nil, gedcom.TagText, "", "2", nil),
-				}),
-			}),
+			gedcom.NewNameNode("",
+				gedcom.NewNode(gedcom.TagSurname, "", "",
+					gedcom.NewNode(gedcom.TagText, "", "1"),
+					gedcom.NewNode(gedcom.TagText, "", "2"),
+				),
+			),
 			[]gedcom.Tag{gedcom.TagSurname, gedcom.TagText},
-			[]gedcom.Node{
-				gedcom.NewNodeWithChildren(nil, gedcom.TagText, "", "1", nil),
-				gedcom.NewNodeWithChildren(nil, gedcom.TagText, "", "2", nil),
+			gedcom.Nodes{
+				gedcom.NewNode(gedcom.TagText, "", "1"),
+				gedcom.NewNode(gedcom.TagText, "", "2"),
 			},
 		},
 		{
-			gedcom.NewNameNode(nil, "", "", []gedcom.Node{
-				gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, "", "", []gedcom.Node{
-					gedcom.NewNodeWithChildren(nil, gedcom.TagText, "", "", nil),
-				}),
-			}),
+			gedcom.NewNameNode("",
+				gedcom.NewNode(gedcom.TagSurname, "", "",
+					gedcom.NewNode(gedcom.TagText, "", ""),
+				),
+			),
 			[]gedcom.Tag{gedcom.TagGivenName, gedcom.TagText},
-			[]gedcom.Node{},
+			gedcom.Nodes{},
 		},
 		{
-			gedcom.NewNameNode(nil, "", "", []gedcom.Node{
-				gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, "", "", []gedcom.Node{
-					gedcom.NewNodeWithChildren(nil, gedcom.TagText, "", "", nil),
-				}),
-			}),
+			gedcom.NewNameNode("",
+				gedcom.NewNode(gedcom.TagSurname, "", "",
+					gedcom.NewNode(gedcom.TagText, "", ""),
+				),
+			),
 			[]gedcom.Tag{gedcom.TagSurname, gedcom.TagSurname},
-			[]gedcom.Node{},
+			gedcom.Nodes{},
 		},
 		{
-			gedcom.NewNameNode(nil, "", "", []gedcom.Node{
-				gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, "", "", []gedcom.Node{
-					gedcom.NewNodeWithChildren(nil, gedcom.TagText, "", "", nil),
-				}),
-			}),
+			gedcom.NewNameNode("",
+				gedcom.NewNode(gedcom.TagSurname, "", "",
+					gedcom.NewNode(gedcom.TagText, "", ""),
+				),
+			),
 			[]gedcom.Tag{gedcom.TagSurname, gedcom.TagGivenName},
-			[]gedcom.Node{},
+			gedcom.Nodes{},
 		},
 	}
 
@@ -175,8 +175,8 @@ func TestNodesWithTagPath(t *testing.T) {
 }
 
 func TestHasNestedNode(t *testing.T) {
-	surname := gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, "", "", nil)
-	givenName := gedcom.NewNodeWithChildren(nil, gedcom.TagGivenName, "", "", nil)
+	surname := gedcom.NewNode(gedcom.TagSurname, "", "")
+	givenName := gedcom.NewNode(gedcom.TagGivenName, "", "")
 
 	// ghost:ignore
 	tests := []struct {
@@ -203,44 +203,44 @@ func TestHasNestedNode(t *testing.T) {
 
 		// No children.
 		{
-			gedcom.NewNameNode(nil, "", "", nil),
+			gedcom.NewNameNode(""),
 			surname,
 			false,
 		},
 		{
-			gedcom.NewNameNode(nil, "", "", []gedcom.Node{}),
+			gedcom.NewNameNode(""),
 			surname,
 			false,
 		},
 
 		// Other cases.
 		{
-			gedcom.NewNameNode(nil, "", "", []gedcom.Node{
+			gedcom.NewNameNode("",
 				surname,
-			}),
+			),
 			surname,
 			true,
 		},
 		{
-			gedcom.NewNameNode(nil, "", "", []gedcom.Node{
+			gedcom.NewNameNode("",
 				surname,
-			}),
-			gedcom.NewNodeWithChildren(nil, gedcom.TagSurname, "", "", nil),
+			),
+			gedcom.NewNode(gedcom.TagSurname, "", ""),
 			false,
 		},
 		{
-			gedcom.NewNameNode(nil, "", "", []gedcom.Node{
+			gedcom.NewNameNode("",
 				givenName,
-			}),
+			),
 			surname,
 			false,
 		},
 		{
-			gedcom.NewNameNode(nil, "", "", []gedcom.Node{
-				gedcom.NewNodeWithChildren(nil, gedcom.TagGivenName, "", "", []gedcom.Node{
+			gedcom.NewNameNode("",
+				gedcom.NewNode(gedcom.TagGivenName, "", "",
 					givenName,
-				}),
-			}),
+				),
+			),
 			givenName,
 			true,
 		},
@@ -254,38 +254,16 @@ func TestHasNestedNode(t *testing.T) {
 	}
 }
 
-func TestCastNodes(t *testing.T) {
-	CastNodes := tf.Function(t, gedcom.CastNodes)
+func TestNodes_CastTo(t *testing.T) {
+	CastTo := tf.Function(t, gedcom.Nodes.CastTo)
 
-	CastNodes(nil, (*gedcom.NameNode)(nil)).
+	CastTo(nil, (*gedcom.NameNode)(nil)).
 		Returns([]*gedcom.NameNode{})
 
-	CastNodes([]gedcom.Node{}, (*gedcom.NameNode)(nil)).
+	CastTo(gedcom.Nodes{}, (*gedcom.NameNode)(nil)).
 		Returns([]*gedcom.NameNode{})
 
-	name := gedcom.NewNameNode(nil, "Elliot Rupert de Peyster /Chance/", "", nil)
-	CastNodes([]gedcom.Node{name}, (*gedcom.NameNode)(nil)).
+	name := gedcom.NewNameNode("Elliot Rupert de Peyster /Chance/")
+	CastTo(gedcom.Nodes{name}, (*gedcom.NameNode)(nil)).
 		Returns([]*gedcom.NameNode{name})
-}
-
-func TestNodes(t *testing.T) {
-	Nodes := tf.Function(t, gedcom.Nodes)
-
-	Nodes(nil).Returns(nil)
-
-	Nodes(gedcom.NewBirthNode(nil, "", "", nil)).Returns(nil)
-
-	Nodes(gedcom.NewBirthNode(nil, "", "", []gedcom.Node{})).Returns([]gedcom.Node{})
-
-	Nodes(gedcom.NewDocument()).Returns(nil)
-
-	Nodes(gedcom.NewDocumentWithNodes(nil)).Returns(nil)
-
-	Nodes(gedcom.NewDocumentWithNodes([]gedcom.Node{})).Returns([]gedcom.Node{})
-
-	Nodes(gedcom.NewDocumentWithNodes([]gedcom.Node{
-		gedcom.NewBirthNode(nil, "", "", nil),
-	})).Returns([]gedcom.Node{
-		gedcom.NewBirthNode(nil, "", "", nil),
-	})
 }

--- a/note_node.go
+++ b/note_node.go
@@ -7,8 +7,8 @@ type NoteNode struct {
 }
 
 // NewNoteNode creates a new NOTE node.
-func NewNoteNode(document *Document, value, pointer string, children []Node) *NoteNode {
+func NewNoteNode(value string, children ...Node) *NoteNode {
 	return &NoteNode{
-		newSimpleNode(document, TagNote, value, pointer, children),
+		newSimpleNode(TagNote, value, "", children...),
 	}
 }

--- a/note_node_test.go
+++ b/note_node_test.go
@@ -7,15 +7,13 @@ import (
 )
 
 func TestNewNoteNode(t *testing.T) {
-	doc := gedcom.NewDocument()
-	child := gedcom.NewNameNode(doc, "", "", nil)
-	node := gedcom.NewNoteNode(doc, "foo", "bar", []gedcom.Node{child})
+	child := gedcom.NewNameNode("")
+	node := gedcom.NewNoteNode("foo", child)
 
 	assert.NotNil(t, node)
 	assert.IsType(t, node, (*gedcom.NoteNode)(nil))
 	assert.Equal(t, gedcom.TagNote, node.Tag())
-	assert.Equal(t, []gedcom.Node{child}, node.Nodes())
-	assert.Equal(t, doc, node.Document())
+	assert.Equal(t, gedcom.Nodes{child}, node.Nodes())
 	assert.Equal(t, "foo", node.Value())
-	assert.Equal(t, "bar", node.Pointer())
+	assert.Equal(t, "", node.Pointer())
 }

--- a/phonetic_variation_node.go
+++ b/phonetic_variation_node.go
@@ -22,9 +22,9 @@ type PhoneticVariationNode struct {
 }
 
 // NewPhoneticVariationNode creates a new FONE node.
-func NewPhoneticVariationNode(document *Document, value, pointer string, children []Node) *PhoneticVariationNode {
+func NewPhoneticVariationNode(value string, children ...Node) *PhoneticVariationNode {
 	return &PhoneticVariationNode{
-		newSimpleNode(document, TagPhonetic, value, pointer, children),
+		newSimpleNode(TagPhonetic, value, "", children...),
 	}
 }
 

--- a/phonetic_variation_node_test.go
+++ b/phonetic_variation_node_test.go
@@ -7,17 +7,15 @@ import (
 )
 
 func TestNewPhoneticVariationNode(t *testing.T) {
-	doc := gedcom.NewDocument()
-	child := gedcom.NewNameNode(doc, "", "", nil)
-	node := gedcom.NewPhoneticVariationNode(doc, "foo", "bar", []gedcom.Node{child})
+	child := gedcom.NewNameNode("")
+	node := gedcom.NewPhoneticVariationNode("foo", child)
 
 	assert.NotNil(t, node)
 	assert.IsType(t, node, (*gedcom.PhoneticVariationNode)(nil))
 	assert.Equal(t, gedcom.TagPhonetic, node.Tag())
-	assert.Equal(t, []gedcom.Node{child}, node.Nodes())
-	assert.Equal(t, doc, node.Document())
+	assert.Equal(t, gedcom.Nodes{child}, node.Nodes())
 	assert.Equal(t, "foo", node.Value())
-	assert.Equal(t, "bar", node.Pointer())
+	assert.Equal(t, "", node.Pointer())
 }
 
 func TestPhoneticVariationNode_Type(t *testing.T) {
@@ -31,32 +29,32 @@ func TestPhoneticVariationNode_Type(t *testing.T) {
 			expected: nil,
 		},
 		{
-			node:     gedcom.NewPhoneticVariationNode(nil, "", "", nil),
+			node:     gedcom.NewPhoneticVariationNode(""),
 			expected: nil,
 		},
 		{
-			node:     gedcom.NewPhoneticVariationNode(nil, "", "", []gedcom.Node{}),
+			node:     gedcom.NewPhoneticVariationNode(""),
 			expected: nil,
 		},
 		{
-			node: gedcom.NewPhoneticVariationNode(nil, "", "", []gedcom.Node{
-				gedcom.NewTypeNode(nil, "", "", []gedcom.Node{}),
-			}),
-			expected: gedcom.NewTypeNode(nil, "", "", []gedcom.Node{}),
+			node: gedcom.NewPhoneticVariationNode("",
+				gedcom.NewTypeNode(""),
+			),
+			expected: gedcom.NewTypeNode(""),
 		},
 		{
-			node: gedcom.NewPhoneticVariationNode(nil, "", "", []gedcom.Node{
-				gedcom.NewNameNode(nil, "", "", []gedcom.Node{}),
-			}),
+			node: gedcom.NewPhoneticVariationNode("",
+				gedcom.NewNameNode(""),
+			),
 			expected: nil,
 		},
 		{
-			node: gedcom.NewPhoneticVariationNode(nil, "", "", []gedcom.Node{
-				gedcom.NewNameNode(nil, "", "", []gedcom.Node{}),
-				gedcom.NewTypeNode(nil, "1", "", []gedcom.Node{}),
-				gedcom.NewTypeNode(nil, "2", "", []gedcom.Node{}),
-			}),
-			expected: gedcom.NewTypeNode(nil, "1", "", []gedcom.Node{}),
+			node: gedcom.NewPhoneticVariationNode("",
+				gedcom.NewNameNode(""),
+				gedcom.NewTypeNode("1"),
+				gedcom.NewTypeNode("2"),
+			),
+			expected: gedcom.NewTypeNode("1"),
 		},
 	}
 

--- a/place_node.go
+++ b/place_node.go
@@ -15,9 +15,9 @@ type PlaceNode struct {
 //
 // The original specification was derived from
 // http://wiki-en.genealogy.net/GEDCOM/PLAC-Tag
-func NewPlaceNode(document *Document, value, pointer string, children []Node) *PlaceNode {
+func NewPlaceNode(value string, children ...Node) *PlaceNode {
 	return &PlaceNode{
-		newSimpleNode(document, TagPlace, value, pointer, children),
+		newSimpleNode(TagPlace, value, "", children...),
 	}
 }
 

--- a/place_node_test.go
+++ b/place_node_test.go
@@ -23,56 +23,56 @@ var placeTests = []struct {
 		country: "",
 	},
 	{
-		node:    gedcom.NewPlaceNode(nil, "Waterloo", "", nil),
+		node:    gedcom.NewPlaceNode("Waterloo"),
 		name:    "Waterloo",
 		county:  "",
 		state:   "",
 		country: "",
 	},
 	{
-		node:    gedcom.NewPlaceNode(nil, "Waterloo, NSW", "", nil),
+		node:    gedcom.NewPlaceNode("Waterloo, NSW"),
 		name:    "Waterloo, NSW",
 		county:  "",
 		state:   "",
 		country: "",
 	},
 	{
-		node:    gedcom.NewPlaceNode(nil, "Cove,Cache,Utah,USA.", "", nil),
+		node:    gedcom.NewPlaceNode("Cove,Cache,Utah,USA."),
 		name:    "Cove",
 		county:  "Cache",
 		state:   "Utah",
 		country: "USA.",
 	},
 	{
-		node:    gedcom.NewPlaceNode(nil, "Cove, Cache, Utah, USA.", "", nil),
+		node:    gedcom.NewPlaceNode("Cove, Cache, Utah, USA."),
 		name:    "Cove",
 		county:  "Cache",
 		state:   "Utah",
 		country: "USA.",
 	},
 	{
-		node:    gedcom.NewPlaceNode(nil, "United States", "", nil),
+		node:    gedcom.NewPlaceNode("United States"),
 		name:    "United States",
 		county:  "",
 		state:   "",
 		country: "United States",
 	},
 	{
-		node:    gedcom.NewPlaceNode(nil, "Foo, australia.", "", nil),
+		node:    gedcom.NewPlaceNode("Foo, australia."),
 		name:    "Foo, australia.",
 		county:  "",
 		state:   "",
 		country: "Australia",
 	},
 	{
-		node:    gedcom.NewPlaceNode(nil, "Bar, Nashville, USA", "", nil),
+		node:    gedcom.NewPlaceNode("Bar, Nashville, USA"),
 		name:    "Bar, Nashville, USA",
 		county:  "",
 		state:   "",
 		country: "USA",
 	},
 	{
-		node:    gedcom.NewPlaceNode(nil, "Hobbitown, New zealand ", "", nil),
+		node:    gedcom.NewPlaceNode("Hobbitown, New zealand "),
 		name:    "Hobbitown, New zealand",
 		county:  "",
 		state:   "",
@@ -81,17 +81,15 @@ var placeTests = []struct {
 }
 
 func TestNewPlaceNode(t *testing.T) {
-	doc := gedcom.NewDocument()
-	child := gedcom.NewNameNode(doc, "", "", nil)
-	node := gedcom.NewPlaceNode(doc, "foo", "bar", []gedcom.Node{child})
+	child := gedcom.NewNameNode("")
+	node := gedcom.NewPlaceNode("foo", child)
 
 	assert.NotNil(t, node)
 	assert.IsType(t, node, (*gedcom.PlaceNode)(nil))
 	assert.Equal(t, gedcom.TagPlace, node.Tag())
-	assert.Equal(t, []gedcom.Node{child}, node.Nodes())
-	assert.Equal(t, doc, node.Document())
+	assert.Equal(t, gedcom.Nodes{child}, node.Nodes())
 	assert.Equal(t, "foo", node.Value())
-	assert.Equal(t, "bar", node.Pointer())
+	assert.Equal(t, "", node.Pointer())
 }
 
 func TestPlaceNode_Name(t *testing.T) {
@@ -137,32 +135,32 @@ func TestPlaceNode_Format(t *testing.T) {
 			expected: nil,
 		},
 		{
-			node:     gedcom.NewPlaceNode(nil, "", "", nil),
+			node:     gedcom.NewPlaceNode(""),
 			expected: nil,
 		},
 		{
-			node:     gedcom.NewPlaceNode(nil, "", "", []gedcom.Node{}),
+			node:     gedcom.NewPlaceNode(""),
 			expected: nil,
 		},
 		{
-			node: gedcom.NewPlaceNode(nil, "", "", []gedcom.Node{
-				gedcom.NewFormatNode(nil, "", "", []gedcom.Node{}),
-			}),
-			expected: gedcom.NewFormatNode(nil, "", "", []gedcom.Node{}),
+			node: gedcom.NewPlaceNode("",
+				gedcom.NewFormatNode(""),
+			),
+			expected: gedcom.NewFormatNode(""),
 		},
 		{
-			node: gedcom.NewPlaceNode(nil, "", "", []gedcom.Node{
-				gedcom.NewNameNode(nil, "", "", []gedcom.Node{}),
-			}),
+			node: gedcom.NewPlaceNode("",
+				gedcom.NewNameNode(""),
+			),
 			expected: nil,
 		},
 		{
-			node: gedcom.NewPlaceNode(nil, "", "", []gedcom.Node{
-				gedcom.NewNameNode(nil, "", "", []gedcom.Node{}),
-				gedcom.NewFormatNode(nil, "1", "", []gedcom.Node{}),
-				gedcom.NewFormatNode(nil, "2", "", []gedcom.Node{}),
-			}),
-			expected: gedcom.NewFormatNode(nil, "1", "", []gedcom.Node{}),
+			node: gedcom.NewPlaceNode("",
+				gedcom.NewNameNode(""),
+				gedcom.NewFormatNode("1"),
+				gedcom.NewFormatNode("2"),
+			),
+			expected: gedcom.NewFormatNode("1"),
 		},
 	}
 
@@ -184,39 +182,39 @@ func TestPlaceNode_PhoneticVariations(t *testing.T) {
 			expected: []*gedcom.PhoneticVariationNode{},
 		},
 		{
-			node:     gedcom.NewPlaceNode(nil, "", "", nil),
+			node:     gedcom.NewPlaceNode(""),
 			expected: []*gedcom.PhoneticVariationNode{},
 		},
 		{
-			node:     gedcom.NewPlaceNode(nil, "", "", []gedcom.Node{}),
+			node:     gedcom.NewPlaceNode(""),
 			expected: []*gedcom.PhoneticVariationNode{},
 		},
 		{
-			node: gedcom.NewPlaceNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewPhoneticVariationNode(nil, "", "", []gedcom.Node{}),
-			}),
+			node: gedcom.NewNode(gedcom.TagPlace, "", "P1",
+				gedcom.NewPhoneticVariationNode(""),
+			).(*gedcom.PlaceNode),
 			expected: []*gedcom.PhoneticVariationNode{
-				gedcom.NewPhoneticVariationNode(nil, "", "", []gedcom.Node{}),
+				gedcom.NewPhoneticVariationNode(""),
 			},
 		},
 		{
-			node: gedcom.NewPlaceNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewPhoneticVariationNode(nil, "", "", []gedcom.Node{}),
-				gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
-			}),
+			node: gedcom.NewNode(gedcom.TagPlace, "", "P1",
+				gedcom.NewPhoneticVariationNode(""),
+				gedcom.NewNode(gedcom.TagDeath, "", ""),
+			).(*gedcom.PlaceNode),
 			expected: []*gedcom.PhoneticVariationNode{
-				gedcom.NewPhoneticVariationNode(nil, "", "", []gedcom.Node{}),
+				gedcom.NewPhoneticVariationNode(""),
 			},
 		},
 		{
-			node: gedcom.NewPlaceNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewPhoneticVariationNode(nil, "foo", "", []gedcom.Node{}),
-				gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
-				gedcom.NewPhoneticVariationNode(nil, "bar", "", []gedcom.Node{}),
-			}),
+			node: gedcom.NewNode(gedcom.TagPlace, "", "P1",
+				gedcom.NewPhoneticVariationNode("foo"),
+				gedcom.NewNode(gedcom.TagDeath, "", ""),
+				gedcom.NewPhoneticVariationNode("bar"),
+			).(*gedcom.PlaceNode),
 			expected: []*gedcom.PhoneticVariationNode{
-				gedcom.NewPhoneticVariationNode(nil, "foo", "", []gedcom.Node{}),
-				gedcom.NewPhoneticVariationNode(nil, "bar", "", []gedcom.Node{}),
+				gedcom.NewPhoneticVariationNode("foo"),
+				gedcom.NewPhoneticVariationNode("bar"),
 			},
 		},
 	}
@@ -239,39 +237,39 @@ func TestPlaceNode_RomanizedVariations(t *testing.T) {
 			expected: []*gedcom.RomanizedVariationNode{},
 		},
 		{
-			node:     gedcom.NewPlaceNode(nil, "", "", nil),
+			node:     gedcom.NewPlaceNode(""),
 			expected: []*gedcom.RomanizedVariationNode{},
 		},
 		{
-			node:     gedcom.NewPlaceNode(nil, "", "", []gedcom.Node{}),
+			node:     gedcom.NewPlaceNode(""),
 			expected: []*gedcom.RomanizedVariationNode{},
 		},
 		{
-			node: gedcom.NewPlaceNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewRomanizedVariationNode(nil, "", "", []gedcom.Node{}),
-			}),
+			node: gedcom.NewNode(gedcom.TagPlace, "", "P1",
+				gedcom.NewRomanizedVariationNode(""),
+			).(*gedcom.PlaceNode),
 			expected: []*gedcom.RomanizedVariationNode{
-				gedcom.NewRomanizedVariationNode(nil, "", "", []gedcom.Node{}),
+				gedcom.NewRomanizedVariationNode(""),
 			},
 		},
 		{
-			node: gedcom.NewPlaceNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewRomanizedVariationNode(nil, "", "", []gedcom.Node{}),
-				gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
-			}),
+			node: gedcom.NewNode(gedcom.TagPlace, "", "P1",
+				gedcom.NewRomanizedVariationNode(""),
+				gedcom.NewNode(gedcom.TagDeath, "", ""),
+			).(*gedcom.PlaceNode),
 			expected: []*gedcom.RomanizedVariationNode{
-				gedcom.NewRomanizedVariationNode(nil, "", "", []gedcom.Node{}),
+				gedcom.NewRomanizedVariationNode(""),
 			},
 		},
 		{
-			node: gedcom.NewPlaceNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewRomanizedVariationNode(nil, "foo", "", []gedcom.Node{}),
-				gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
-				gedcom.NewRomanizedVariationNode(nil, "bar", "", []gedcom.Node{}),
-			}),
+			node: gedcom.NewNode(gedcom.TagPlace, "", "P1",
+				gedcom.NewRomanizedVariationNode("foo"),
+				gedcom.NewNode(gedcom.TagDeath, "", ""),
+				gedcom.NewRomanizedVariationNode("bar"),
+			).(*gedcom.PlaceNode),
 			expected: []*gedcom.RomanizedVariationNode{
-				gedcom.NewRomanizedVariationNode(nil, "foo", "", []gedcom.Node{}),
-				gedcom.NewRomanizedVariationNode(nil, "bar", "", []gedcom.Node{}),
+				gedcom.NewRomanizedVariationNode("foo"),
+				gedcom.NewRomanizedVariationNode("bar"),
 			},
 		},
 	}
@@ -294,32 +292,32 @@ func TestPlaceNode_Map(t *testing.T) {
 			expected: nil,
 		},
 		{
-			node:     gedcom.NewPlaceNode(nil, "", "", nil),
+			node:     gedcom.NewPlaceNode(""),
 			expected: nil,
 		},
 		{
-			node:     gedcom.NewPlaceNode(nil, "", "", []gedcom.Node{}),
+			node:     gedcom.NewPlaceNode(""),
 			expected: nil,
 		},
 		{
-			node: gedcom.NewPlaceNode(nil, "", "", []gedcom.Node{
-				gedcom.NewMapNode(nil, "", "", []gedcom.Node{}),
-			}),
-			expected: gedcom.NewMapNode(nil, "", "", []gedcom.Node{}),
+			node: gedcom.NewPlaceNode("",
+				gedcom.NewMapNode(""),
+			),
+			expected: gedcom.NewMapNode(""),
 		},
 		{
-			node: gedcom.NewPlaceNode(nil, "", "", []gedcom.Node{
-				gedcom.NewNameNode(nil, "", "", []gedcom.Node{}),
-			}),
+			node: gedcom.NewPlaceNode("",
+				gedcom.NewNameNode(""),
+			),
 			expected: nil,
 		},
 		{
-			node: gedcom.NewPlaceNode(nil, "", "", []gedcom.Node{
-				gedcom.NewNameNode(nil, "", "", []gedcom.Node{}),
-				gedcom.NewMapNode(nil, "1", "", []gedcom.Node{}),
-				gedcom.NewMapNode(nil, "2", "", []gedcom.Node{}),
-			}),
-			expected: gedcom.NewMapNode(nil, "1", "", []gedcom.Node{}),
+			node: gedcom.NewPlaceNode("",
+				gedcom.NewNameNode(""),
+				gedcom.NewMapNode("1"),
+				gedcom.NewMapNode("2"),
+			),
+			expected: gedcom.NewMapNode("1"),
 		},
 	}
 
@@ -341,39 +339,39 @@ func TestPlaceNode_Notes(t *testing.T) {
 			expected: []*gedcom.NoteNode{},
 		},
 		{
-			node:     gedcom.NewPlaceNode(nil, "", "", nil),
+			node:     gedcom.NewPlaceNode(""),
 			expected: []*gedcom.NoteNode{},
 		},
 		{
-			node:     gedcom.NewPlaceNode(nil, "", "", []gedcom.Node{}),
+			node:     gedcom.NewPlaceNode(""),
 			expected: []*gedcom.NoteNode{},
 		},
 		{
-			node: gedcom.NewPlaceNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewNoteNode(nil, "", "", []gedcom.Node{}),
-			}),
+			node: gedcom.NewNode(gedcom.TagPlace, "", "P1",
+				gedcom.NewNoteNode(""),
+			).(*gedcom.PlaceNode),
 			expected: []*gedcom.NoteNode{
-				gedcom.NewNoteNode(nil, "", "", []gedcom.Node{}),
+				gedcom.NewNoteNode(""),
 			},
 		},
 		{
-			node: gedcom.NewPlaceNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewNoteNode(nil, "", "", []gedcom.Node{}),
-				gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
-			}),
+			node: gedcom.NewNode(gedcom.TagPlace, "", "P1",
+				gedcom.NewNoteNode(""),
+				gedcom.NewNode(gedcom.TagDeath, "", ""),
+			).(*gedcom.PlaceNode),
 			expected: []*gedcom.NoteNode{
-				gedcom.NewNoteNode(nil, "", "", []gedcom.Node{}),
+				gedcom.NewNoteNode(""),
 			},
 		},
 		{
-			node: gedcom.NewPlaceNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewNoteNode(nil, "foo", "", []gedcom.Node{}),
-				gedcom.NewNodeWithChildren(nil, gedcom.TagDeath, "", "", []gedcom.Node{}),
-				gedcom.NewNoteNode(nil, "bar", "", []gedcom.Node{}),
-			}),
+			node: gedcom.NewNode(gedcom.TagPlace, "", "P1",
+				gedcom.NewNoteNode("foo"),
+				gedcom.NewNode(gedcom.TagDeath, "", ""),
+				gedcom.NewNoteNode("bar"),
+			).(*gedcom.PlaceNode),
 			expected: []*gedcom.NoteNode{
-				gedcom.NewNoteNode(nil, "foo", "", []gedcom.Node{}),
-				gedcom.NewNoteNode(nil, "bar", "", []gedcom.Node{}),
+				gedcom.NewNoteNode("foo"),
+				gedcom.NewNoteNode("bar"),
 			},
 		},
 	}

--- a/placer_test.go
+++ b/placer_test.go
@@ -9,63 +9,63 @@ import (
 func TestPlaces(t *testing.T) {
 	// ghost:ignore
 	tests := []struct {
-		nodes []gedcom.Node
+		nodes gedcom.Nodes
 		want  []*gedcom.PlaceNode
 	}{
 		{nil, nil},
 		{
-			[]gedcom.Node{
-				gedcom.NewNodeWithChildren(nil, gedcom.TagVersion, "foo", "", nil),
+			gedcom.Nodes{
+				gedcom.NewNode(gedcom.TagVersion, "foo", ""),
 			},
 			nil,
 		},
 		{
-			[]gedcom.Node{
-				gedcom.NewNameNode(nil, "foo bar", "", []gedcom.Node{
-					gedcom.NewPlaceNode(nil, "Australia", "", nil),
-				}),
+			gedcom.Nodes{
+				gedcom.NewNameNode("foo bar",
+					gedcom.NewPlaceNode("Australia"),
+				),
 			},
 			[]*gedcom.PlaceNode{
-				gedcom.NewPlaceNode(nil, "Australia", "", nil),
+				gedcom.NewPlaceNode("Australia"),
 			},
 		},
 		{
-			[]gedcom.Node{
-				gedcom.NewNameNode(nil, "foo bar", "", []gedcom.Node{
-					gedcom.NewPlaceNode(nil, "Australia", "", nil),
-					gedcom.NewPlaceNode(nil, "United States", "", nil),
-				}),
+			gedcom.Nodes{
+				gedcom.NewNameNode("foo bar",
+					gedcom.NewPlaceNode("Australia"),
+					gedcom.NewPlaceNode("United States"),
+				),
 			},
 			[]*gedcom.PlaceNode{
-				gedcom.NewPlaceNode(nil, "Australia", "", nil),
-				gedcom.NewPlaceNode(nil, "United States", "", nil),
+				gedcom.NewPlaceNode("Australia"),
+				gedcom.NewPlaceNode("United States"),
 			},
 		},
 		{
-			[]gedcom.Node{
-				gedcom.NewNameNode(nil, "foo bar", "", []gedcom.Node{
-					gedcom.NewPlaceNode(nil, "Australia", "", nil),
-					gedcom.NewPlaceNode(nil, "United States", "", nil),
-				}),
-				gedcom.NewNameNode(nil, "foo bar", "", []gedcom.Node{
-					gedcom.NewPlaceNode(nil, "England", "", nil),
-				}),
+			gedcom.Nodes{
+				gedcom.NewNameNode("foo bar",
+					gedcom.NewPlaceNode("Australia"),
+					gedcom.NewPlaceNode("United States"),
+				),
+				gedcom.NewNameNode("foo bar",
+					gedcom.NewPlaceNode("England"),
+				),
 			},
 			[]*gedcom.PlaceNode{
-				gedcom.NewPlaceNode(nil, "Australia", "", nil),
-				gedcom.NewPlaceNode(nil, "United States", "", nil),
-				gedcom.NewPlaceNode(nil, "England", "", nil),
+				gedcom.NewPlaceNode("Australia"),
+				gedcom.NewPlaceNode("United States"),
+				gedcom.NewPlaceNode("England"),
 			},
 		},
 		{
-			[]gedcom.Node{
-				gedcom.NewNameNode(nil, "foo bar", "", nil),
-				gedcom.NewNameNode(nil, "foo bar", "", []gedcom.Node{
-					gedcom.NewPlaceNode(nil, "Australia", "", nil),
-				}),
+			gedcom.Nodes{
+				gedcom.NewNameNode("foo bar"),
+				gedcom.NewNameNode("foo bar",
+					gedcom.NewPlaceNode("Australia"),
+				),
 			},
 			[]*gedcom.PlaceNode{
-				gedcom.NewPlaceNode(nil, "Australia", "", nil),
+				gedcom.NewPlaceNode("Australia"),
 			},
 		},
 	}

--- a/q/engine_test.go
+++ b/q/engine_test.go
@@ -15,14 +15,13 @@ func TestEngine_Start(t *testing.T) {
 
 	parser := q.NewParser()
 
-	document := gedcom.NewDocumentWithNodes([]gedcom.Node{
-		gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-			gedcom.NewNameNode(nil, "Elliot /Chance/", "", nil),
-		}),
-		gedcom.NewIndividualNode(nil, "", "P2", []gedcom.Node{
-			gedcom.NewNameNode(nil, "Dina /Wyche/", "", nil),
-		}),
-	})
+	document := gedcom.NewDocument()
+	document.AddIndividual("P1",
+		gedcom.NewNameNode("Elliot /Chance/"),
+	)
+	document.AddIndividual("P2",
+		gedcom.NewNameNode("Dina /Wyche/"),
+	)
 
 	documents := []*gedcom.Document{document}
 
@@ -32,21 +31,14 @@ func TestEngine_Start(t *testing.T) {
 
 	engine, err = parser.ParseString(".Individuals")
 	if assert.NoError(t, err) {
-		Start(engine, documents).Returns(gedcom.IndividualNodes{
-			gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-				gedcom.NewNameNode(nil, "Elliot /Chance/", "", nil),
-			}),
-			gedcom.NewIndividualNode(nil, "", "P2", []gedcom.Node{
-				gedcom.NewNameNode(nil, "Dina /Wyche/", "", nil),
-			}),
-		}, nil)
+		Start(engine, documents).Returns(document.Individuals(), nil)
 	}
 
 	engine, err = parser.ParseString(".Individuals | .Name")
 	if assert.NoError(t, err) {
 		Start(engine, documents).Returns([]*gedcom.NameNode{
-			gedcom.NewNameNode(nil, "Elliot /Chance/", "", nil),
-			gedcom.NewNameNode(nil, "Dina /Wyche/", "", nil),
+			gedcom.NewNameNode("Elliot /Chance/"),
+			gedcom.NewNameNode("Dina /Wyche/"),
 		}, nil)
 	}
 
@@ -69,8 +61,8 @@ func TestEngine_Start(t *testing.T) {
 	engine, err = parser.ParseString("Names is .Individuals | .Name; Names")
 	if assert.NoError(t, err) {
 		Start(engine, documents).Returns([]*gedcom.NameNode{
-			gedcom.NewNameNode(nil, "Elliot /Chance/", "", nil),
-			gedcom.NewNameNode(nil, "Dina /Wyche/", "", nil),
+			gedcom.NewNameNode("Elliot /Chance/"),
+			gedcom.NewNameNode("Dina /Wyche/"),
 		}, nil)
 	}
 
@@ -106,15 +98,15 @@ func TestEngine_Start(t *testing.T) {
 	engine, err = parser.ParseString(".Individuals | .Name | First(1)")
 	if assert.NoError(t, err) {
 		Start(engine, documents).Returns([]*gedcom.NameNode{
-			gedcom.NewNameNode(nil, "Elliot /Chance/", "", nil),
+			gedcom.NewNameNode("Elliot /Chance/"),
 		}, nil)
 	}
 
 	engine, err = parser.ParseString(".Individuals | .Name | Last(23)")
 	if assert.NoError(t, err) {
 		Start(engine, documents).Returns([]*gedcom.NameNode{
-			gedcom.NewNameNode(nil, "Elliot /Chance/", "", nil),
-			gedcom.NewNameNode(nil, "Dina /Wyche/", "", nil),
+			gedcom.NewNameNode("Elliot /Chance/"),
+			gedcom.NewNameNode("Dina /Wyche/"),
 		}, nil)
 	}
 
@@ -129,8 +121,8 @@ func TestEngine_Start(t *testing.T) {
 	engine, err = parser.ParseString(".Individuals | { name: .Name }")
 	if assert.NoError(t, err) {
 		Start(engine, documents).Returns([]map[string]interface{}{
-			{"name": gedcom.NewNameNode(nil, "Elliot /Chance/", "", nil)},
-			{"name": gedcom.NewNameNode(nil, "Dina /Wyche/", "", nil)},
+			{"name": gedcom.NewNameNode("Elliot /Chance/")},
+			{"name": gedcom.NewNameNode("Dina /Wyche/")},
 		}, nil)
 	}
 
@@ -138,11 +130,11 @@ func TestEngine_Start(t *testing.T) {
 	if assert.NoError(t, err) {
 		Start(engine, documents).Returns([]map[string]interface{}{
 			{
-				"name": gedcom.NewNameNode(nil, "Elliot /Chance/", "", nil),
+				"name": gedcom.NewNameNode("Elliot /Chance/"),
 				"age":  gedcom.Age{},
 			},
 			{
-				"name": gedcom.NewNameNode(nil, "Dina /Wyche/", "", nil),
+				"name": gedcom.NewNameNode("Dina /Wyche/"),
 				"age":  gedcom.Age{},
 			},
 		}, nil)

--- a/q/formatter_test.go
+++ b/q/formatter_test.go
@@ -37,8 +37,8 @@ var formatterTests = []struct {
 	},
 	{
 		result: []*gedcom.NameNode{
-			gedcom.NewNameNode(nil, "Elliot /Chance/", "", nil),
-			gedcom.NewNameNode(nil, "Dina /Wyche/", "", nil),
+			gedcom.NewNameNode("Elliot /Chance/"),
+			gedcom.NewNameNode("Dina /Wyche/"),
 		},
 		asJSON: []byte(`[{"Tag":"NAME","Value":"Elliot /Chance/"},{"Tag":"NAME","Value":"Dina /Wyche/"}]
 `),
@@ -62,10 +62,10 @@ NAME,Dina /Wyche/
 		asGEDCOM:  []byte("0 NAME Elliot /Chance/\n0 NAME Dina /Wyche/\n"),
 	},
 	{
-		result: gedcom.NewIndividualNode(nil, "", "P1", []gedcom.Node{
-			gedcom.NewNameNode(nil, "Elliot /Chance/", "", nil),
-			gedcom.NewNameNode(nil, "Dina /Wyche/", "", nil),
-		}),
+		result: gedcom.NewDocument().AddIndividual("P1",
+			gedcom.NewNameNode("Elliot /Chance/"),
+			gedcom.NewNameNode("Dina /Wyche/"),
+		),
 		asJSON: []byte(`{"Nodes":[{"Tag":"NAME","Value":"Elliot /Chance/"},{"Tag":"NAME","Value":"Dina /Wyche/"}],"Pointer":"P1","Tag":"INDI"}
 `),
 		asPrettyJSON: []byte(`{

--- a/q/question_mark_expr_test.go
+++ b/q/question_mark_expr_test.go
@@ -7,7 +7,11 @@ import (
 )
 
 var documentChoices = []string{
+	".AddFamily",
+	".AddFamilyWithHusbandAndWife",
+	".AddIndividual",
 	".AddNode",
+	".DeleteNode",
 	".Families",
 	".GEDCOMString",
 	".Individuals",

--- a/residence_node.go
+++ b/residence_node.go
@@ -6,9 +6,9 @@ type ResidenceNode struct {
 }
 
 // NewResidenceNode creates a new RESI node.
-func NewResidenceNode(document *Document, value, pointer string, children []Node) *ResidenceNode {
+func NewResidenceNode(value string, children ...Node) *ResidenceNode {
 	return &ResidenceNode{
-		newSimpleNode(document, TagResidence, value, pointer, children),
+		newSimpleNode(TagResidence, value, "", children...),
 	}
 }
 

--- a/residence_node_test.go
+++ b/residence_node_test.go
@@ -9,15 +9,13 @@ import (
 )
 
 func TestNewResidenceNode(t *testing.T) {
-	doc := gedcom.NewDocument()
-	child := gedcom.NewNameNode(doc, "", "", nil)
-	node := gedcom.NewResidenceNode(doc, "foo", "bar", []gedcom.Node{child})
+	child := gedcom.NewNameNode("")
+	node := gedcom.NewResidenceNode("foo", child)
 
 	assert.Equal(t, gedcom.TagResidence, node.Tag())
-	assert.Equal(t, []gedcom.Node{child}, node.Nodes())
-	assert.Equal(t, doc, node.Document())
+	assert.Equal(t, gedcom.Nodes{child}, node.Nodes())
 	assert.Equal(t, "foo", node.Value())
-	assert.Equal(t, "bar", node.Pointer())
+	assert.Equal(t, "", node.Pointer())
 }
 
 func TestResidenceNode_Dates(t *testing.T) {
@@ -25,38 +23,36 @@ func TestResidenceNode_Dates(t *testing.T) {
 
 	Dates((*gedcom.ResidenceNode)(nil)).Returns([]*gedcom.DateNode(nil))
 
-	Dates(gedcom.NewResidenceNode(nil, "", "", nil)).Returns([]*gedcom.DateNode(nil))
-
-	Dates(gedcom.NewResidenceNode(nil, "", "", []gedcom.Node{})).
+	Dates(gedcom.NewResidenceNode("")).
 		Returns([]*gedcom.DateNode(nil))
 
-	Dates(gedcom.NewResidenceNode(nil, "", "", []gedcom.Node{
-		gedcom.NewDateNode(nil, "3 Sep 2001", "", nil),
-	})).Returns([]*gedcom.DateNode{
-		gedcom.NewDateNode(nil, "3 Sep 2001", "", nil),
+	Dates(gedcom.NewResidenceNode("",
+		gedcom.NewDateNode("3 Sep 2001"),
+	)).Returns([]*gedcom.DateNode{
+		gedcom.NewDateNode("3 Sep 2001"),
 	})
 
-	Dates(gedcom.NewResidenceNode(nil, "", "", []gedcom.Node{
-		gedcom.NewDateNode(nil, "7 Jan 2001", "", nil),
-		gedcom.NewDateNode(nil, "3 Sep 2001", "", nil),
-	})).Returns([]*gedcom.DateNode{
-		gedcom.NewDateNode(nil, "7 Jan 2001", "", nil),
-		gedcom.NewDateNode(nil, "3 Sep 2001", "", nil),
+	Dates(gedcom.NewResidenceNode("",
+		gedcom.NewDateNode("7 Jan 2001"),
+		gedcom.NewDateNode("3 Sep 2001"),
+	)).Returns([]*gedcom.DateNode{
+		gedcom.NewDateNode("7 Jan 2001"),
+		gedcom.NewDateNode("3 Sep 2001"),
 	})
 }
 
 func TestResidenceNode_Equals(t *testing.T) {
 	Equals := tf.Function(t, (*gedcom.ResidenceNode).Equals)
 
-	n1 := gedcom.NewResidenceNode(nil, "foo", "", nil)
-	n2 := gedcom.NewResidenceNode(nil, "bar", "", nil)
-	n3 := gedcom.NewResidenceNode(nil, "bar", "", []gedcom.Node{
-		gedcom.NewDateNode(nil, "3 Sep 1943", "", nil),
-		gedcom.NewDateNode(nil, "Oct 1943", "", nil),
-	})
-	n4 := gedcom.NewResidenceNode(nil, "bar", "", []gedcom.Node{
-		gedcom.NewDateNode(nil, "Oct 1943", "", nil),
-	})
+	n1 := gedcom.NewResidenceNode("foo")
+	n2 := gedcom.NewResidenceNode("bar")
+	n3 := gedcom.NewResidenceNode("bar",
+		gedcom.NewDateNode("3 Sep 1943"),
+		gedcom.NewDateNode("Oct 1943"),
+	)
+	n4 := gedcom.NewResidenceNode("bar",
+		gedcom.NewDateNode("Oct 1943"),
+	)
 
 	// nils
 	Equals((*gedcom.ResidenceNode)(nil), (*gedcom.ResidenceNode)(nil)).Returns(false)
@@ -64,7 +60,7 @@ func TestResidenceNode_Equals(t *testing.T) {
 	Equals((*gedcom.ResidenceNode)(nil), n1).Returns(false)
 
 	// Wrong node type.
-	Equals(n1, gedcom.NewNameNode(nil, "foo", "", nil)).Returns(false)
+	Equals(n1, gedcom.NewNameNode("foo")).Returns(false)
 
 	// General cases.
 	Equals(n1, n1).Returns(false)
@@ -76,14 +72,14 @@ func TestResidenceNode_Equals(t *testing.T) {
 func TestResidenceNode_Years(t *testing.T) {
 	Years := tf.Function(t, (*gedcom.ResidenceNode).Years)
 
-	Years(gedcom.NewResidenceNode(nil, "", "", nil)).Returns(0.0)
+	Years(gedcom.NewResidenceNode("")).Returns(0.0)
 
-	Years(gedcom.NewResidenceNode(nil, "", "", []gedcom.Node{
-		gedcom.NewDateNode(nil, "3 SEP 1943", "", nil),
-	})).Returns(1943.672131147541)
+	Years(gedcom.NewResidenceNode("",
+		gedcom.NewDateNode("3 SEP 1943"),
+	)).Returns(1943.672131147541)
 
-	Years(gedcom.NewResidenceNode(nil, "", "", []gedcom.Node{
-		gedcom.NewDateNode(nil, "3 SEP 1943", "", nil),
-		gedcom.NewDateNode(nil, "3 SEP 1920", "", nil),
-	})).Returns(1920.6730245231608)
+	Years(gedcom.NewResidenceNode("",
+		gedcom.NewDateNode("3 SEP 1943"),
+		gedcom.NewDateNode("3 SEP 1920"),
+	)).Returns(1920.6730245231608)
 }

--- a/romanized_variation_node.go
+++ b/romanized_variation_node.go
@@ -19,9 +19,9 @@ type RomanizedVariationNode struct {
 }
 
 // NewRomanizedVariationNode creates a new ROMN node.
-func NewRomanizedVariationNode(document *Document, value, pointer string, children []Node) *RomanizedVariationNode {
+func NewRomanizedVariationNode(value string, children ...Node) *RomanizedVariationNode {
 	return &RomanizedVariationNode{
-		newSimpleNode(document, TagRomanized, value, pointer, children),
+		newSimpleNode(TagRomanized, value, "", children...),
 	}
 }
 

--- a/romanized_variation_node_test.go
+++ b/romanized_variation_node_test.go
@@ -7,17 +7,15 @@ import (
 )
 
 func TestNewRomanizedVariationNode(t *testing.T) {
-	doc := gedcom.NewDocument()
-	child := gedcom.NewNameNode(doc, "", "", nil)
-	node := gedcom.NewRomanizedVariationNode(doc, "foo", "bar", []gedcom.Node{child})
+	child := gedcom.NewNameNode("")
+	node := gedcom.NewRomanizedVariationNode("foo", child)
 
 	assert.NotNil(t, node)
 	assert.IsType(t, node, (*gedcom.RomanizedVariationNode)(nil))
 	assert.Equal(t, gedcom.TagRomanized, node.Tag())
-	assert.Equal(t, []gedcom.Node{child}, node.Nodes())
-	assert.Equal(t, doc, node.Document())
+	assert.Equal(t, gedcom.Nodes{child}, node.Nodes())
 	assert.Equal(t, "foo", node.Value())
-	assert.Equal(t, "bar", node.Pointer())
+	assert.Equal(t, "", node.Pointer())
 }
 
 func TestRomanizedVariationNode_Type(t *testing.T) {
@@ -31,32 +29,32 @@ func TestRomanizedVariationNode_Type(t *testing.T) {
 			expected: nil,
 		},
 		{
-			node:     gedcom.NewRomanizedVariationNode(nil, "", "", nil),
+			node:     gedcom.NewRomanizedVariationNode(""),
 			expected: nil,
 		},
 		{
-			node:     gedcom.NewRomanizedVariationNode(nil, "", "", []gedcom.Node{}),
+			node:     gedcom.NewRomanizedVariationNode(""),
 			expected: nil,
 		},
 		{
-			node: gedcom.NewRomanizedVariationNode(nil, "", "", []gedcom.Node{
-				gedcom.NewTypeNode(nil, "", "", []gedcom.Node{}),
-			}),
-			expected: gedcom.NewTypeNode(nil, "", "", []gedcom.Node{}),
+			node: gedcom.NewRomanizedVariationNode("",
+				gedcom.NewTypeNode(""),
+			),
+			expected: gedcom.NewTypeNode(""),
 		},
 		{
-			node: gedcom.NewRomanizedVariationNode(nil, "", "", []gedcom.Node{
-				gedcom.NewNameNode(nil, "", "", []gedcom.Node{}),
-			}),
+			node: gedcom.NewRomanizedVariationNode("",
+				gedcom.NewNameNode(""),
+			),
 			expected: nil,
 		},
 		{
-			node: gedcom.NewRomanizedVariationNode(nil, "", "", []gedcom.Node{
-				gedcom.NewNameNode(nil, "", "", []gedcom.Node{}),
-				gedcom.NewTypeNode(nil, "1", "", []gedcom.Node{}),
-				gedcom.NewTypeNode(nil, "2", "", []gedcom.Node{}),
-			}),
-			expected: gedcom.NewTypeNode(nil, "1", "", []gedcom.Node{}),
+			node: gedcom.NewRomanizedVariationNode("",
+				gedcom.NewNameNode(""),
+				gedcom.NewTypeNode("1"),
+				gedcom.NewTypeNode("2"),
+			),
+			expected: gedcom.NewTypeNode("1"),
 		},
 	}
 

--- a/simple_document_node.go
+++ b/simple_document_node.go
@@ -1,0 +1,33 @@
+package gedcom
+
+type simpleDocumentNode struct {
+	*SimpleNode
+	document *Document
+}
+
+func newSimpleDocumentNode(document *Document, tag Tag, value, pointer string, children ...Node) *simpleDocumentNode {
+	return &simpleDocumentNode{
+		SimpleNode: newSimpleNode(tag, value, pointer, children...),
+		document:   document,
+	}
+}
+
+func (node *simpleDocumentNode) Document() *Document {
+	return node.document
+}
+
+func (node *simpleDocumentNode) ShallowCopy() Node {
+	if IsNil(node) {
+		return nil
+	}
+
+	document := node.Document()
+	tag := node.Tag()
+	value := node.Value()
+	pointer := node.Pointer()
+
+	newNode := newSimpleDocumentNode(document, tag, value, pointer)
+	document.AddNode(newNode)
+
+	return newNode
+}

--- a/source_node.go
+++ b/source_node.go
@@ -5,9 +5,9 @@ type SourceNode struct {
 	*SimpleNode
 }
 
-func NewSourceNode(document *Document, value, pointer string, children []Node) *SourceNode {
+func NewSourceNode(value, pointer string, children ...Node) *SourceNode {
 	return &SourceNode{
-		newSimpleNode(document, TagSource, value, pointer, children),
+		newSimpleNode(TagSource, value, pointer, children...),
 	}
 }
 

--- a/type_node.go
+++ b/type_node.go
@@ -11,8 +11,8 @@ type TypeNode struct {
 }
 
 // NewTypeNode creates a new TYPE node.
-func NewTypeNode(document *Document, value, pointer string, children []Node) *TypeNode {
+func NewTypeNode(value string, children ...Node) *TypeNode {
 	return &TypeNode{
-		newSimpleNode(document, TagType, value, pointer, children),
+		newSimpleNode(TagType, value, "", children...),
 	}
 }

--- a/type_node_test.go
+++ b/type_node_test.go
@@ -7,15 +7,13 @@ import (
 )
 
 func TestNewTypeNode(t *testing.T) {
-	doc := gedcom.NewDocument()
-	child := gedcom.NewNameNode(doc, "", "", nil)
-	node := gedcom.NewTypeNode(doc, "foo", "bar", []gedcom.Node{child})
+	child := gedcom.NewNameNode("")
+	node := gedcom.NewTypeNode("foo", child)
 
 	assert.NotNil(t, node)
 	assert.IsType(t, node, (*gedcom.TypeNode)(nil))
 	assert.Equal(t, gedcom.TagType, node.Tag())
-	assert.Equal(t, []gedcom.Node{child}, node.Nodes())
-	assert.Equal(t, doc, node.Document())
+	assert.Equal(t, gedcom.Nodes{child}, node.Nodes())
 	assert.Equal(t, "foo", node.Value())
-	assert.Equal(t, "bar", node.Pointer())
+	assert.Equal(t, "", node.Pointer())
 }

--- a/unique_id_node.go
+++ b/unique_id_node.go
@@ -39,9 +39,9 @@ type UniqueIDNode struct {
 	*SimpleNode
 }
 
-func NewUniqueIDNode(document *Document, value, pointer string, children []Node) *UniqueIDNode {
+func NewUniqueIDNode(value string, children ...Node) *UniqueIDNode {
 	return &UniqueIDNode{
-		newSimpleNode(document, UnofficialTagUniqueID, value, pointer, children),
+		newSimpleNode(UnofficialTagUniqueID, value, "", children...),
 	}
 }
 
@@ -56,7 +56,7 @@ func NewUniqueIDNode(document *Document, value, pointer string, children []Node)
 // GEDCOM tag to carry that identifier. The Universally Unique ID (UUID) is that
 // globally unique identifier, and _UID is the tag that carries it.
 //
-// Microsoft developers known UUID as Globally Unique IDentifier (GUID). What
+// Microsoft developers known UUID as Globally Unique Identifier (GUID). What
 // makes UUIDs so suitable is that they were developed so precisely so that
 // everyone can generate UUIDs, without coordinating with anyone else, and still
 // be practically sure that the generated identifier is unique.

--- a/unique_id_node_test.go
+++ b/unique_id_node_test.go
@@ -14,40 +14,38 @@ var uniqueIDNodeTests = map[string]struct {
 	checksum string
 }{
 	"Empty": {
-		node:     gedcom.NewUniqueIDNode(nil, "", "", nil),
+		node:     gedcom.NewUniqueIDNode(""),
 		uuid:     gedcom.UUID(""),
 		uuidErr:  errors.New("invalid UUID: "),
 		checksum: "",
 	},
 	"UUIDOnly": {
-		node:     gedcom.NewUniqueIDNode(nil, "EE13561DDB204985BFFDEEBF82A5226C", "", nil),
+		node:     gedcom.NewUniqueIDNode("EE13561DDB204985BFFDEEBF82A5226C"),
 		uuid:     gedcom.UUID("ee13561d-db20-4985-bffd-eebf82a5226c"),
 		checksum: "",
 	},
 	"UUIDAndChecksum": {
-		node:     gedcom.NewUniqueIDNode(nil, "EE13561DDB204985BFFDEEBF82A5226C5B2E", "", nil),
+		node:     gedcom.NewUniqueIDNode("EE13561DDB204985BFFDEEBF82A5226C5B2E"),
 		uuid:     gedcom.UUID("ee13561d-db20-4985-bffd-eebf82a5226c"),
 		checksum: "5B2E",
 	},
 	"GUIDOnly": {
-		node:     gedcom.NewUniqueIDNode(nil, "{EE13561D-DB20-4985-BFFD-EEBF82A5226C}", "", nil),
+		node:     gedcom.NewUniqueIDNode("{EE13561D-DB20-4985-BFFD-EEBF82A5226C}"),
 		uuid:     gedcom.UUID("ee13561d-db20-4985-bffd-eebf82a5226c"),
 		checksum: "",
 	},
 }
 
 func TestNewUniqueIDNode(t *testing.T) {
-	doc := gedcom.NewDocument()
-	child := gedcom.NewNameNode(doc, "", "", nil)
-	node := gedcom.NewUniqueIDNode(doc, "foo", "bar", []gedcom.Node{child})
+	child := gedcom.NewNameNode("")
+	node := gedcom.NewUniqueIDNode("foo", child)
 
 	assert.NotNil(t, node)
 	assert.IsType(t, node, (*gedcom.UniqueIDNode)(nil))
 	assert.Equal(t, gedcom.UnofficialTagUniqueID, node.Tag())
-	assert.Equal(t, []gedcom.Node{child}, node.Nodes())
-	assert.Equal(t, doc, node.Document())
+	assert.Equal(t, gedcom.Nodes{child}, node.Nodes())
 	assert.Equal(t, "foo", node.Value())
-	assert.Equal(t, "bar", node.Pointer())
+	assert.Equal(t, "", node.Pointer())
 }
 
 func TestUniqueIDNode_UUID(t *testing.T) {
@@ -79,33 +77,33 @@ func TestUniqueIDNode_Equals(t *testing.T) {
 		expected bool
 	}{
 		"Equal1": {
-			gedcom.NewUniqueIDNode(nil, "EE13561DDB204985BFFDEEBF82A5226C", "", nil),
-			gedcom.NewUniqueIDNode(nil, "EE13561DDB204985BFFDEEBF82A5226C", "", nil),
+			gedcom.NewUniqueIDNode("EE13561DDB204985BFFDEEBF82A5226C"),
+			gedcom.NewUniqueIDNode("EE13561DDB204985BFFDEEBF82A5226C"),
 			true,
 		},
 		"Equal2": {
-			gedcom.NewUniqueIDNode(nil, "EE13561DDB204985BFFDEEBF82A5226C", "", nil),
-			gedcom.NewUniqueIDNode(nil, "EE13561DDB204985BFFDEEBF82A5226C5B2E", "", nil),
+			gedcom.NewUniqueIDNode("EE13561DDB204985BFFDEEBF82A5226C"),
+			gedcom.NewUniqueIDNode("EE13561DDB204985BFFDEEBF82A5226C5B2E"),
 			true,
 		},
 		"Equal3": {
-			gedcom.NewUniqueIDNode(nil, "EE13561DDB204985BFFDEEBF82A5226C5B2E", "", nil),
-			gedcom.NewUniqueIDNode(nil, "EE13561DDB204985BFFDEEBF82A5226C5B2E", "", nil),
+			gedcom.NewUniqueIDNode("EE13561DDB204985BFFDEEBF82A5226C5B2E"),
+			gedcom.NewUniqueIDNode("EE13561DDB204985BFFDEEBF82A5226C5B2E"),
 			true,
 		},
 		"NotEqual1": {
-			gedcom.NewUniqueIDNode(nil, "AE13561DDB204985BFFDEEBF82A5226C", "", nil),
-			gedcom.NewUniqueIDNode(nil, "EE13561DDB204985BFFDEEBF82A5226C", "", nil),
+			gedcom.NewUniqueIDNode("AE13561DDB204985BFFDEEBF82A5226C"),
+			gedcom.NewUniqueIDNode("EE13561DDB204985BFFDEEBF82A5226C"),
 			false,
 		},
 		"NotEqual2": {
-			gedcom.NewUniqueIDNode(nil, "AE13561DDB204985BFFDEEBF82A5226C", "", nil),
-			gedcom.NewUniqueIDNode(nil, "EE13561DDB204985BFFDEEBF82A5226C5B2E", "", nil),
+			gedcom.NewUniqueIDNode("AE13561DDB204985BFFDEEBF82A5226C"),
+			gedcom.NewUniqueIDNode("EE13561DDB204985BFFDEEBF82A5226C5B2E"),
 			false,
 		},
 		"NotEqual3": {
-			gedcom.NewUniqueIDNode(nil, "AE13561DDB204985BFFDEEBF82A5226C5B2E", "", nil),
-			gedcom.NewUniqueIDNode(nil, "EE13561DDB204985BFFDEEBF82A5226C5B2E", "", nil),
+			gedcom.NewUniqueIDNode("AE13561DDB204985BFFDEEBF82A5226C5B2E"),
+			gedcom.NewUniqueIDNode("EE13561DDB204985BFFDEEBF82A5226C5B2E"),
 			false,
 		},
 	} {

--- a/util.go
+++ b/util.go
@@ -105,14 +105,14 @@ func Value(node Node) string {
 //
 //   nil
 //   Node
-//   []Node
+//   Nodes
 //
 // If any of the inputs are not one of the above types then a panic is raised.
 //
-// Using nil as a Node or including nil as one of the elements for []Node will
+// Using nil as a Node or including nil as one of the elements for Nodes will
 // be ignored, so you should not receive any nil values in the output.
-func Compound(nodes ...interface{}) []Node {
-	result := []Node{}
+func Compound(nodes ...interface{}) Nodes {
+	result := Nodes{}
 
 	for _, n := range nodes {
 		v := reflect.ValueOf(n)

--- a/util_test.go
+++ b/util_test.go
@@ -54,30 +54,30 @@ func TestCleanSpace(t *testing.T) {
 }
 
 var firtLastTests = []struct {
-	nodes       []gedcom.Node
+	nodes       gedcom.Nodes
 	first, last gedcom.Node
 }{
-	{[]gedcom.Node{}, nil, nil},
-	{[]gedcom.Node{nil}, nil, nil},
+	{gedcom.Nodes{}, nil, nil},
+	{gedcom.Nodes{nil}, nil, nil},
 	{
-		[]gedcom.Node{gedcom.NewNameNode(nil, "a", "", nil)},
-		gedcom.NewNameNode(nil, "a", "", nil),
-		gedcom.NewNameNode(nil, "a", "", nil),
+		gedcom.Nodes{gedcom.NewNameNode("a")},
+		gedcom.NewNameNode("a"),
+		gedcom.NewNameNode("a"),
 	},
 	{
-		[]gedcom.Node{nil, gedcom.NewNameNode(nil, "a", "", nil)},
-		gedcom.NewNameNode(nil, "a", "", nil),
-		gedcom.NewNameNode(nil, "a", "", nil),
+		gedcom.Nodes{nil, gedcom.NewNameNode("a")},
+		gedcom.NewNameNode("a"),
+		gedcom.NewNameNode("a"),
 	},
 	{
-		[]gedcom.Node{
+		gedcom.Nodes{
 			nil,
-			gedcom.NewNameNode(nil, "a", "", nil),
-			gedcom.NewNameNode(nil, "b", "", nil),
+			gedcom.NewNameNode("a"),
+			gedcom.NewNameNode("b"),
 			nil,
 		},
-		gedcom.NewNameNode(nil, "a", "", nil),
-		gedcom.NewNameNode(nil, "b", "", nil),
+		gedcom.NewNameNode("a"),
+		gedcom.NewNameNode("b"),
 	},
 }
 
@@ -103,8 +103,8 @@ func TestValue(t *testing.T) {
 		want string
 	}{
 		{nil, ""},
-		{gedcom.NewNodeWithChildren(nil, gedcom.TagVersion, "foo", "", nil), "foo"},
-		{gedcom.NewNameNode(nil, "foo bar", "", nil), "foo bar"},
+		{gedcom.NewNode(gedcom.TagVersion, "foo", ""), "foo"},
+		{gedcom.NewNameNode("foo bar"), "foo bar"},
 	}
 
 	for _, test := range tests {
@@ -115,22 +115,22 @@ func TestValue(t *testing.T) {
 }
 
 func TestCompound(t *testing.T) {
-	n1 := gedcom.NewNameNode(nil, "Joe /Bloggs/", "", []gedcom.Node{})
-	n2 := gedcom.NewNameNode(nil, "Jane /Doe/", "", []gedcom.Node{})
-	n3 := gedcom.NewNameNode(nil, "John /Smith/", "", []gedcom.Node{})
+	n1 := gedcom.NewNameNode("Joe /Bloggs/")
+	n2 := gedcom.NewNameNode("Jane /Doe/")
+	n3 := gedcom.NewNameNode("John /Smith/")
 
 	tests := []struct {
 		inputs []interface{}
-		want   []gedcom.Node
+		want   gedcom.Nodes
 	}{
-		{[]interface{}{}, []gedcom.Node{}},
-		{[]interface{}{nil}, []gedcom.Node{}},
-		{[]interface{}{n1}, []gedcom.Node{n1}},
-		{[]interface{}{n1, n1}, []gedcom.Node{n1, n1}},
-		{[]interface{}{n1, nil, n2}, []gedcom.Node{n1, n2}},
-		{[]interface{}{[]gedcom.Node{n1, n2}}, []gedcom.Node{n1, n2}},
-		{[]interface{}{[]gedcom.Node{n1, n2}, n3}, []gedcom.Node{n1, n2, n3}},
-		{[]interface{}{[]gedcom.Node{nil, n2}, n3}, []gedcom.Node{n2, n3}},
+		{[]interface{}{}, gedcom.Nodes{}},
+		{[]interface{}{nil}, gedcom.Nodes{}},
+		{[]interface{}{n1}, gedcom.Nodes{n1}},
+		{[]interface{}{n1, n1}, gedcom.Nodes{n1, n1}},
+		{[]interface{}{n1, n2}, gedcom.Nodes{n1, n2}},
+		{[]interface{}{gedcom.Nodes{n1, n2}}, gedcom.Nodes{n1, n2}},
+		{[]interface{}{gedcom.Nodes{n1, n2}, n3}, gedcom.Nodes{n1, n2, n3}},
+		{[]interface{}{gedcom.Nodes{nil, n2}, n3}, gedcom.Nodes{n2, n3}},
 	}
 
 	for _, test := range tests {
@@ -143,8 +143,8 @@ func TestCompound(t *testing.T) {
 func TestNodeCondition(t *testing.T) {
 	NodeCondition := tf.Function(t, gedcom.NodeCondition)
 
-	bob := gedcom.NewNameNode(nil, "Bob", "", nil)
-	sally := gedcom.NewNameNode(nil, "Sally", "", nil)
+	bob := gedcom.NewNameNode("Bob")
+	sally := gedcom.NewNameNode("Sally")
 
 	NodeCondition(true, bob, sally).Returns(bob)
 	NodeCondition(false, bob, sally).Returns(sally)
@@ -156,8 +156,9 @@ func TestPointer(t *testing.T) {
 		want string
 	}{
 		{nil, ""},
-		{gedcom.NewNodeWithChildren(nil, gedcom.TagVersion, "foo", "a", nil), "a"},
-		{gedcom.NewNameNode(nil, "foo bar", "b", nil), "b"},
+		{gedcom.NewNode(gedcom.TagVersion, "foo", "a"), "a"},
+		{gedcom.NewDocument().AddIndividual("b"), "b"},
+		{gedcom.NewDocument().AddFamily("c"), "c"},
 	}
 
 	for _, test := range tests {
@@ -168,64 +169,64 @@ func TestPointer(t *testing.T) {
 }
 
 func TestDateAndPlace(t *testing.T) {
-	date3Sep1953 := gedcom.NewDateNode(nil, "3 Sep 1953", "", nil)
-	date1Sep1953 := gedcom.NewDateNode(nil, "1 Sep 1953", "", nil)
-	place1 := gedcom.NewPlaceNode(nil, "Australia", "", nil)
-	place2 := gedcom.NewPlaceNode(nil, "United Kingdom", "", nil)
+	date3Sep1953 := gedcom.NewDateNode("3 Sep 1953")
+	date1Sep1953 := gedcom.NewDateNode("1 Sep 1953")
+	place1 := gedcom.NewPlaceNode("Australia")
+	place2 := gedcom.NewPlaceNode("United Kingdom")
 
 	// ghost:ignore
 	for _, test := range []struct {
-		nodes []gedcom.Node
+		nodes gedcom.Nodes
 		date  *gedcom.DateNode
 		place *gedcom.PlaceNode
 	}{
 		{
-			nodes: []gedcom.Node{},
+			nodes: gedcom.Nodes{},
 			date:  nil,
 			place: nil,
 		},
 		{
-			nodes: []gedcom.Node{
-				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{date3Sep1953}),
+			nodes: gedcom.Nodes{
+				gedcom.NewBirthNode("", date3Sep1953),
 			},
 			date:  date3Sep1953,
 			place: nil,
 		},
 		{
-			nodes: []gedcom.Node{
-				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{date3Sep1953}),
-				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{date1Sep1953}),
+			nodes: gedcom.Nodes{
+				gedcom.NewBirthNode("", date3Sep1953),
+				gedcom.NewBirthNode("", date1Sep1953),
 			},
 			date:  date3Sep1953,
 			place: nil,
 		},
 		{
-			nodes: []gedcom.Node{
-				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{place1}),
+			nodes: gedcom.Nodes{
+				gedcom.NewBirthNode("", place1),
 			},
 			date:  nil,
 			place: place1,
 		},
 		{
-			nodes: []gedcom.Node{
-				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{date3Sep1953, place1}),
+			nodes: gedcom.Nodes{
+				gedcom.NewBirthNode("", date3Sep1953, place1),
 			},
 			date:  date3Sep1953,
 			place: place1,
 		},
 		{
-			nodes: []gedcom.Node{
-				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{date3Sep1953}),
-				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{place1}),
+			nodes: gedcom.Nodes{
+				gedcom.NewBirthNode("", date3Sep1953),
+				gedcom.NewBirthNode("", place1),
 			},
 			date:  date3Sep1953,
 			place: place1,
 		},
 		{
-			nodes: []gedcom.Node{
-				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{date3Sep1953}),
-				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{place1}),
-				gedcom.NewBirthNode(nil, "", "", []gedcom.Node{place2, date1Sep1953}),
+			nodes: gedcom.Nodes{
+				gedcom.NewBirthNode("", date3Sep1953),
+				gedcom.NewBirthNode("", place1),
+				gedcom.NewBirthNode("", place2, date1Sep1953),
 			},
 			date:  date3Sep1953,
 			place: place1,

--- a/wife_node.go
+++ b/wife_node.go
@@ -1,0 +1,53 @@
+package gedcom
+
+import "fmt"
+
+// WifeNode is the natural, adopted, or sealed (LDS) child of a father and a
+// mother.
+type WifeNode struct {
+	*SimpleNode
+	family *FamilyNode
+}
+
+func newWifeNode(family *FamilyNode, value string, children ...Node) *WifeNode {
+	return &WifeNode{
+		newSimpleNode(TagWife, value, "", children...),
+		family,
+	}
+}
+
+func newWifeNodeWithIndividual(family *FamilyNode, individual *IndividualNode) *WifeNode {
+	// TODO: check individual belongs to the same document as family
+	return newWifeNode(family, fmt.Sprintf("@%s@", individual.Pointer()))
+}
+
+func (node *WifeNode) Family() *FamilyNode {
+	return node.family
+}
+
+func (node *WifeNode) Individual() *IndividualNode {
+	if node == nil {
+		return nil
+	}
+
+	n := node.family.document.NodeByPointer(valueToPointer(node.value))
+
+	// TODO: may not exist
+	return n.(*IndividualNode)
+}
+
+func (node *WifeNode) Similarity(other *WifeNode, options SimilarityOptions) float64 {
+	if node == nil || other == nil {
+		return 0.5
+	}
+
+	return node.Individual().Similarity(other.Individual(), options)
+}
+
+func (node *WifeNode) IsIndividual(node2 *IndividualNode) bool {
+	if node == nil || node2 == nil {
+		return false
+	}
+
+	return node.Individual().Is(node2)
+}

--- a/years_test.go
+++ b/years_test.go
@@ -14,8 +14,8 @@ func TestYears(t *testing.T) {
 		{nil, 0},
 		{gedcom.Yearer(nil), 0},
 		{gedcom.Date{1, 1, 1789, false, gedcom.DateConstraintExact}, 1789.0027322404371},
-		{gedcom.NewDateNode(nil, "Foo", "", nil), 0},
-		{gedcom.NewDateNode(nil, "31 Jan 1435", "", nil), 1435.0846994535518},
+		{gedcom.NewDateNode("Foo"), 0},
+		{gedcom.NewDateNode("31 Jan 1435"), 1435.0846994535518},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This is the biggest refactoring in a long time. This address several issues with the API that have been bothing me.

1. All nodes were created with basically the same interface, that always required a document. Now constructors are much more simple for most of them that do not need a document. For the handful that still do, these can only be created from the document itself to prevent the need to pass the Document around separately.

2. Since nodes that require an owner (such as a Document or Family) can only be created through these entities it will greatly improve strategies for caching where changed occur after the document is initially loaded. I haven't heavily jumped into this teritory, but it will have to happen soon.

3. Families are now structures correctly with ChildNode, HusbandNode and WifeNode rather than trying to step around these. Apart from being closer to the GEDCOM structure this also make it easier to build families programamtically without awkwardly moving pointers around as values.

4. Nodes is a new type for []Node.

Other more minor changes such as deleting nodes and correctly mapping documents when duplicating nodes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/gedcom/232)
<!-- Reviewable:end -->
