### PR TITLE
Refactoring DateNode to DateRange

### DIFF
--- a/date_node.go
+++ b/date_node.go
@@ -1,314 +1,47 @@
-// Dates
-//
-// Dates in GEDCOM files can be very complex as they can cater for many
-// scenarios:
-//
-// 1. Incomplete, like "Dec 1943"
-//
-// 2. Anchored, like "Aft. 3 Sep 2003" or "Before 1923"
-//
-// 3. Ranges, like "Bet. 4 Apr 1823 and 8 Apr 1823"
-//
-// 4. Phrases, like "(Foo Bar)"
-//
-// This package provides a very rich API for dealing with all kind of dates in a
-// meaningful and sensible way. Some notable features include:
-//
-// 1. All dates, even though that specify an specific day have a minimum and
-// maximum value that are their true bounds. This is especially important for
-// larger date ranges like the whole month of "Jun 1945".
-//
-// 2. Upper and lower bounds of dates can be converted to the native Go
-// time.Time object.
-//
-// 3. There is a Years function that provides a convenient way to normalise a
-// date range into a number for easier distance and comparison measurements.
-//
-// 4. Algorithms for calculating the similarity of dates on a configurable
-// parabola.
 package gedcom
 
 import (
-	"errors"
 	"fmt"
-	"math"
-	"regexp"
-	"strings"
-	"time"
 )
-
-// DefaultMaxYearsForSimilarity is a sensible default for the Similarity
-// function (maxYears) when comparing dates. The importance of maxYears is
-// explained in DateNode.Similarity.
-//
-// Unless you need to ensure similarity values are retained correctly through
-// versions you should use this constant instead of specifying a raw value to
-// DateNode.Similarity. This value may change in time if a more accurate default
-// is found.
-//
-// The gedcomtune tool was used to find an ideal value for this. Generally
-// speaking 2 - 3 years yielded much the same result. Any further in either
-// direction led to a drop in accuracy for matching individuals.
-const DefaultMaxYearsForSimilarity = float64(3)
 
 // DateNode represents a DATE node.
 //
-// A date in GEDCOM always represents a range contained between the StartDate()
-// and EndDate(), even when it represents a single day, like "23 Jan 1921".
-//
-// Before diving into the full specs below you should be aware of the known
-// limitations:
-//
-// 1. Only the Gregorian calendar with the English language (for month names)
-// is currently supported.
-//
-// 2. You should only expect dates that are valid and within the range of Go's
-// supported libraries will work correctly. That is years between 0 and 9999. It
-// is possible that dates outside of this range may be interpreted correctly but
-// you should not rely on that remaining the same.
-//
-// 3. There are surly more keyword combinations used in GEDCOM files than are
-// documented below. Interpreting these dates is not necessarily guaranteed to
-// work, not work or retain the same behaviour between releases. If you believe
-// there are other known cases please open an issue or pull request.
-//
-// Now into the specification. There are two basic forms of a DATE value:
-//
-//   between date and date
-//   date
-//
-// The second case is actually equivalent to the first case the the same "date"
-// substituted twice.
-//
-// The "between" keyword can be any of (non case sensitive):
-//
-//   between
-//   bet
-//   bet.
-//   from
-//
-// The "and" keyword can be one of (non case sensitive):
-//
-//   -
-//   and
-//   to
-//
-// A "date" has three basic forms:
-//
-//   prefix? day month year
-//   prefix? month year
-//   prefix? year
-//
-// The "prefix" is optional and can be used to indicate if the date is
-// approximate or not with one of the following keywords:
-//
-//   abt
-//   abt.
-//   about
-//   c.
-//   circa
-//
-// Or, the "prefix" can be used to signify unbounded dates with one of the
-// following keywords:
-//
-//   after
-//   aft
-//   aft.
-//   before
-//   bef
-//   bef.
-//
-// The "day" must be an integer between 1 and 31 and can have a single
-// proceeding zero, like "03". The day should be valid against the month used.
-// The behavior is unexpected when using invalid dates like "31 Feb 1999", but
-// you will likely not receive a date at all if it's invalid.
-//
-// The "month" must be one of the following strings (case in-sensitive):
-//
-//   apr
-//   april
-//   aug
-//   august
-//   dec
-//   december
-//   feb
-//   february
-//   jan
-//   january
-//   jul
-//   july
-//   jun
-//   june
-//   mar
-//   march
-//   may
-//   nov
-//   november
-//   oct
-//   october
-//   sep
-//   september
-//
-// The "year" must be an integer with a value between 0 and 9999 (as to conform
-// to the restrictions of the Go time package). It may be possible to parse
-// dates outside of this range but they behaviour is not defined.
-//
-// The "year" may be 1 to 4 digits but it always treated as the absolute year.
-// The year 89 is treated as the year 89, not 1989, for example.
+// See the full specification for dates in the documentation for Date.
 type DateNode struct {
 	*SimpleNode
-	didParseDate    bool
-	parsedStartDate Date
-	parsedEndDate   Date
+
+	// Dates are expensive to parse so we should not attempt to parse the value
+	// until it is needed. Also, if we have already parsed the value once it
+	// should not be parsed again.
+	alreadyParsed   bool
+	parsedDateRange DateRange
 }
 
 // NewDateNode creates a new DATE node.
 func NewDateNode(value string, children ...Node) *DateNode {
 	return &DateNode{
 		newSimpleNode(TagDate, value, "", children...),
-		false, Date{}, Date{},
+		false, DateRange{},
 	}
 }
-
-func (node *DateNode) parse(dateToTest string, layoutsToTry []string) (Date, error) {
-	for _, layout := range layoutsToTry {
-		ts, err := time.Parse(layout, dateToTest)
-		if err == nil {
-			return Date{
-				Day:   ts.Day(),
-				Month: ts.Month(),
-				Year:  ts.Year(),
-			}, nil
-		}
-	}
-
-	// Cannot parse date.
-	return Date{}, errors.New("cannot parse date")
-}
-
-var months = map[string]time.Month{
-	"apr":       time.April,
-	"april":     time.April,
-	"aug":       time.August,
-	"august":    time.August,
-	"dec":       time.December,
-	"december":  time.December,
-	"feb":       time.February,
-	"february":  time.February,
-	"jan":       time.January,
-	"january":   time.January,
-	"jul":       time.July,
-	"july":      time.July,
-	"jun":       time.June,
-	"june":      time.June,
-	"mar":       time.March,
-	"march":     time.March,
-	"may":       time.May,
-	"nov":       time.November,
-	"november":  time.November,
-	"oct":       time.October,
-	"october":   time.October,
-	"sep":       time.September,
-	"september": time.September,
-}
-
-func parseMonthName(parts []string, monthPos int) (string, error) {
-	if len(parts) == 0 {
-		return "", errors.New("cannot parse month")
-	}
-
-	monthName := strings.ToLower(parts[monthPos])
-
-	return CleanSpace(monthName), nil
-}
-
-var dateRegexp = regexp.MustCompile(
-	fmt.Sprintf(`(?i)^(%s|%s|%s)? ?(\d+ )?(\w+ )?(\d+)$`,
-		DateWordsAbout, DateWordsBefore, DateWordsAfter))
-
-func parseDateParts(dateString string, isEndOfRange bool) Date {
-	parts := dateRegexp.FindStringSubmatch(dateString)
-
-	// Place holders for the locations of each regexp group.
-	constraintPos, dayPos, monthPos, yearPos := 1, 2, 3, 4
-
-	monthName, err := parseMonthName(parts, monthPos)
-
-	switch {
-	case len(parts) == 0, // Could not match the regexp.
-		err != nil: // The month is unknown.
-		return Date{
-			IsEndOfRange: isEndOfRange,
-		}
-	}
-
-	day := Atoi(parts[dayPos])
-	month := time.Month(months[monthName])
-	year := Atoi(parts[yearPos])
-
-	// Check the date is valid.
-	_, err = time.Parse("_2 1 2006",
-		fmt.Sprintf("%d %d %04d", day, month, year))
-	if parts[dayPos] != "" && err != nil {
-		return Date{
-			IsEndOfRange: isEndOfRange,
-			Constraint:   DateConstraintFromString(parts[constraintPos]),
-		}
-	}
-
-	return Date{
-		Day:          day,
-		Month:        month,
-		Year:         year,
-		IsEndOfRange: isEndOfRange,
-		Constraint:   DateConstraintFromString(parts[constraintPos]),
-	}
-}
-
-var rangeRegexp = regexp.MustCompile(fmt.Sprintf(`(?i)^(%s) (.+) (%s) (.+)$`,
-	DateWordsBetween, DateWordsAnd))
 
 // If the node is nil both results will be zero dates.
-func (node *DateNode) DateRange() (startDate Date, endDate Date) {
+func (node *DateNode) DateRange() (dateRange DateRange) {
 	if node == nil {
-		return Date{}, Date{}
+		return NewZeroDateRange()
 	}
 
 	// Parsing dates is very expensive. Cache them.
-	if node.didParseDate {
-		return node.parsedStartDate, node.parsedEndDate
+	if node.alreadyParsed {
+		return node.parsedDateRange
 	}
 
 	defer func(node *DateNode) {
-		node.parsedStartDate = startDate
-		node.parsedEndDate = endDate
-		node.didParseDate = true
+		node.parsedDateRange = dateRange
+		node.alreadyParsed = true
 	}(node)
 
-	dateString := CleanSpace(node.Value())
-
-	// Try to match a range first.
-	parts := rangeRegexp.FindStringSubmatch(dateString)
-	if len(parts) > 0 {
-		return parseDateParts(parts[2], false), parseDateParts(parts[4], true)
-	}
-
-	// Single date.
-	return parseDateParts(dateString, false), parseDateParts(dateString, true)
-}
-
-// StartDate returns the start component date of DateRange.
-func (node *DateNode) StartDate() Date {
-	start, _ := node.DateRange()
-
-	return start
-}
-
-// EndDate returns the end component date of DateRange.
-func (node *DateNode) EndDate() Date {
-	_, end := node.DateRange()
-
-	return end
+	return NewDateRangeWithString(node.Value())
 }
 
 // String returns the date range as defined in the specification of DateNode.
@@ -320,7 +53,7 @@ func (node *DateNode) EndDate() Date {
 //   Abt. 13 Nov 1983
 //
 func (node *DateNode) String() string {
-	startDate, endDate := node.DateRange()
+	startDate, endDate := node.StartAndEndDates()
 
 	if startDate.Is(endDate) {
 		return startDate.String()
@@ -329,89 +62,22 @@ func (node *DateNode) String() string {
 	return fmt.Sprintf("Bet. %s and %s", startDate, endDate)
 }
 
-// Years works in a similar way to Date.Years() but also takes into
-// consideration the StartDate() and EndDate() values of a whole date range,
-// like "Bet. 1943 and 1945". It does this by averaging out the Years() value of
-// the StartDate() and EndDate() values.
+// Years fulfils the Yearer interface and is a convenience for:
 //
-// If the DateNode has a single date, like "Mar 1937" then Years will return the
-// same value as the Years on the start or end date (no average will be used.)
+//   node.DateRange().Years()
 //
-// You can read the specific conversion rules in Date.Years() but be aware that
-// the returned value is an approximation and should not be used in date
-// calculations.
 func (node *DateNode) Years() float64 {
-	start, end := node.DateRangeYears()
-
-	return (start + end) / 2.0
+	return node.DateRange().Years()
 }
 
-// DateRangeYears returns the Years values for the DateRange.
-func (node *DateNode) DateRangeYears() (float64, float64) {
-	start, end := node.DateRange()
-
-	return start.Years(), end.Years()
-}
-
-// Similarity returns a value from 0.0 to 1.0 to identify how similar two dates
-// (or date ranges) are to each other. 1.0 would mean that the dates are exactly
-// the same, whereas 0.0 would mean that they are not similar at all.
-//
-// Similarity is safe to use when either date is nil. If either side is nil then
-// 0.5 is returned. Not because they are similar but because there is not enough
-// information to make the distinction either way. This is important when using
-// date comparisons in combination or part of larger calculations where missing
-// data on both sides does not lead to very low scores unnecessarily.
-//
-// The returned value is calculated on a parabola that awards higher values to
-// dates that are proportionally closer to each other. That is, dates that are
-// twice as close will have more than twice the score. This attempts to satisfy
-// a usable comparison values for close specific dates as well as more relaxed
-// values (such as those that one provide an approximate year).
-//
-// Only the difference between dates is used in the calculation so it is not
-// affected by time lines. That is to say that the difference between the years
-// 500 and 502 would return the same similarity as the years 2000 to 2002.
-//
-// The maxYears allows the error margin to be adjusted. Dates that are further
-// apart (in any direction) than maxYears will always return 0.0.
-//
-// A greater maxYears can be used when dates are less exact (such as ancient
-// dates that could be commonly off by 10 years or more) or a smaller value when
-// dealing with recent dates that are provided in a more exact form.
-//
-// A sensible default value for maxYears is provided with
-// DefaultMaxYearsForSimilarity. You should use this if you are unsure. There is
-// also more explanation on the constant.
 func (node *DateNode) Similarity(node2 *DateNode, maxYears float64) float64 {
 	if node == nil || node2 == nil {
 		return 0.5
 	}
 
-	leftYears := node.Years()
-	rightYears := node2.Years()
-	yearsApart := leftYears - rightYears
-	similarity := math.Pow(yearsApart/maxYears, 2)
-
-	// When one date is invalid the similarity will go asymptotic.
-	if similarity > 1 {
-		return 0
-	}
-
-	return 1 - similarity
+	return node.DateRange().Similarity(node2.DateRange(), maxYears)
 }
 
-// Equals compares the values of two dates taking into consideration the date
-// constraint.
-//
-// If either date is nil then false is always returned. Even if both dates are
-// nil.
-//
-// A DateNode is considered to be equal only when its StartDate() and EndDate()
-// both equal their respective values in the other DateNode.
-//
-// The comparisons of dates is quite complicated. See the documentation for
-// Date.Equals for a full explanation.
 func (node *DateNode) Equals(node2 Node) bool {
 	leftIsNil := IsNil(node)
 	rightIsNil := IsNil(node2)
@@ -421,79 +87,60 @@ func (node *DateNode) Equals(node2 Node) bool {
 	}
 
 	if date2, ok := node2.(*DateNode); ok {
-		// Phrases can only be compared to themselves and they must be the exact
-		// same value to be considered equal.
-		if node.IsPhrase() && date2.IsPhrase() && node.value == date2.value {
-			return true
-		}
-
-		// Invalid dates follow the same rules as phrases.
-		if !node.IsValid() && !date2.IsValid() && node.value == date2.value {
-			return true
-		}
-
-		// Compare dates by value range.
-		matchStartDate := node.StartDate().Equals(date2.StartDate())
-		matchEndDate := node.EndDate().Equals(date2.EndDate())
-
-		return matchStartDate && matchEndDate
+		return node.DateRange().Equals(date2.DateRange())
 	}
 
 	return false
 }
 
-// IsValid returns true only when the node is not nil and the start and end date
-// are non-zero.
-//
-// A "zero date" (Date.IsZero) is a date that is missing the year, month and
-// day. Even if there is other associated information this date is considered to
-// be useless for most purposes.
-//
-// It is safe and completely valid to use IsValid on a nil node.
 func (node *DateNode) IsValid() bool {
 	if node == nil {
 		return false
 	}
 
-	start, end := node.DateRange()
-
-	return !start.IsZero() && !end.IsZero()
+	return node.DateRange().IsValid()
 }
 
-// IsExact will return true if the date range represents a single day with an
-// exact constraint.
-//
-// See Date.IsExact for more information.
+func (node *DateNode) StartDate() Date {
+	if node == nil {
+		return Date{}
+	}
+
+	dateRange := node.DateRange()
+
+	return dateRange.StartDate()
+}
+
+func (node *DateNode) EndDate() Date {
+	if node == nil {
+		return Date{}
+	}
+
+	dateRange := node.DateRange()
+
+	return dateRange.EndDate()
+}
+
+func (node *DateNode) StartAndEndDates() (Date, Date) {
+	if node == nil {
+		return NewZeroDateRange().StartAndEndDates()
+	}
+
+	return node.DateRange().StartAndEndDates()
+}
+
 func (node *DateNode) IsExact() bool {
-	start, end := node.DateRange()
-	startIsExact := start.IsExact()
-	endIsExact := end.IsExact()
+	if node == nil {
+		return false
+	}
 
-	return startIsExact && endIsExact
+	return node.DateRange().IsExact()
 }
 
-// IsPhrase returns true if the date value is a phrase.
-//
-// A phrase is any statement offered as a date when the year is not
-// recognizable to a date parser, but which gives information about when an
-// event occurred. The date phrase is enclosed in matching parentheses.
-//
-// IsPhrase is safe to use on a nil DateNode, and will return false.
 func (node *DateNode) IsPhrase() bool {
 	if node == nil {
 		return false
 	}
 
-	v := node.value
-
-	if len(v) == 0 {
-		return false
-	}
-
-	firstLetter := v[0]
-
-	// ghost:ignore
-	lastLetter := v[len(v)-1]
-
-	return firstLetter == '(' && lastLetter == ')'
+	return node.DateRange().IsPhrase()
 }

--- a/date_node_test.go
+++ b/date_node_test.go
@@ -800,10 +800,10 @@ func TestDateNode_Equals(t *testing.T) {
 	Equals(d11, d9).Returns(true)
 }
 
-func TestDateNode_DateRange(t *testing.T) {
-	DateRange := tf.Function(t, (*gedcom.DateNode).DateRange)
+func TestDateNode_StartAndEndDates(t *testing.T) {
+	StartAndEndDates := tf.Function(t, (*gedcom.DateNode).StartAndEndDates)
 
-	DateRange((*gedcom.DateNode)(nil)).Returns(gedcom.Date{}, gedcom.Date{})
+	StartAndEndDates((*gedcom.DateNode)(nil)).Returns(gedcom.Date{}, gedcom.Date{})
 }
 
 func TestDateNode_IsPhrase(t *testing.T) {

--- a/date_range.go
+++ b/date_range.go
@@ -1,0 +1,298 @@
+package gedcom
+
+import (
+	"fmt"
+	"math"
+	"regexp"
+	"time"
+)
+
+// A DateRange represents a period of time.
+//
+// The minimum possible period is 1 day and ranges only have a resolution of a
+// single day.
+//
+// DateRanges should be considered immutable and are passed by value because of
+// this. You should create a new DateRange to represent a new range rather than
+// mutating an existing DateRange.
+type DateRange struct {
+	start, end     Date
+	originalString string
+}
+
+func NewZeroDateRange() DateRange {
+	return DateRange{}
+}
+
+func NewDateRangeWithString(s string) (dr DateRange) {
+	defer func(originalString string) {
+		dr.originalString = originalString
+	}(s)
+
+	dateString := CleanSpace(s)
+
+	// Try to match a range first.
+	parts := dateRangeRegexp.FindStringSubmatch(dateString)
+	if len(parts) > 0 {
+		return NewDateRange(
+			parseDateParts(parts[2], false),
+			parseDateParts(parts[4], true),
+		)
+	}
+
+	// Single date.
+	return NewDateRange(
+		parseDateParts(dateString, false),
+		parseDateParts(dateString, true),
+	)
+}
+
+// NewDateRange creates a new date range between two provided dates. It is
+// expected that the start date be less than or equal to the end date.
+func NewDateRange(start, end Date) DateRange {
+	start.IsEndOfRange = false
+	end.IsEndOfRange = true
+
+	return DateRange{
+		start: start,
+		end:   end,
+	}
+}
+
+// Describes the matrix of possible ranges where each letter represents Before,
+// Equal or After. A lower-case letter refers to the lower boundary. Conversely
+// an upper-case letter refers to the upper boundary.
+var dateRangeCompareMatrix = map[string]DateRangeComparison{
+	"bb": DateRangeComparisonEntirelyBefore,
+	"be": DateRangeComparisonBefore,
+	"ba": DateRangeComparisonPartiallyBefore,
+	"bB": DateRangeComparisonPartiallyBefore,
+	"bE": DateRangeComparisonOutsideEnd,
+	"bA": DateRangeComparisonOutside,
+	"eb": DateRangeComparisonInvalid,
+	"ee": DateRangeComparisonInsideStart,
+	"ea": DateRangeComparisonInsideStart,
+	"eB": DateRangeComparisonInsideStart,
+	"eE": DateRangeComparisonEqual,
+	"eA": DateRangeComparisonOutsideStart,
+	"ab": DateRangeComparisonInvalid,
+	"ae": DateRangeComparisonInvalid,
+	"aa": DateRangeComparisonInside,
+	"aB": DateRangeComparisonInside,
+	"aE": DateRangeComparisonInsideEnd,
+	"aA": DateRangeComparisonPartiallyAfter,
+	// Bx is the same as ax.
+	"Eb": DateRangeComparisonInvalid,
+	"Ee": DateRangeComparisonInvalid,
+	"Ea": DateRangeComparisonInvalid,
+	"EB": DateRangeComparisonInvalid,
+	"EE": DateRangeComparisonInsideEnd,
+	"EA": DateRangeComparisonAfter,
+	"Ab": DateRangeComparisonInvalid,
+	"Ae": DateRangeComparisonInvalid,
+	"Aa": DateRangeComparisonInvalid,
+	"AB": DateRangeComparisonInvalid,
+	"AE": DateRangeComparisonInvalid,
+	"AA": DateRangeComparisonEntirelyAfter,
+}
+
+func compareDatesForLetter(value, start, end Date) string {
+	// We only deal with whole days. This is needed for dates that are ending
+	// dates so we don't get the 23:59:59.999 part.
+	valueTime := value.Time().Truncate(24 * time.Hour)
+	startTime := start.Time().Truncate(24 * time.Hour)
+	endTime := end.Time().Truncate(24 * time.Hour)
+
+	switch {
+	case valueTime.Equal(startTime):
+		return "e"
+
+	case valueTime.Equal(endTime):
+		return "E"
+
+	case valueTime.Before(startTime):
+		return "b"
+
+	case valueTime.After(endTime):
+		return "A"
+	}
+
+	// a and B would be the same thing.
+	return "a"
+}
+
+func (dr DateRange) Compare(dr2 DateRange) DateRangeComparison {
+	start := compareDatesForLetter(dr.start, dr2.start, dr2.end)
+	end := compareDatesForLetter(dr.end, dr2.start, dr2.end)
+
+	return dateRangeCompareMatrix[start+end]
+}
+
+// Start is the lower boundary of the date range.
+func (dr DateRange) StartDate() Date {
+	return dr.start
+}
+
+// End is the upper boundary of the date range.
+func (dr DateRange) EndDate() Date {
+	return dr.end
+}
+
+// Before returns true if the start date is before the other start date.
+//
+// The idea of "before" in the context of overlapping date ranges is ambiguous.
+// The simplest way to think treat all these situations is to only look at the
+// start date for each range. No matter when the end dates are or how much of
+// each other then end up overlapping.
+func (dr DateRange) Before(dr2 DateRange) bool {
+	return dr.start.IsBefore(dr2.start)
+}
+
+// After returns true if the end date is after the other end date.
+//
+// See Before for a more detailed explanation.
+func (dr DateRange) After(dr2 DateRange) bool {
+	return dr.end.IsAfter(dr2.end)
+}
+
+var dateRangeRegexp = regexp.MustCompile(
+	fmt.Sprintf(`(?i)^(%s) (.+) (%s) (.+)$`, DateWordsBetween, DateWordsAnd))
+
+// Years works in a similar way to Date.Years() but also takes into
+// consideration the StartDate() and EndDate() values of a whole date range,
+// like "Bet. 1943 and 1945". It does this by averaging out the Years() value of
+// the StartDate() and EndDate() values.
+//
+// If the DateNode has a single date, like "Mar 1937" then Years will return the
+// same value as the Years on the start or end date (no average will be used.)
+//
+// You can read the specific conversion rules in Date.Years() but be aware that
+// the returned value is an approximation and should not be used in date
+// calculations.
+func (dr DateRange) Years() float64 {
+	return (dr.StartDate().Years() + dr.EndDate().Years()) / 2.0
+}
+
+// Similarity returns a value from 0.0 to 1.0 to identify how similar two dates
+// (or date ranges) are to each other. 1.0 would mean that the dates are exactly
+// the same, whereas 0.0 would mean that they are not similar at all.
+//
+// Similarity is safe to use when either date is nil. If either side is nil then
+// 0.5 is returned. Not because they are similar but because there is not enough
+// information to make the distinction either way. This is important when using
+// date comparisons in combination or part of larger calculations where missing
+// data on both sides does not lead to very low scores unnecessarily.
+//
+// The returned value is calculated on a parabola that awards higher values to
+// dates that are proportionally closer to each other. That is, dates that are
+// twice as close will have more than twice the score. This attempts to satisfy
+// a usable comparison values for close specific dates as well as more relaxed
+// values (such as those that one provide an approximate year).
+//
+// Only the difference between dates is used in the calculation so it is not
+// affected by time lines. That is to say that the difference between the years
+// 500 and 502 would return the same similarity as the years 2000 to 2002.
+//
+// The maxYears allows the error margin to be adjusted. Dates that are further
+// apart (in any direction) than maxYears will always return 0.0.
+//
+// A greater maxYears can be used when dates are less exact (such as ancient
+// dates that could be commonly off by 10 years or more) or a smaller value when
+// dealing with recent dates that are provided in a more exact form.
+//
+// A sensible default value for maxYears is provided with
+// DefaultMaxYearsForSimilarity. You should use this if you are unsure. There is
+// also more explanation on the constant.
+func (dr DateRange) Similarity(dr2 DateRange, maxYears float64) float64 {
+	leftYears := dr.Years()
+	rightYears := dr2.Years()
+	yearsApart := leftYears - rightYears
+	similarity := math.Pow(yearsApart/maxYears, 2)
+
+	// When one date is invalid the similarity will go asymptotic.
+	if similarity > 1 {
+		return 0
+	}
+
+	return 1 - similarity
+}
+
+// Equals compares the values of two dates taking into consideration the date
+// constraint.
+//
+// If either date is nil then false is always returned. Even if both dates are
+// nil.
+//
+// A DateNode is considered to be equal only when its StartDate() and EndDate()
+// both equal their respective values in the other DateNode.
+//
+// The comparisons of dates is quite complicated. See the documentation for
+// Date.Equals for a full explanation.
+func (dr DateRange) Equals(dr2 DateRange) bool {
+	// Phrases can only be compared to themselves and they must be the exact
+	// same value to be considered equal.
+	if dr.IsPhrase() && dr2.IsPhrase() && dr.originalString == dr2.originalString {
+		return true
+	}
+
+	// Invalid dates follow the same rules as phrases.
+	if !dr.IsValid() && !dr2.IsValid() && dr.originalString == dr2.originalString {
+		return true
+	}
+
+	// Compare dates by value range.
+	matchStartDate := dr.StartDate().Equals(dr2.StartDate())
+	matchEndDate := dr.EndDate().Equals(dr2.EndDate())
+
+	return matchStartDate && matchEndDate
+}
+
+func (dr DateRange) StartAndEndDates() (Date, Date) {
+	return dr.StartDate(), dr.EndDate()
+}
+
+// IsValid returns true only when the node is not nil and the start and end date
+// are non-zero.
+//
+// A "zero date" (Date.IsZero) is a date that is missing the year, month and
+// day. Even if there is other associated information this date is considered to
+// be useless for most purposes.
+//
+// It is safe and completely valid to use IsValid on a nil node.
+func (dr DateRange) IsValid() bool {
+	start, end := dr.StartAndEndDates()
+
+	return !start.IsZero() && !end.IsZero()
+}
+
+// IsExact will return true if the date range represents a single day with an
+// exact constraint.
+//
+// See Date.IsExact for more information.
+func (dr DateRange) IsExact() bool {
+	start, end := dr.StartAndEndDates()
+	startIsExact := start.IsExact()
+	endIsExact := end.IsExact()
+
+	return startIsExact && endIsExact
+}
+
+// IsPhrase returns true if the date value is a phrase.
+//
+// A phrase is any statement offered as a date when the year is not
+// recognizable to a date parser, but which gives information about when an
+// event occurred. The date phrase is enclosed in matching parentheses.
+//
+// IsPhrase is safe to use on a nil DateNode, and will return false.
+func (dr DateRange) IsPhrase() bool {
+	if len(dr.originalString) == 0 {
+		return false
+	}
+
+	firstLetter := dr.originalString[0]
+
+	// ghost:ignore
+	lastLetter := dr.originalString[len(dr.originalString)-1]
+
+	return firstLetter == '(' && lastLetter == ')'
+}

--- a/date_range_comparison.go
+++ b/date_range_comparison.go
@@ -1,0 +1,258 @@
+package gedcom
+
+import "fmt"
+
+// DateRangeComparison describe how two date ranges (each can be described with
+// a DateNode) relate to each other.
+//
+// Since we are comparing ranges of time, rather than absolute points there are
+// several variations of results to be considered. It's easiest to explain
+// visually where Left and Right are the date range operands respectively:
+//
+//                                                       Method returns true:
+//   Left:                        |========|
+//   Right:
+//     Equal:                     |========|             IsEqual()
+//     Inside:                    | <====> |             IsPartiallyEqual()
+//     InsideStart:               |======> |             IsPartiallyEqual()
+//     InsideEnd:                 | <======|             IsPartiallyEqual()
+//     Outside:               <===+========+===>         IsPartiallyEqual()
+//     OutsideStart:              |========+===>         IsPartiallyEqual()
+//     OutsideEnd:            <===+========|             IsPartiallyEqual()
+//     PartiallyBefore:       <===+===>    |             IsPartiallyEqual()
+//     PartiallyAfter:            |     <==+===>         IsPartiallyEqual()
+//     Before:                <===|        |             IsNotEqual()
+//     After:                     |        |===>         IsNotEqual()
+//     EntirelyBefore:        <=> |        |             IsNotEqual()
+//     EntirelyAfter:             |        | <=>         IsNotEqual()
+//
+// The Simplified value is the DateRangeComparisonSimplified value which is
+// derived from DateRangeComparison.Simplified().
+type DateRangeComparison int
+
+// Each of the constants below represent how the ranges cross over. See
+// DateRangeComparison for a visual explanation.
+const (
+	// DateRangeComparisonInvalid is only used in cases of an error.
+	DateRangeComparisonInvalid = DateRangeComparison(iota)
+
+	// Equal means that both date ranges are exactly the same in start and end
+	// date, or they have an equivalent other value:
+	//
+	//   Yes:
+	//     3 Sep 1943            3 Sep 1943
+	//     Sep 1943 - Mar 1944   Sep 1943 - Mar 1944
+	//     (world war 2)         (world war 2)
+	//
+	//   No:
+	//     3 Sep 1943            Sep 1943
+	//     Sep 1943 - Mar 1944   Sep 1943 - 3 Mar 1944
+	//     (world war 2)         (world war 1)
+	//
+	DateRangeComparisonEqual = iota
+
+	// Inside means that the right operand is both smaller and encapsulated by
+	// the greater range in both directions of the left operand. The Start and
+	// End derivatives represent if certain boundaries are also equal.
+	//
+	//   Yes:
+	//     3 Sep 1943 - 20 Sep 1943   5 Sep 1943 - 17 Sep 1943
+	//     Sep 1943                   3 Sep 1943 - 20 Sep 1943
+	//   No:
+	//     3 Sep 1943 - 20 Sep 1943   1 Sep 1943 - 5 Sep 1943
+	//     Sep 1943                   20 Sep 1943 - 10 Oct 1943
+	//     (world war 2)              (world war 2)
+	//
+	DateRangeComparisonInside      = iota
+	DateRangeComparisonInsideStart = iota
+	DateRangeComparisonInsideEnd   = iota
+
+	// Outside means that the right operand is larger in both directions. The
+	// opposite of Inside. The Start and End derivatives represent if certain
+	// boundaries are also equal.
+	//
+	//   Yes:
+	//     3 Sep 1943 - 20 Sep 1943   1 Sep 1943 - 25 Sep 1943
+	//     Sep 1943                   14 Jul 1943 - 10 Oct 1943
+	//   No:
+	//     3 Sep 1943 - 20 Sep 1943   1 Sep 1943 - 5 Sep 1943
+	//     Sep 1943                   20 Sep 1943 - 10 Oct 1943
+	//     (world war 2)              (world war 2)
+	//
+	DateRangeComparisonOutside      = iota
+	DateRangeComparisonOutsideStart = iota
+	DateRangeComparisonOutsideEnd   = iota
+
+	// PartiallyBefore means the right operand range surrounds the start of the
+	// left operand.
+	//
+	//   Yes:
+	//     3 Sep 1943 - 20 Sep 1943   1 Sep 1943 - 5 Sep 1943
+	//     Sep 1943                   14 Jul 1943 - 10 Sep 1943
+	//   No:
+	//     3 Sep 1943 - 20 Sep 1943   1 Sep 1943 - 25 Sep 1943
+	//     Sep 1943                   20 Sep 1943 - 10 Oct 1943
+	//     (world war 2)              (world war 2)
+	//
+	DateRangeComparisonPartiallyBefore = iota
+
+	// PartiallyAfter means the right operand range surrounds the end of the
+	// left operand.
+	//
+	//   Yes:
+	//     3 Sep 1943 - 20 Sep 1943   17 Sep 1943 - 25 Sep 1943
+	//     Sep 1943                   10 Sep 1943 - 10 Oct 1943
+	//   No:
+	//     3 Sep 1943 - 20 Sep 1943   10 Sep 1943 - 15 Sep 1943
+	//     Sep 1943                   20 Sep 1943 - 25 Sep 1943
+	//     (world war 2)              (world war 2)
+	//
+	DateRangeComparisonPartiallyAfter = iota
+
+	// Before means the right operand range starts before the left operand's
+	// before, but ends at the same value as the start of the left operand.
+	//
+	//   Yes:
+	//     3 Sep 1943 - 20 Sep 1943   1 Sep 1943 - 3 Sep 1943
+	//     Sep 1943                   14 Jul 1943 - 1 Sep 1943
+	//   No:
+	//     3 Sep 1943 - 20 Sep 1943   1 Sep 1943 - 4 Sep 1943
+	//     Sep 1943                   14 Jul 1943 - 10 Sep 1943
+	//     (world war 2)              (world war 2)
+	//
+	DateRangeComparisonBefore = iota
+
+	// After means the right operand starts at the end of the left operand and
+	// ends somewhere thereafter.
+	//
+	//   Yes:
+	//     3 Sep 1943 - 20 Sep 1943   20 Sep 1943 - 25 Sep 1943
+	//     Sep 1943                   30 Sep 1943 - 10 Oct 1943
+	//   No:
+	//     3 Sep 1943 - 20 Sep 1943   19 Sep 1943 - 25 Sep 1943
+	//     Sep 1943                   20 Sep 1943 - 25 Sep 1943
+	//     (world war 2)              (world war 2)
+	//
+	DateRangeComparisonAfter = iota
+
+	// EntirelyBefore means that the full range of the right operand is before
+	// any of the range of the left operand.
+	//
+	//   Yes:
+	//     3 Sep 1943 - 20 Sep 1943   1 Sep 1943 - 2 Sep 1943
+	//     Sep 1943                   3 Jul 1943 - 10 Jul 1943
+	//   No:
+	//     3 Sep 1943 - 20 Sep 1943   19 Sep 1943 - 25 Sep 1943
+	//     Sep 1943                   20 Sep 1943 - 25 Sep 1943
+	//     (world war 2)              (world war 2)
+	//
+	DateRangeComparisonEntirelyBefore = iota
+
+	// EntirelyAfter means that the full range of the right operand is after
+	// any of the range of the left operand.
+	//
+	//   Yes:
+	//     3 Sep 1943 - 20 Sep 1943   25 Sep 1943 - 30 Sep 1943
+	//     Sep 1943                   3 Oct 1943 - 10 Oct 1943
+	//   No:
+	//     3 Sep 1943 - 20 Sep 1943   19 Sep 1943 - 25 Sep 1943
+	//     Sep 1943                   20 Sep 1943 - 25 Sep 1943
+	//     (world war 2)              (world war 2)
+	//
+	DateRangeComparisonEntirelyAfter = iota
+)
+
+// IsEqual returns true only if both date ranges are exactly the same.
+//
+// It's important to note that a DateRangeComparison can be in one of three
+// simplified states: Equal, PartiallyEqual or NotEqual. So !IsEqual() is not
+// the same as IsNotEqual().
+func (c DateRangeComparison) IsEqual() bool {
+	return c == DateRangeComparisonEqual
+}
+
+// IsPartiallyEqual returns true if any part of the date range touches or
+// intersects another.
+func (c DateRangeComparison) IsPartiallyEqual() bool {
+	switch c {
+	case DateRangeComparisonInside,
+		DateRangeComparisonInsideStart,
+		DateRangeComparisonInsideEnd,
+		DateRangeComparisonOutside,
+		DateRangeComparisonOutsideStart,
+		DateRangeComparisonOutsideEnd,
+		DateRangeComparisonPartiallyBefore,
+		DateRangeComparisonPartiallyAfter:
+		return true
+	}
+
+	return false
+}
+
+// IsNotEqual returns true if the two date ranges do not intersect at any point.
+//
+// It's important to note that a DateRangeComparison can be in one of three
+// simplified states: Equal, PartiallyEqual or NotEqual. So !IsNotEqual() is not
+// the same as IsEqual().
+func (c DateRangeComparison) IsNotEqual() bool {
+	switch c {
+	case DateRangeComparisonBefore,
+		DateRangeComparisonAfter,
+		DateRangeComparisonEntirelyBefore,
+		DateRangeComparisonEntirelyAfter:
+		return true
+	}
+
+	return false
+}
+
+// String returns the name of the constant like
+// "DateRangeComparisonInsideStart".
+func (c DateRangeComparison) String() string {
+	switch c {
+	case DateRangeComparisonInvalid:
+		return "DateRangeComparisonInvalid"
+
+	case DateRangeComparisonEqual:
+		return "DateRangeComparisonEqual"
+
+	case DateRangeComparisonInside:
+		return "DateRangeComparisonInside"
+
+	case DateRangeComparisonInsideStart:
+		return "DateRangeComparisonInsideStart"
+
+	case DateRangeComparisonInsideEnd:
+		return "DateRangeComparisonInsideEnd"
+
+	case DateRangeComparisonOutside:
+		return "DateRangeComparisonOutside"
+
+	case DateRangeComparisonOutsideStart:
+		return "DateRangeComparisonOutsideStart"
+
+	case DateRangeComparisonOutsideEnd:
+		return "DateRangeComparisonOutsideEnd"
+
+	case DateRangeComparisonPartiallyBefore:
+		return "DateRangeComparisonPartiallyBefore"
+
+	case DateRangeComparisonPartiallyAfter:
+		return "DateRangeComparisonPartiallyAfter"
+
+	case DateRangeComparisonBefore:
+		return "DateRangeComparisonBefore"
+
+	case DateRangeComparisonAfter:
+		return "DateRangeComparisonAfter"
+
+	case DateRangeComparisonEntirelyBefore:
+		return "DateRangeComparisonEntirelyBefore"
+
+	case DateRangeComparisonEntirelyAfter:
+		return "DateRangeComparisonEntirelyAfter"
+
+	default:
+		panic(fmt.Sprintf("invalid constant: %d", c))
+	}
+}

--- a/date_range_comparison_test.go
+++ b/date_range_comparison_test.go
@@ -1,0 +1,61 @@
+package gedcom_test
+
+import (
+	"fmt"
+	"github.com/elliotchance/gedcom"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+var dateRangeComparisonTests = []struct {
+	comparison                            gedcom.DateRangeComparison
+	isEqual, isPartiallyEqual, isNotEqual bool
+	string                                string
+}{
+	{gedcom.DateRangeComparisonInvalid, false, false, false, "DateRangeComparisonInvalid"},
+	{gedcom.DateRangeComparisonEqual, true, false, false, "DateRangeComparisonEqual"},
+	{gedcom.DateRangeComparisonInside, false, true, false, "DateRangeComparisonInside"},
+	{gedcom.DateRangeComparisonInsideStart, false, true, false, "DateRangeComparisonInsideStart"},
+	{gedcom.DateRangeComparisonInsideEnd, false, true, false, "DateRangeComparisonInsideEnd"},
+	{gedcom.DateRangeComparisonOutside, false, true, false, "DateRangeComparisonOutside"},
+	{gedcom.DateRangeComparisonOutsideStart, false, true, false, "DateRangeComparisonOutsideStart"},
+	{gedcom.DateRangeComparisonOutsideEnd, false, true, false, "DateRangeComparisonOutsideEnd"},
+	{gedcom.DateRangeComparisonPartiallyBefore, false, true, false, "DateRangeComparisonPartiallyBefore"},
+	{gedcom.DateRangeComparisonPartiallyAfter, false, true, false, "DateRangeComparisonPartiallyAfter"},
+	{gedcom.DateRangeComparisonBefore, false, false, true, "DateRangeComparisonBefore"},
+	{gedcom.DateRangeComparisonAfter, false, false, true, "DateRangeComparisonAfter"},
+	{gedcom.DateRangeComparisonEntirelyBefore, false, false, true, "DateRangeComparisonEntirelyBefore"},
+	{gedcom.DateRangeComparisonEntirelyAfter, false, false, true, "DateRangeComparisonEntirelyAfter"},
+}
+
+func TestDateRangeComparison_IsEqual(t *testing.T) {
+	for _, test := range dateRangeComparisonTests {
+		t.Run(fmt.Sprintf("%d", test.comparison), func(t *testing.T) {
+			assert.Equal(t, test.isEqual, test.comparison.IsEqual())
+		})
+	}
+}
+
+func TestDateRangeComparison_IsPartiallyEqual(t *testing.T) {
+	for _, test := range dateRangeComparisonTests {
+		t.Run(fmt.Sprintf("%d", test.comparison), func(t *testing.T) {
+			assert.Equal(t, test.isPartiallyEqual, test.comparison.IsPartiallyEqual())
+		})
+	}
+}
+
+func TestDateRangeComparison_IsNotEqual(t *testing.T) {
+	for _, test := range dateRangeComparisonTests {
+		t.Run(fmt.Sprintf("%d", test.comparison), func(t *testing.T) {
+			assert.Equal(t, test.isNotEqual, test.comparison.IsNotEqual())
+		})
+	}
+}
+
+func TestDateRangeComparison_String(t *testing.T) {
+	for _, test := range dateRangeComparisonTests {
+		t.Run(fmt.Sprintf("%d", test.comparison), func(t *testing.T) {
+			assert.Equal(t, test.string, test.comparison.String())
+		})
+	}
+}

--- a/date_range_test.go
+++ b/date_range_test.go
@@ -1,0 +1,278 @@
+package gedcom_test
+
+import (
+	"fmt"
+	"github.com/elliotchance/gedcom"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+//                              4 Sep    19 Sep
+//                            3 Sep |    | 20 Sep
+//                          2 Sep | |    | | 21 Sep
+//                        1 Sep | | |    | | | 30 Sep
+//                            v v v v    v v v v
+//   Left:                    .   |========|   .
+//   Right                    .                .
+//     Equal:                 .   |========|   .
+//     Inside:                .   | <====> |   .
+//     InsideStart:           .   |======> |   .
+//     InsideEnd:             .   | <======|   .
+//     Outside:               <===+========+===>
+//     OutsideStart:          .   |========+===>
+//     OutsideEnd:            <===+========|   .
+//     PartiallyBefore:       <===+=>      |   .
+//     PartiallyAfter:        .   |      <=+===>
+//     Before:                <===|        |   .
+//     After:                 .   |        |===>
+//     EntirelyBefore:        <=> |        |   .
+//     EntirelyAfter:         .   |        | <=>
+//
+var dateRangeCompareTest = map[string]struct {
+	comparison    gedcom.DateRangeComparison
+	before, after bool
+}{
+	"1_1": {
+		gedcom.DateRangeComparisonEntirelyBefore,
+		true,
+		false,
+	},
+	"1_2": {
+		gedcom.DateRangeComparisonEntirelyBefore,
+		true,
+		false,
+	},
+	"1_3": {
+		gedcom.DateRangeComparisonBefore,
+		true,
+		false,
+	},
+	"1_4": {
+		gedcom.DateRangeComparisonPartiallyBefore,
+		true,
+		false,
+	},
+	"1_19": {
+		gedcom.DateRangeComparisonPartiallyBefore,
+		true,
+		false,
+	},
+	"1_20": {
+		gedcom.DateRangeComparisonOutsideEnd,
+		true,
+		false,
+	},
+	"1_21": {
+		gedcom.DateRangeComparisonOutside,
+		true,
+		true,
+	},
+	"1_30": {
+		gedcom.DateRangeComparisonOutside,
+		true,
+		true,
+	},
+
+	"2_2": {
+		gedcom.DateRangeComparisonEntirelyBefore,
+		true,
+		false,
+	},
+	"2_3": {
+		gedcom.DateRangeComparisonBefore,
+		true,
+		false,
+	},
+	"2_4": {
+		gedcom.DateRangeComparisonPartiallyBefore,
+		true,
+		false,
+	},
+	"2_19": {
+		gedcom.DateRangeComparisonPartiallyBefore,
+		true,
+		false,
+	},
+	"2_20": {
+		gedcom.DateRangeComparisonOutsideEnd,
+		true,
+		false,
+	},
+	"2_21": {
+		gedcom.DateRangeComparisonOutside,
+		true,
+		true,
+	},
+	"2_30": {
+		gedcom.DateRangeComparisonOutside,
+		true,
+		true,
+	},
+
+	"3_3": {
+		gedcom.DateRangeComparisonInsideStart,
+		false,
+		false,
+	},
+	"3_4": {
+		gedcom.DateRangeComparisonInsideStart,
+		false,
+		false,
+	},
+	"3_19": {
+		gedcom.DateRangeComparisonInsideStart,
+		false,
+		false,
+	},
+	"3_20": {
+		gedcom.DateRangeComparisonEqual,
+		false,
+		false,
+	},
+	"3_21": {
+		gedcom.DateRangeComparisonOutsideStart,
+		false,
+		true,
+	},
+	"3_30": {
+		gedcom.DateRangeComparisonOutsideStart,
+		false,
+		true,
+	},
+
+	"4_4": {
+		gedcom.DateRangeComparisonInside,
+		false,
+		false,
+	},
+	"4_19": {
+		gedcom.DateRangeComparisonInside,
+		false,
+		false,
+	},
+	"4_20": {
+		gedcom.DateRangeComparisonInsideEnd,
+		false,
+		false,
+	},
+	"4_21": {
+		gedcom.DateRangeComparisonPartiallyAfter,
+		false,
+		true,
+	},
+	"4_30": {
+		gedcom.DateRangeComparisonPartiallyAfter,
+		false,
+		true,
+	},
+
+	"19_19": {
+		gedcom.DateRangeComparisonInside,
+		false,
+		false,
+	},
+	"19_20": {
+		gedcom.DateRangeComparisonInsideEnd,
+		false,
+		false,
+	},
+	"19_21": {
+		gedcom.DateRangeComparisonPartiallyAfter,
+		false,
+		true,
+	},
+	"19_30": {
+		gedcom.DateRangeComparisonPartiallyAfter,
+		false,
+		true,
+	},
+
+	"20_20": {
+		gedcom.DateRangeComparisonInsideEnd,
+		false,
+		false,
+	},
+	"20_21": {
+		gedcom.DateRangeComparisonAfter,
+		false,
+		true,
+	},
+	"20_30": {
+		gedcom.DateRangeComparisonAfter,
+		false,
+		true,
+	},
+
+	"21_21": {
+		gedcom.DateRangeComparisonEntirelyAfter,
+		false,
+		true,
+	},
+	"21_30": {
+		gedcom.DateRangeComparisonEntirelyAfter,
+		false,
+		true,
+	},
+
+	"30_30": {
+		gedcom.DateRangeComparisonEntirelyAfter,
+		false,
+		true,
+	},
+}
+
+func dateRangeCompareRange(s string) gedcom.DateRange {
+	var startDay, endDay int
+
+	fmt.Sscanf(s, "%d_%d", &startDay, &endDay)
+
+	start := gedcom.Date{
+		Day:   startDay,
+		Month: time.September,
+		Year:  1943,
+	}
+
+	end := gedcom.Date{
+		Day:   endDay,
+		Month: time.September,
+		Year:  1943,
+	}
+
+	return gedcom.NewDateRange(start, end)
+}
+
+func TestDateRange_Compare(t *testing.T) {
+	base := dateRangeCompareRange("3_20")
+
+	for testName, test := range dateRangeCompareTest {
+		t.Run(testName, func(t *testing.T) {
+			dr := dateRangeCompareRange(testName)
+			expected := test.comparison.String()
+			actual := dr.Compare(base).String()
+			assert.Equal(t, expected, actual)
+		})
+	}
+}
+
+func TestDateRange_Before(t *testing.T) {
+	base := dateRangeCompareRange("3_20")
+
+	for testName, test := range dateRangeCompareTest {
+		t.Run(testName, func(t *testing.T) {
+			dr := dateRangeCompareRange(testName)
+			assert.Equal(t, test.before, dr.Before(base))
+		})
+	}
+}
+
+func TestDateRange_After(t *testing.T) {
+	base := dateRangeCompareRange("3_20")
+
+	for testName, test := range dateRangeCompareTest {
+		t.Run(testName, func(t *testing.T) {
+			dr := dateRangeCompareRange(testName)
+			assert.Equal(t, test.after, dr.After(base))
+		})
+	}
+}

--- a/date_test.go
+++ b/date_test.go
@@ -1,11 +1,12 @@
 package gedcom_test
 
 import (
+	"testing"
+	"time"
+
 	"github.com/elliotchance/gedcom"
 	"github.com/elliotchance/tf"
 	"github.com/stretchr/testify/assert"
-	"testing"
-	"time"
 )
 
 func TestDate_Time(t *testing.T) {


### PR DESCRIPTION
Most of the date range functionality was in the DateNode which means it could not be used in other places we need to represent date ranges. There is now a DateRange type where most of these methods have been moved to.

Also, more comprehensive comparisons can be made like Before, After and range comparison constants.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/gedcom/234)
<!-- Reviewable:end -->
