### PR TITLE
Warning: Unparsable date

### DIFF
--- a/date_node.go
+++ b/date_node.go
@@ -166,3 +166,13 @@ func (node *DateNode) Sub(node2 *DateNode) (min Duration, max Duration, errs err
 
 	return
 }
+
+func (node *DateNode) Warnings() Warnings {
+	if !node.IsValid() {
+		return Warnings{
+			NewUnparsableDateWarning(node),
+		}
+	}
+
+	return nil
+}

--- a/duration.go
+++ b/duration.go
@@ -1,10 +1,10 @@
 package gedcom
 
 import (
-	"time"
 	"fmt"
 	"math"
 	"strings"
+	"time"
 )
 
 // A duration that only considers whole-day resolution.
@@ -44,7 +44,7 @@ func (d Duration) String() string {
 		parts = append(parts, pluralize(months, "month"))
 	}
 
-	if days := int(math.Ceil(float64(d)/float64(oneDay))); days != 0 {
+	if days := int(math.Ceil(float64(d) / float64(oneDay))); days != 0 {
 		parts = append(parts, pluralize(days, "day"))
 	}
 

--- a/duration_test.go
+++ b/duration_test.go
@@ -1,9 +1,9 @@
 package gedcom_test
 
 import (
-	"testing"
-	"github.com/elliotchance/tf"
 	"github.com/elliotchance/gedcom"
+	"github.com/elliotchance/tf"
+	"testing"
 	"time"
 )
 

--- a/errors.go
+++ b/errors.go
@@ -1,9 +1,9 @@
 package gedcom
 
 import (
+	"errors"
 	"fmt"
 	"strings"
-	"errors"
 )
 
 type Errors []error

--- a/q/question_mark_expr_test.go
+++ b/q/question_mark_expr_test.go
@@ -21,6 +21,7 @@ var documentChoices = []string{
 	".SetNodes",
 	".Sources",
 	".String",
+	".Warnings",
 }
 
 var functionAndVariableChoices = []string{

--- a/unparsable_date_warning.go
+++ b/unparsable_date_warning.go
@@ -1,0 +1,21 @@
+package gedcom
+
+import "fmt"
+
+type UnparsableDateWarning struct {
+	Date *DateNode
+}
+
+func NewUnparsableDateWarning(date *DateNode) *UnparsableDateWarning {
+	return &UnparsableDateWarning{
+		Date: date,
+	}
+}
+
+func (w *UnparsableDateWarning) Name() string {
+	return "UnparsableDate"
+}
+
+func (w *UnparsableDateWarning) String() string {
+	return fmt.Sprintf(`Unparsable date "%s"`, w.Date.Value())
+}

--- a/warner.go
+++ b/warner.go
@@ -1,0 +1,5 @@
+package gedcom
+
+type Warner interface {
+	Warnings() Warnings
+}

--- a/warning.go
+++ b/warning.go
@@ -1,0 +1,8 @@
+package gedcom
+
+import "fmt"
+
+type Warning interface {
+	fmt.Stringer
+	Name() string
+}

--- a/warnings.go
+++ b/warnings.go
@@ -1,0 +1,11 @@
+package gedcom
+
+type Warnings []Warning
+
+func (ws Warnings) Strings() (ss []string) {
+	for _, w := range ws {
+		ss = append(ss, w.String())
+	}
+
+	return
+}


### PR DESCRIPTION
This is the first of its kind. Nodes can now implement a Warner interface which returns a slice of Warning entities. Document also implements Warner to aggregate all warnings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/gedcom/237)
<!-- Reviewable:end -->
