### PR TITLE
Decoder: Allow double space before tag. Fixes #243

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -157,7 +157,7 @@ func (dec *Decoder) readLine() (string, error) {
 	return string(buf.Bytes()), nil
 }
 
-var lineRegexp = regexp.MustCompile(`^(\d) (@[^@]+@ )?(\w+) ?(.*)?$`)
+var lineRegexp = regexp.MustCompile(`^(\d) +(@[^@]+@ )?(\w+) ?(.*)?$`)
 
 func parseLine(line string, document *Document, family *FamilyNode) (Node, int, error) {
 	parts := lineRegexp.FindStringSubmatch(line)

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -314,6 +314,20 @@ func TestDecoder_Decode(t *testing.T) {
 		})
 	}
 
+	t.Run("DoubleSpace", func(t *testing.T) {
+		// Issue #243
+
+		decoder := gedcom.NewDecoder(strings.NewReader("0  _PUBLISH"))
+
+		actual, err := decoder.Decode()
+		assert.NoError(t, err)
+
+		doc := gedcom.NewDocument()
+		doc.AddNode(gedcom.NewNode(gedcom.TagFromString("_PUBLISH"), "", ""))
+
+		assertDocumentEqual(t, doc, actual)
+	})
+
 	t.Run("BOM", func(t *testing.T) {
 		ged := "\xEF\xBB\xBF0 HEAD\n1 CHAR UTF-8"
 		decoder := gedcom.NewDecoder(strings.NewReader(ged))


### PR DESCRIPTION
I'm not sure if this is strickly permitted in the GEDCOM standard and the extra space will not be retained when encoded.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/gedcom/244)
<!-- Reviewable:end -->
