### PR TITLE
WifeNode: pointer may be invalid

### DIFF
--- a/husband_node.go
+++ b/husband_node.go
@@ -1,7 +1,5 @@
 package gedcom
 
-import "fmt"
-
 // HusbandNode is an individual in the family role of a married man or father.
 type HusbandNode struct {
 	*SimpleNode
@@ -13,11 +11,6 @@ func newHusbandNode(family *FamilyNode, value string, children ...Node) *Husband
 		newSimpleNode(TagHusband, value, "", children...),
 		family,
 	}
-}
-
-func newHusbandNodeWithIndividual(family *FamilyNode, individual *IndividualNode) *HusbandNode {
-	// TODO: check individual belongs to the same document as family
-	return newHusbandNode(family, fmt.Sprintf("@%s@", individual.Pointer()))
 }
 
 func (node *HusbandNode) Family() *FamilyNode {

--- a/wife_node.go
+++ b/wife_node.go
@@ -1,7 +1,5 @@
 package gedcom
 
-import "fmt"
-
 // WifeNode is an individual in the role as a mother and/or married woman.
 type WifeNode struct {
 	*SimpleNode
@@ -15,11 +13,6 @@ func newWifeNode(family *FamilyNode, value string, children ...Node) *WifeNode {
 	}
 }
 
-func newWifeNodeWithIndividual(family *FamilyNode, individual *IndividualNode) *WifeNode {
-	// TODO: check individual belongs to the same document as family
-	return newWifeNode(family, fmt.Sprintf("@%s@", individual.Pointer()))
-}
-
 func (node *WifeNode) Family() *FamilyNode {
 	return node.family
 }
@@ -31,7 +24,10 @@ func (node *WifeNode) Individual() *IndividualNode {
 
 	n := node.family.document.NodeByPointer(valueToPointer(node.value))
 
-	// TODO: may not exist
+	if IsNil(n) {
+		return nil
+	}
+
 	return n.(*IndividualNode)
 }
 


### PR DESCRIPTION
Fixed a bug where locating a WifeNode through the individual pointer may not work becuase of a nil cast. Interesting this bug did not apply to the HusbandNode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/gedcom/247)
<!-- Reviewable:end -->
