### PR TITLE
Added QMarshaller interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /gh-md-toc
 /coverage.txt
 /gedcomq/gedcomq
+gedcomq/*.ged

--- a/child_born_before_parent_warning.go
+++ b/child_born_before_parent_warning.go
@@ -37,3 +37,14 @@ func (w *ChildBornBeforeParentWarning) String() string {
 func (w *ChildBornBeforeParentWarning) SetContext(context WarningContext) {
 	w.Context = context
 }
+
+func (w *ChildBornBeforeParentWarning) MarshalQ() interface{} {
+	return map[string]interface{}{
+		"String":  w.String(),
+		"Name":    w.Name(),
+		"Context": w.Context.MarshalQ(),
+
+		"Parent": w.Parent.Pointer(),
+		"Child":  w.Child.Individual().Pointer(),
+	}
+}

--- a/gedcomq/main.go
+++ b/gedcomq/main.go
@@ -72,7 +72,7 @@ func output(result interface{}) {
 		log.Panicf("unsupported format: %s", optionFormat)
 	}
 
-	formatter.Write(result)
+	formatter.Write(gedcom.MarshalQ(result))
 }
 
 func parseCLIFlags() {

--- a/individual_node.go
+++ b/individual_node.go
@@ -937,3 +937,10 @@ func (node *IndividualNode) AddBirthDate(birthDate string) *IndividualNode {
 
 	return node
 }
+
+func (node *IndividualNode) MarshalQ() interface{} {
+	return map[string]interface{}{
+		"Nodes":  node.Nodes(),
+		"String": node.String(),
+	}
+}

--- a/q_marshal.go
+++ b/q_marshal.go
@@ -1,0 +1,13 @@
+package gedcom
+
+type QMarshaller interface {
+	MarshalQ() interface{}
+}
+
+func MarshalQ(in interface{}) interface{} {
+	if m, ok := in.(QMarshaller); ok {
+		return m.MarshalQ()
+	}
+
+	return in
+}

--- a/q_marshal_test.go
+++ b/q_marshal_test.go
@@ -1,0 +1,43 @@
+package gedcom_test
+
+import (
+	"github.com/elliotchance/gedcom"
+	"github.com/elliotchance/tf"
+	"testing"
+)
+
+type fakeQ struct {
+	value interface{}
+}
+
+func (f fakeQ) MarshalQ() interface{} {
+	return f.value
+}
+
+type fakeQ2 struct {
+	Value interface{}
+}
+
+func TestMarshalQ(t *testing.T) {
+	MarshalQ := tf.Function(t, gedcom.MarshalQ)
+
+	MarshalQ(nil).Returns(nil)
+
+	MarshalQ("foo").Returns("foo")
+
+	MarshalQ(map[string]string{
+		"a": "b",
+	}).Returns(map[string]string{
+		"a": "b",
+	})
+
+	MarshalQ(map[string]interface{}{
+		"a": fakeQ{123},
+	}).Returns(map[string]interface{}{
+		"a": fakeQ{123},
+	})
+
+	MarshalQ(fakeQ{123}).Returns(123)
+
+	MarshalQ(fakeQ{fakeQ{456}}).Returns(fakeQ{456})
+}

--- a/siblings_born_too_close_warning.go
+++ b/siblings_born_too_close_warning.go
@@ -31,3 +31,13 @@ func (w *SiblingsBornTooCloseWarning) SetContext(context WarningContext) {
 	w.Context = context
 }
 
+func (w *SiblingsBornTooCloseWarning) MarshalQ() interface{} {
+	return map[string]interface{}{
+		"String":  w.String(),
+		"Context": w.Context.MarshalQ(),
+		"Name":    w.Name(),
+
+		"Sibling1": valueToPointer(w.Sibling1.Value()),
+		"Sibling2": valueToPointer(w.Sibling2.Value()),
+	}
+}

--- a/unparsable_date_warning.go
+++ b/unparsable_date_warning.go
@@ -26,3 +26,13 @@ func (w *UnparsableDateWarning) String() string {
 func (w *UnparsableDateWarning) SetContext(context WarningContext) {
 	w.Context = context
 }
+
+func (w *UnparsableDateWarning) MarshalQ() interface{} {
+	return map[string]interface{}{
+		"String":  w.String(),
+		"Name":    w.Name(),
+		"Context": w.Context.MarshalQ(),
+
+		"Date": w.Date.Value(),
+	}
+}

--- a/warning.go
+++ b/warning.go
@@ -6,6 +6,7 @@ import (
 
 type Warning interface {
 	fmt.Stringer
+	QMarshaller
 
 	Name() string
 	SetContext(context WarningContext)

--- a/warnings.go
+++ b/warnings.go
@@ -9,3 +9,12 @@ func (ws Warnings) Strings() (ss []string) {
 
 	return
 }
+
+func (ws Warnings) MarshalQ() interface{} {
+	out := []interface{}{}
+	for _, warning := range ws {
+		out = append(out, warning.MarshalQ())
+	}
+
+	return out
+}


### PR DESCRIPTION
QMarshaller provides MarshalQ which works in a similar way to the JSON marshaller. It is used to provide custom formatting for the q engine.

If objects do not implement this interface then the behavior remains the same.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/gedcom/250)
<!-- Reviewable:end -->
