### PR TITLE
Added IncorrectEventOrderWarning

### DIFF
--- a/child_born_before_parent_warning.go
+++ b/child_born_before_parent_warning.go
@@ -3,9 +3,9 @@ package gedcom
 import "fmt"
 
 type ChildBornBeforeParentWarning struct {
-	Parent  *IndividualNode
-	Child   *ChildNode
-	Context WarningContext
+	SimpleWarning
+	Parent *IndividualNode
+	Child  *ChildNode
 }
 
 func NewChildBornBeforeParentWarning(parent *IndividualNode, child *ChildNode) *ChildBornBeforeParentWarning {
@@ -32,10 +32,6 @@ func (w *ChildBornBeforeParentWarning) String() string {
 
 	return fmt.Sprintf("The child %s was born before %s %s %s.",
 		w.Child, w.Child.Individual().Sex().OwnershipWord(), relationship, w.Parent)
-}
-
-func (w *ChildBornBeforeParentWarning) SetContext(context WarningContext) {
-	w.Context = context
 }
 
 func (w *ChildBornBeforeParentWarning) MarshalQ() interface{} {

--- a/date_range.go
+++ b/date_range.go
@@ -315,3 +315,12 @@ func (dr DateRange) ParseError() error {
 
 	return nil
 }
+
+func (dr DateRange) String() string {
+	start, end := dr.StartAndEndDates()
+	if start.Equals(end) {
+		return start.String()
+	}
+
+	return fmt.Sprintf("Bet. %s and %s", start, end)
+}

--- a/document_test.go
+++ b/document_test.go
@@ -256,6 +256,17 @@ var documentWarningTests = map[string]struct {
 			`Unparsable date "around world war 2"`,
 		},
 	},
+	"DeathBeforeBirth": {
+		func(doc *gedcom.Document) {
+			doc.AddIndividual("P1").
+				AddName("Jenny /Chance/").
+				AddBirthDate("16 May 1989").
+				AddDeathDate("16 May 1979")
+		},
+		[]string{
+			"The death (16 May 1979) was before the birth (16 May 1989) of Jenny Chance (b. 16 May 1989, d. 16 May 1979).",
+		},
+	},
 }
 
 func TestDocument_Warnings(t *testing.T) {

--- a/incorrect_event_order_warning.go
+++ b/incorrect_event_order_warning.go
@@ -1,0 +1,46 @@
+package gedcom
+
+import (
+	"fmt"
+	"strings"
+)
+
+// IncorrectEventOrderWarning produces warnings where events for an individual
+// are in an incorrect order. For example a burial before a death event, or a
+// baptism before a birth.
+type IncorrectEventOrderWarning struct {
+	SimpleWarning
+	FirstEvent, SecondEvent         Node
+	FirstDateRange, SecondDateRange DateRange
+}
+
+func NewIncorrectEventOrderWarning(firstEvent Node, firstDateRange DateRange, secondEvent Node, secondDateRange DateRange) *IncorrectEventOrderWarning {
+	return &IncorrectEventOrderWarning{
+		FirstEvent:      firstEvent,
+		FirstDateRange:  firstDateRange,
+		SecondEvent:     secondEvent,
+		SecondDateRange: secondDateRange,
+	}
+}
+
+func (w *IncorrectEventOrderWarning) Name() string {
+	return "IncorrectEventOrder"
+}
+
+func (w *IncorrectEventOrderWarning) String() string {
+	return fmt.Sprintf(`The %s (%s) was before the %s (%s) of %s.`,
+		strings.ToLower(w.FirstEvent.Tag().String()), w.FirstDateRange,
+		strings.ToLower(w.SecondEvent.Tag().String()), w.SecondDateRange,
+		w.Context.Individual)
+}
+
+func (w *IncorrectEventOrderWarning) MarshalQ() interface{} {
+	return map[string]interface{}{
+		"String":  w.String(),
+		"Name":    w.Name(),
+		"Context": w.Context.MarshalQ(),
+
+		"FirstEvent":  w.FirstEvent,
+		"SecondEvent": w.SecondEvent,
+	}
+}

--- a/siblings_born_too_close_warning.go
+++ b/siblings_born_too_close_warning.go
@@ -3,8 +3,8 @@ package gedcom
 import "fmt"
 
 type SiblingsBornTooCloseWarning struct {
+	SimpleWarning
 	Sibling1, Sibling2 *ChildNode
-	Context            WarningContext
 }
 
 func NewSiblingsBornTooCloseWarning(sibling1, sibling2 *ChildNode) *SiblingsBornTooCloseWarning {
@@ -25,10 +25,6 @@ func (w *SiblingsBornTooCloseWarning) String() string {
 
 	return fmt.Sprintf("The siblings %s and %s were born within %s of each other.",
 		w.Sibling1, w.Sibling2, Duration(min).String())
-}
-
-func (w *SiblingsBornTooCloseWarning) SetContext(context WarningContext) {
-	w.Context = context
 }
 
 func (w *SiblingsBornTooCloseWarning) MarshalQ() interface{} {

--- a/simple_warning.go
+++ b/simple_warning.go
@@ -1,0 +1,9 @@
+package gedcom
+
+type SimpleWarning struct {
+	Context WarningContext
+}
+
+func (w *SimpleWarning) SetContext(context WarningContext) {
+	w.Context = context
+}

--- a/unparsable_date_warning.go
+++ b/unparsable_date_warning.go
@@ -5,8 +5,8 @@ import (
 )
 
 type UnparsableDateWarning struct {
-	Date    *DateNode
-	Context WarningContext
+	SimpleWarning
+	Date *DateNode
 }
 
 func NewUnparsableDateWarning(date *DateNode) *UnparsableDateWarning {
@@ -21,10 +21,6 @@ func (w *UnparsableDateWarning) Name() string {
 
 func (w *UnparsableDateWarning) String() string {
 	return fmt.Sprintf(`Unparsable date "%s"`, w.Date.Value())
-}
-
-func (w *UnparsableDateWarning) SetContext(context WarningContext) {
-	w.Context = context
 }
 
 func (w *UnparsableDateWarning) MarshalQ() interface{} {


### PR DESCRIPTION
IncorrectEventOrderWarning produces warnings where events for an individual are in an incorrect order. For example a burial before a death event, or a baptism before a birth.

This patch also creates a SimpleWarning so there is less duplicate code between warnings and a few helper methods for events on IndividualNode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/gedcom/252)
<!-- Reviewable:end -->
