### PR TITLE
q: Attach stack trace on panic

### DIFF
--- a/q/accessor_expr.go
+++ b/q/accessor_expr.go
@@ -3,6 +3,7 @@ package q
 import (
 	"fmt"
 	"reflect"
+	"runtime/debug"
 )
 
 // AccessorExpr is used to fetch the value of a property or to invoke a method.
@@ -64,7 +65,9 @@ func (e *AccessorExpr) Evaluate(engine *Engine, input interface{}, args []*State
 func (e *AccessorExpr) evaluateAccessor(accessor string, input interface{}) (r interface{}, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			err = fmt.Errorf("cannot use .%s on %s", accessor, getType(input))
+			stackTrace := string(debug.Stack())
+			err = fmt.Errorf("panic %s.%s: %v\n%s", getType(input), accessor, r,
+				stackTrace)
 		}
 	}()
 

--- a/q/accessor_expr_test.go
+++ b/q/accessor_expr_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/elliotchance/gedcom/q"
 	"github.com/elliotchance/tf"
 	"testing"
+	"github.com/stretchr/testify/assert"
 )
 
 type MyStruct struct {
@@ -16,6 +17,10 @@ func (ms *MyStruct) Foo() string {
 
 func (ms MyStruct) Baz() []string {
 	return []string{"qux", "quux"}
+}
+
+func (ms MyStruct) Panic() string {
+	panic("oh no!")
 }
 
 func TestAccessorExpr_Evaluate(t *testing.T) {
@@ -49,4 +54,10 @@ func TestAccessorExpr_Evaluate(t *testing.T) {
 		Errors(`MyStruct does not have a method or property named "Missing"`)
 	Evaluate(&q.AccessorExpr{Query: ".Missing"}, engine, ms2, nil).
 		Errors(`MyStruct does not have a method or property named "Missing"`)
+
+	// Panics
+	q := &q.AccessorExpr{Query: ".Panic"}
+	_, err := q.Evaluate(engine, ms1, nil)
+	assert.NotNil(t, err)
+	assert.Regexp(t, `^panic MyStruct.Panic: oh no!\ngoroutine `, err)
 }

--- a/q/question_mark_expr_test.go
+++ b/q/question_mark_expr_test.go
@@ -39,7 +39,8 @@ func TestQuestionMarkExpr_Evaluate(t *testing.T) {
 		(*q.QuestionMarkExpr).Evaluate)
 	engine := &q.Engine{}
 
-	expected := append([]string{".Baz", ".Foo"}, functionAndVariableChoices...)
+	expected := append([]string{".Baz", ".Foo", ".Panic"},
+		functionAndVariableChoices...)
 
 	Evaluate(&q.QuestionMarkExpr{}, engine, &MyStruct{}, nil).
 		Returns(expected, nil)


### PR DESCRIPTION
If an accessor fails the panic message and stack trace are now added to the error returned.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/gedcom/259)
<!-- Reviewable:end -->
