### PR TITLE
ChildNode: Individual() may panic

### DIFF
--- a/child_node.go
+++ b/child_node.go
@@ -26,9 +26,16 @@ func (node *ChildNode) Family() *FamilyNode {
 }
 
 func (node *ChildNode) Individual() *IndividualNode {
+	if node == nil {
+		return nil
+	}
+
 	n := node.family.document.NodeByPointer(valueToPointer(node.value))
 
-	// TODO: may not exist
+	if IsNil(n) {
+		return nil
+	}
+
 	return n.(*IndividualNode)
 }
 

--- a/child_node_test.go
+++ b/child_node_test.go
@@ -1,0 +1,23 @@
+package gedcom_test
+
+import (
+	"testing"
+	"github.com/elliotchance/gedcom"
+	"github.com/stretchr/testify/assert"
+	"github.com/elliotchance/tf"
+)
+
+func TestChildNode_Individual(t *testing.T) {
+	Individual := tf.NamedFunction(t, "ChildNode_Individual",
+		(*gedcom.ChildNode).Individual)
+
+	Individual(nil).Returns(nil)
+
+	doc := gedcom.NewDocument()
+	p1 := doc.AddIndividual("P1")
+	p2 := doc.AddIndividual("P2")
+	f1 := doc.AddFamilyWithHusbandAndWife("F1", p1, nil)
+	f1.AddChild(p2)
+
+	assert.Equal(t, f1.Children()[0].Individual(), p2)
+}


### PR DESCRIPTION
FIxed a bug where the Individual() of a ChildNode may panic if the individual cannot be resolved.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/gedcom/260)
<!-- Reviewable:end -->
