### PR TITLE
HTMLFormatter: Remove os.Stdout

### DIFF
--- a/q/html_formatter.go
+++ b/q/html_formatter.go
@@ -4,7 +4,6 @@ import (
 	"github.com/elliotchance/gedcom"
 	"github.com/elliotchance/gedcom/html/core"
 	"io"
-	"os"
 	"reflect"
 )
 
@@ -18,14 +17,14 @@ func (f *HTMLFormatter) Write(result interface{}) error {
 	// Nil should be treated as a blank document.
 	if gedcom.IsNil(result) {
 		_, err := core.NewPage(pageTitle, core.NewSpace(), "").
-			WriteHTMLTo(os.Stdout)
+			WriteHTMLTo(f.Writer)
 
 		return err
 	}
 
 	if x, ok := result.(core.Component); ok {
 		row := core.NewRow(core.NewColumn(core.EntireRow, x))
-		_, err := core.NewPage(pageTitle, row, "").WriteHTMLTo(os.Stdout)
+		_, err := core.NewPage(pageTitle, row, "").WriteHTMLTo(f.Writer)
 
 		return err
 	}


### PR DESCRIPTION
Fixed a bug where HTMLFormatter was writing to os.Stdout instead of the Writer buffer as it should.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/gedcom/261)
<!-- Reviewable:end -->
