### PR TITLE
Decoder: AllowMultiLine mangles some nodes

### DIFF
--- a/child_node_test.go
+++ b/child_node_test.go
@@ -1,10 +1,10 @@
 package gedcom_test
 
 import (
-	"testing"
 	"github.com/elliotchance/gedcom"
-	"github.com/stretchr/testify/assert"
 	"github.com/elliotchance/tf"
+	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func TestChildNode_Individual(t *testing.T) {

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -312,6 +312,19 @@ func TestDecoder_Decode(t *testing.T) {
 
 			assertDocumentEqual(t, doc, actual)
 		})
+
+		t.Run(testName+"WithAllowMultiLine", func(t *testing.T) {
+			decoder := gedcom.NewDecoder(strings.NewReader(test.ged))
+			decoder.AllowMultiLine = true
+
+			actual, err := decoder.Decode()
+			assert.NoError(t, err, test.ged)
+
+			doc := gedcom.NewDocument()
+			test.expected(doc)
+
+			assertDocumentEqual(t, doc, actual)
+		})
 	}
 
 	t.Run("DoubleSpace", func(t *testing.T) {

--- a/q/accessor_expr_test.go
+++ b/q/accessor_expr_test.go
@@ -3,8 +3,8 @@ package q_test
 import (
 	"github.com/elliotchance/gedcom/q"
 	"github.com/elliotchance/tf"
-	"testing"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 type MyStruct struct {


### PR DESCRIPTION
Since AllowMultiLine will allow blank lines to continue there is a bug where this might lead to node values having a traing new line.

For these cases the error cascades down to node that need to decode the value (such as a date) and the added newline break the regexps.

Now new lines can still exist in multiline values, but the value itself cannot end with a new line. This is a good balance been compatibility and consistence.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/gedcom/262)
<!-- Reviewable:end -->
