### PR TITLE
HTML: Fix panic on nil Component

### DIFF
--- a/html/core/components.go
+++ b/html/core/components.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"io"
+	"reflect"
 )
 
 // Components is a wrapper for zero more components that rendered at the same
@@ -14,7 +15,7 @@ func NewComponents(items ...Component) *Components {
 	nonNilItems := []Component{}
 
 	for _, item := range items {
-		if item != nil {
+		if !reflect.ValueOf(item).IsNil() {
 			nonNilItems = append(nonNilItems, item)
 		}
 	}


### PR DESCRIPTION
A nasty little bug where the nil check on a set of components was not correctly identifying a nil Component.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/gedcom/265)
<!-- Reviewable:end -->
