### PR TITLE
gedcom2html: Faster and customizable rendering

### DIFF
--- a/gedcom2html/main.go
+++ b/gedcom2html/main.go
@@ -13,53 +13,24 @@
 //
 // You can see an online example at http://dechauncy.family.
 //
-// Using the Checksum File
-//
-// The "-checksum" generates a file called "checksum.csv". This file contains
-// file names and their SHA-1 checksum like:
-//
-//   amos-adams.html,b0538fb8186a50c4079c902fec2b4ba0af843061
-//   massachusetts-united-states.html,79db811c089e8ab5653d34551e6540cb2ea2c947
-//
-// The lines are ordered by the file name so the output is ideal for comparison.
-//
-// Here is an example of using the previous and current checksum file to
-// generate sync commands:
-//
-//   join -a 1 -a 2 -t, -o 0.1,1.2,2.2 /old/checksum.csv /new/checksum.csv | \
-//      awk -F, '$2 == $3 { next } { print $3 == "" \
-//          ? "rm /some/folder/" $1 \
-//          : "cp" " " $1 " /some/folder/" $1 }'
-//
-// Will produce commands like:
-//
-//   cp abos-adams.html /some/folder/abos-adams.html
-//   rm /some/folder/massachusetts-united-states.html
-//
 package main
 
 import (
-	"crypto/sha1"
 	"flag"
-	"fmt"
 	"github.com/elliotchance/gedcom"
 	"github.com/elliotchance/gedcom/html"
 	"github.com/elliotchance/gedcom/html/core"
 	"github.com/elliotchance/gedcom/util"
-	"io"
-	"io/ioutil"
 	"log"
 	"os"
-	"sort"
-	"strings"
 )
 
 var (
 	optionGedcomFile        string
 	optionOutputDir         string
 	optionGoogleAnalyticsID string
-	optionChecksum          bool
 	optionLivingVisibility  string
+	optionJobs              int
 
 	optionNoIndividuals bool
 	optionNoPlaces      bool
@@ -78,8 +49,6 @@ func main() {
 		" be deleted.")
 	flag.StringVar(&optionGoogleAnalyticsID, "google-analytics-id", "",
 		"The Google Analytics ID, like 'UA-78454410-2'.")
-	flag.BoolVar(&optionChecksum, "checksum", false,
-		"Output a checksum file, helpful for syncing large trees.")
 	flag.StringVar(&optionLivingVisibility, "living",
 		html.LivingVisibilityPlaceholder, util.CLIDescription(`
 			Controls how information for living individuals are handled:
@@ -90,6 +59,10 @@ func main() {
 
 			"placeholder": Show a "Hidden" placeholder that only that
 			individuals are known but will not be displayed.`))
+	flag.IntVar(&optionJobs, "jobs", 1,
+		"Increasing this value will consume more resources but render the"+
+			"website faster. An ideal value would be the number of CPUs "+
+			"available, if you can spare it.")
 
 	flag.BoolVar(&optionNoIndividuals, "no-individuals", false,
 		"Exclude Individuals.")
@@ -121,131 +94,24 @@ func main() {
 		log.Fatal(err)
 	}
 
-	options := html.PublishShowOptions{
-		ShowIndividuals: !optionNoIndividuals,
-		ShowPlaces:      !optionNoPlaces,
-		ShowFamilies:    !optionNoFamilies,
-		ShowSurnames:    !optionNoSurnames,
-		ShowSources:     !optionNoSources,
-		ShowStatistics:  !optionNoStatistics,
-		Checksum:        optionChecksum,
+	options := &html.PublishShowOptions{
+		ShowIndividuals:  !optionNoIndividuals,
+		ShowPlaces:       !optionNoPlaces,
+		ShowFamilies:     !optionNoFamilies,
+		ShowSurnames:     !optionNoSurnames,
+		ShowSources:      !optionNoSources,
+		ShowStatistics:   !optionNoStatistics,
+		LivingVisibility: html.NewLivingVisibility(optionLivingVisibility),
 	}
 
-	visibility := html.NewLivingVisibility(optionLivingVisibility)
-
-	// Create the pages.
-	if !optionNoIndividuals {
-		for _, letter := range html.GetIndexLetters(document) {
-			createFile(html.PageIndividuals(letter),
-				html.NewIndividualListPage(document, letter, optionGoogleAnalyticsID, options, visibility))
-		}
-
-		for _, individual := range html.GetIndividuals(document) {
-			if individual.IsLiving() {
-				switch visibility {
-				case html.LivingVisibilityHide,
-					html.LivingVisibilityPlaceholder:
-					continue
-
-				case html.LivingVisibilityShow:
-					// Proceed.
-				}
-			}
-
-			page := html.NewIndividualPage(document, individual, optionGoogleAnalyticsID, options, visibility)
-			createFile(html.PageIndividual(document, individual, visibility), page)
-		}
+	writer := core.NewDirectoryFileWriter(optionOutputDir)
+	writer.WillWriteFile = func(file *core.File) {
+		log.Printf("%s/%s\n", optionOutputDir, file.Name)
 	}
 
-	if !optionNoPlaces {
-		page := html.NewPlaceListPage(document, optionGoogleAnalyticsID, options)
-		createFile(html.PagePlaces(), page)
-
-		// Sort the places so that the generated page names will be more
-		// deterministic.
-		places := html.GetPlaces(document)
-		placeKeys := []string{}
-
-		for key := range places {
-			placeKeys = append(placeKeys, key)
-		}
-
-		sort.Strings(placeKeys)
-
-		for _, key := range placeKeys {
-			place := places[key]
-			page := html.NewPlacePage(document, key, optionGoogleAnalyticsID, options, visibility)
-			createFile(html.PagePlace(document, place.PrettyName), page)
-		}
-	}
-
-	if !optionNoFamilies {
-		createFile(html.PageFamilies(), html.NewFamilyListPage(document, optionGoogleAnalyticsID, options, visibility))
-	}
-
-	if !optionNoSurnames {
-		createFile(html.PageSurnames(), html.NewSurnameListPage(document, optionGoogleAnalyticsID, options))
-	}
-
-	if !optionNoSources {
-		createFile(html.PageSources(), html.NewSourceListPage(document, optionGoogleAnalyticsID, options))
-
-		for _, source := range document.Sources() {
-			page := html.NewSourcePage(document, source, optionGoogleAnalyticsID, options)
-			createFile(html.PageSource(source), page)
-		}
-	}
-
-	if !optionNoStatistics {
-		createFile(html.PageStatistics(),
-			html.NewStatisticsPage(document, optionGoogleAnalyticsID, options, visibility))
-	}
-
-	// Calculate checksum
-	if optionChecksum {
-		lines := []string{}
-		fileInfos, err := ioutil.ReadDir(optionOutputDir)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		for _, fileInfo := range fileInfos {
-			checksum := fileSha1(fileInfo.Name())
-			line := fmt.Sprintf("%s,%s", fileInfo.Name(), checksum)
-			lines = append(lines, line)
-		}
-
-		sort.Strings(lines)
-
-		createFile("checksum.csv", core.NewText(strings.Join(lines, "\n")))
-	}
-}
-
-func fileSha1(path string) string {
-	f, err := os.Open(optionOutputDir + "/" + path)
+	publisher := html.NewPublisher(document, options)
+	err = publisher.Publish(writer, optionJobs)
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer f.Close()
-
-	h := sha1.New()
-	if _, err := io.Copy(h, f); err != nil {
-		log.Fatal(err)
-	}
-
-	return fmt.Sprintf("%x", h.Sum(nil))
-}
-
-func createFile(name string, contents core.Component) {
-	path := fmt.Sprintf("%s/%s", optionOutputDir, name)
-	log.Printf("Writing %s...", path)
-
-	out, err := os.Create(path)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	contents.WriteHTMLTo(out)
-
-	out.Close()
 }

--- a/html/core/directory_file_writer.go
+++ b/html/core/directory_file_writer.go
@@ -1,0 +1,51 @@
+package core
+
+import (
+	"crypto/sha1"
+	"fmt"
+	"io"
+	"os"
+)
+
+type DirectoryFileWriter struct {
+	outputDir     string
+	WillWriteFile func(file *File)
+}
+
+func NewDirectoryFileWriter(outputDir string) *DirectoryFileWriter {
+	return &DirectoryFileWriter{
+		outputDir: outputDir,
+	}
+}
+
+func (writer *DirectoryFileWriter) WriteFile(file *File) error {
+	path := fmt.Sprintf("%s/%s", writer.outputDir, file.Name)
+
+	if writer.WillWriteFile != nil {
+		writer.WillWriteFile(file)
+	}
+
+	out, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+
+	file.Component.WriteHTMLTo(out)
+
+	return out.Close()
+}
+
+func (writer *DirectoryFileWriter) fileSha1(path string) (string, error) {
+	f, err := os.Open(writer.outputDir + "/" + path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	h := sha1.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%x", h.Sum(nil)), nil
+}

--- a/html/core/file.go
+++ b/html/core/file.go
@@ -1,0 +1,13 @@
+package core
+
+type File struct {
+	Name      string
+	Component Component
+}
+
+func NewFile(name string, component Component) *File {
+	return &File{
+		Name:      name,
+		Component: component,
+	}
+}

--- a/html/core/file_writer.go
+++ b/html/core/file_writer.go
@@ -1,0 +1,5 @@
+package core
+
+type FileWriter interface {
+	WriteFile(file *File) error
+}

--- a/html/family_list_page.go
+++ b/html/family_list_page.go
@@ -9,16 +9,14 @@ import (
 type FamilyListPage struct {
 	document          *gedcom.Document
 	googleAnalyticsID string
-	options           PublishShowOptions
-	visibility        LivingVisibility
+	options           *PublishShowOptions
 }
 
-func NewFamilyListPage(document *gedcom.Document, googleAnalyticsID string, options PublishShowOptions, visibility LivingVisibility) *FamilyListPage {
+func NewFamilyListPage(document *gedcom.Document, googleAnalyticsID string, options *PublishShowOptions) *FamilyListPage {
 	return &FamilyListPage{
 		document:          document,
 		googleAnalyticsID: googleAnalyticsID,
 		options:           options,
-		visibility:        visibility,
 	}
 }
 
@@ -28,7 +26,7 @@ func (c *FamilyListPage) WriteHTMLTo(w io.Writer) (int64, error) {
 	}
 
 	for _, family := range c.document.Families() {
-		familyInList := NewFamilyInList(c.document, family, c.visibility)
+		familyInList := NewFamilyInList(c.document, family, c.options.LivingVisibility)
 		table = append(table, familyInList)
 	}
 

--- a/html/individual_list_page.go
+++ b/html/individual_list_page.go
@@ -13,17 +13,15 @@ type IndividualListPage struct {
 	document          *gedcom.Document
 	selectedLetter    rune
 	googleAnalyticsID string
-	options           PublishShowOptions
-	visibility        LivingVisibility
+	options           *PublishShowOptions
 }
 
-func NewIndividualListPage(document *gedcom.Document, selectedLetter rune, googleAnalyticsID string, options PublishShowOptions, visibility LivingVisibility) *IndividualListPage {
+func NewIndividualListPage(document *gedcom.Document, selectedLetter rune, googleAnalyticsID string, options *PublishShowOptions) *IndividualListPage {
 	return &IndividualListPage{
 		document:          document,
 		selectedLetter:    selectedLetter,
 		googleAnalyticsID: googleAnalyticsID,
 		options:           options,
-		visibility:        visibility,
 	}
 }
 
@@ -52,7 +50,7 @@ func (c *IndividualListPage) WriteHTMLTo(w io.Writer) (int64, error) {
 	lastSurname := ""
 	for _, i := range individuals {
 		if i.IsLiving() {
-			switch c.visibility {
+			switch c.options.LivingVisibility {
 			case LivingVisibilityShow:
 				// Proceed.
 
@@ -77,7 +75,7 @@ func (c *IndividualListPage) WriteHTMLTo(w io.Writer) (int64, error) {
 			lastSurname = newSurname
 		}
 
-		table = append(table, NewIndividualInList(c.document, i, c.visibility))
+		table = append(table, NewIndividualInList(c.document, i, c.options.LivingVisibility))
 	}
 
 	livingRow := core.NewRow(
@@ -88,8 +86,8 @@ func (c *IndividualListPage) WriteHTMLTo(w io.Writer) (int64, error) {
 	)
 
 	if livingCount == 0 ||
-		c.visibility == LivingVisibilityHide ||
-		c.visibility == LivingVisibilityShow {
+		c.options.LivingVisibility == LivingVisibilityHide ||
+		c.options.LivingVisibility == LivingVisibilityShow {
 		livingRow = nil
 	}
 
@@ -99,7 +97,7 @@ func (c *IndividualListPage) WriteHTMLTo(w io.Writer) (int64, error) {
 		core.NewSpace(),
 		NewIndividualIndexHeader(c.document, c.selectedLetter),
 		core.NewSpace(),
-		NewSurnameIndex(c.document, c.selectedLetter, c.visibility),
+		NewSurnameIndex(c.document, c.selectedLetter, c.options.LivingVisibility),
 		core.NewSpace(),
 		core.NewRow(
 			core.NewColumn(core.EntireRow, core.NewTable("", table...)),

--- a/html/individual_page.go
+++ b/html/individual_page.go
@@ -12,32 +12,30 @@ type IndividualPage struct {
 	document          *gedcom.Document
 	individual        *gedcom.IndividualNode
 	googleAnalyticsID string
-	options           PublishShowOptions
-	visibility        LivingVisibility
+	options           *PublishShowOptions
 }
 
-func NewIndividualPage(document *gedcom.Document, individual *gedcom.IndividualNode, googleAnalyticsID string, options PublishShowOptions, visibility LivingVisibility) *IndividualPage {
+func NewIndividualPage(document *gedcom.Document, individual *gedcom.IndividualNode, googleAnalyticsID string, options *PublishShowOptions) *IndividualPage {
 	return &IndividualPage{
 		document:          document,
 		individual:        individual,
 		googleAnalyticsID: googleAnalyticsID,
 		options:           options,
-		visibility:        visibility,
 	}
 }
 
 func (c *IndividualPage) WriteHTMLTo(w io.Writer) (int64, error) {
 	name := c.individual.Names()[0]
 
-	individualName := NewIndividualName(c.individual, c.visibility,
+	individualName := NewIndividualName(c.individual, c.options.LivingVisibility,
 		UnknownEmphasis)
-	individualDates := NewIndividualDates(c.individual, c.visibility)
+	individualDates := NewIndividualDates(c.individual, c.options.LivingVisibility)
 
 	return core.NewPage(
 		name.String(),
 		core.NewComponents(
 			NewPublishHeader(c.document, name.String(), selectedExtraTab, c.options),
-			NewAllParentButtons(c.document, c.individual, c.visibility),
+			NewAllParentButtons(c.document, c.individual, c.options.LivingVisibility),
 			core.NewBigTitle(1, individualName),
 			core.NewBigTitle(3, individualDates),
 			core.NewHorizontalRuleRow(),
@@ -46,9 +44,9 @@ func (c *IndividualPage) WriteHTMLTo(w io.Writer) (int64, error) {
 				core.NewColumn(core.HalfRow, NewIndividualAdditionalNames(c.individual)),
 			),
 			core.NewSpace(),
-			newIndividualEvents(c.document, c.individual, c.visibility),
+			newIndividualEvents(c.document, c.individual, c.options.LivingVisibility),
 			core.NewSpace(),
-			NewPartnersAndChildren(c.document, c.individual, c.visibility),
+			NewPartnersAndChildren(c.document, c.individual, c.options.LivingVisibility),
 		),
 		c.googleAnalyticsID,
 	).WriteHTMLTo(w)

--- a/html/individuals.go
+++ b/html/individuals.go
@@ -4,25 +4,40 @@ import (
 	"github.com/elliotchance/gedcom"
 	"regexp"
 	"strings"
+	"sync"
 )
 
+var individualSyncedMap sync.Map // map[string]*gedcom.IndividualNode
 var individualMap map[string]*gedcom.IndividualNode
+var individualMapSync sync.Mutex
 
 var alnumOrDashRegexp = regexp.MustCompile("[^a-z_0-9-]+")
 
 func GetIndividuals(document *gedcom.Document) map[string]*gedcom.IndividualNode {
-	if individualMap == nil {
-		individualMap = map[string]*gedcom.IndividualNode{}
-
-		for _, individual := range document.Individuals() {
-			name := individual.Name().String()
-
-			key := getUniqueKey(alnumOrDashRegexp.
-				ReplaceAllString(strings.ToLower(name), "-"))
-
-			individualMap[key] = individual
-		}
+	if individualMap != nil {
+		return individualMap
 	}
+
+	individualMapSync.Lock()
+
+	for _, individual := range document.Individuals() {
+		name := individual.Name().String()
+
+		key := getUniqueKey(alnumOrDashRegexp.
+			ReplaceAllString(strings.ToLower(name), "-"))
+
+		individualSyncedMap.Store(key, individual)
+	}
+
+	individualMap = map[string]*gedcom.IndividualNode{}
+
+	individualSyncedMap.Range(func(key, value interface{}) bool {
+		individualMap[key.(string)] = value.(*gedcom.IndividualNode)
+
+		return true
+	})
+
+	individualMapSync.Unlock()
 
 	return individualMap
 }

--- a/html/place_list_page.go
+++ b/html/place_list_page.go
@@ -11,10 +11,10 @@ import (
 type PlaceListPage struct {
 	document          *gedcom.Document
 	googleAnalyticsID string
-	options           PublishShowOptions
+	options           *PublishShowOptions
 }
 
-func NewPlaceListPage(document *gedcom.Document, googleAnalyticsID string, options PublishShowOptions) *PlaceListPage {
+func NewPlaceListPage(document *gedcom.Document, googleAnalyticsID string, options *PublishShowOptions) *PlaceListPage {
 	return &PlaceListPage{
 		document:          document,
 		googleAnalyticsID: googleAnalyticsID,

--- a/html/place_page.go
+++ b/html/place_page.go
@@ -10,17 +10,15 @@ type PlacePage struct {
 	document          *gedcom.Document
 	placeKey          string
 	googleAnalyticsID string
-	options           PublishShowOptions
-	visibility        LivingVisibility
+	options           *PublishShowOptions
 }
 
-func NewPlacePage(document *gedcom.Document, placeKey string, googleAnalyticsID string, options PublishShowOptions, visibility LivingVisibility) *PlacePage {
+func NewPlacePage(document *gedcom.Document, placeKey string, googleAnalyticsID string, options *PublishShowOptions) *PlacePage {
 	return &PlacePage{
 		document:          document,
 		placeKey:          placeKey,
 		googleAnalyticsID: googleAnalyticsID,
 		options:           options,
-		visibility:        visibility,
 	}
 }
 
@@ -32,7 +30,7 @@ func (c *PlacePage) WriteHTMLTo(w io.Writer) (int64, error) {
 	}
 
 	for _, node := range place.nodes {
-		placeEvent := NewPlaceEvent(c.document, node, c.visibility)
+		placeEvent := NewPlaceEvent(c.document, node, c.options.LivingVisibility)
 		table = append(table, placeEvent)
 	}
 

--- a/html/publish.go
+++ b/html/publish.go
@@ -1,0 +1,163 @@
+package html
+
+import (
+	"github.com/elliotchance/gedcom"
+	"github.com/elliotchance/gedcom/html/core"
+	"github.com/elliotchance/gedcom/util"
+	"sort"
+)
+
+type PublishShowOptions struct {
+	ShowIndividuals  bool
+	ShowPlaces       bool
+	ShowFamilies     bool
+	ShowSurnames     bool
+	ShowSources      bool
+	ShowStatistics   bool
+	LivingVisibility LivingVisibility
+}
+
+type Publisher struct {
+	doc               *gedcom.Document
+	options           *PublishShowOptions
+	fileWriter        core.FileWriter
+	GoogleAnalyticsID string
+}
+
+// NewPublisher generates the pages to be rendered for a published website.
+//
+// The fileWriter will be responsible for rendering the pages to their
+// destination. Which may be a file system, or somewhere else of your choosing.
+// If you only wish to generate files you should use a DirectoryFileWriter.
+func NewPublisher(doc *gedcom.Document, options *PublishShowOptions) *Publisher {
+	return &Publisher{
+		doc:     doc,
+		options: options,
+	}
+}
+
+func (publisher *Publisher) Publish(fileWriter core.FileWriter, parallel int) (err error) {
+	files := publisher.Files(parallel)
+	util.WorkerPool(parallel, func(_ int) {
+		for file := range files {
+			fileErr := fileWriter.WriteFile(file)
+			if fileErr != nil {
+				err = fileErr
+				break
+			}
+		}
+	})
+
+	return
+}
+
+func (publisher *Publisher) Files(channelSize int) chan *core.File {
+	files := make(chan *core.File, channelSize)
+
+	go func() {
+		publisher.sendFiles(files)
+		close(files)
+	}()
+
+	return files
+}
+
+func (publisher *Publisher) sendIndividualFiles(files chan *core.File) {
+	if publisher.options.ShowIndividuals {
+		for _, letter := range GetIndexLetters(publisher.doc) {
+			files <- core.NewFile(
+				PageIndividuals(letter),
+				NewIndividualListPage(publisher.doc, letter,
+					publisher.GoogleAnalyticsID, publisher.options),
+			)
+		}
+
+		individuals := GetIndividuals(publisher.doc)
+		for _, individual := range individuals {
+			if individual.IsLiving() {
+				switch publisher.options.LivingVisibility {
+				case LivingVisibilityHide,
+					LivingVisibilityPlaceholder:
+					continue
+
+				case LivingVisibilityShow:
+					// Proceed.
+				}
+			}
+
+			page := NewIndividualPage(publisher.doc, individual, publisher.GoogleAnalyticsID, publisher.options)
+			pageName := PageIndividual(publisher.doc, individual, publisher.options.LivingVisibility)
+			files <- core.NewFile(pageName, page)
+		}
+	}
+}
+
+func (publisher *Publisher) sendPlaceFiles(files chan *core.File) {
+	if publisher.options.ShowPlaces {
+		page := NewPlaceListPage(publisher.doc, publisher.GoogleAnalyticsID, publisher.options)
+		files <- core.NewFile(PagePlaces(), page)
+
+		// Sort the places so that the generated page names will be more
+		// deterministic.
+		places := GetPlaces(publisher.doc)
+		placeKeys := []string{}
+
+		for key := range places {
+			placeKeys = append(placeKeys, key)
+		}
+
+		sort.Strings(placeKeys)
+
+		for _, key := range placeKeys {
+			place := places[key]
+			page := NewPlacePage(publisher.doc, key, publisher.GoogleAnalyticsID, publisher.options)
+			files <- core.NewFile(PagePlace(publisher.doc, place.PrettyName), page)
+		}
+	}
+}
+
+func (publisher *Publisher) sendFamilyFiles(files chan *core.File) {
+	if publisher.options.ShowFamilies {
+		files <- core.NewFile(
+			PageFamilies(),
+			NewFamilyListPage(publisher.doc, publisher.GoogleAnalyticsID, publisher.options),
+		)
+	}
+}
+
+func (publisher *Publisher) sendSurnameFiles(files chan *core.File) {
+	if publisher.options.ShowSurnames {
+		files <- core.NewFile(
+			PageSurnames(),
+			NewSurnameListPage(publisher.doc, publisher.GoogleAnalyticsID,
+				publisher.options))
+	}
+}
+
+func (publisher *Publisher) sendSourceFiles(files chan *core.File) {
+	if publisher.options.ShowSources {
+		files <- core.NewFile(PageSources(),
+			NewSourceListPage(publisher.doc, publisher.GoogleAnalyticsID, publisher.options))
+
+		for _, source := range publisher.doc.Sources() {
+			page := NewSourcePage(publisher.doc, source, publisher.GoogleAnalyticsID, publisher.options)
+			files <- core.NewFile(PageSource(source), page)
+		}
+	}
+}
+
+func (publisher *Publisher) sendStatisticsFiles(files chan *core.File) {
+	if publisher.options.ShowStatistics {
+		files <- core.NewFile(PageStatistics(),
+			NewStatisticsPage(publisher.doc, publisher.GoogleAnalyticsID,
+				publisher.options))
+	}
+}
+
+func (publisher *Publisher) sendFiles(files chan *core.File) {
+	publisher.sendIndividualFiles(files)
+	publisher.sendPlaceFiles(files)
+	publisher.sendFamilyFiles(files)
+	publisher.sendSurnameFiles(files)
+	publisher.sendStatisticsFiles(files)
+}

--- a/html/publish_header.go
+++ b/html/publish_header.go
@@ -16,26 +16,16 @@ const (
 	selectedExtraTab       = "extra"
 )
 
-type PublishShowOptions struct {
-	ShowIndividuals bool
-	ShowPlaces      bool
-	ShowFamilies    bool
-	ShowSurnames    bool
-	ShowSources     bool
-	ShowStatistics  bool
-	Checksum        bool
-}
-
 // PublishHeader is the tabbed section at the top of each page. The PublishHeader will be the
 // same on all pages except that some pages will use an extra tab for that page.
 type PublishHeader struct {
 	document    *gedcom.Document
 	extraTab    string
 	selectedTab string
-	options     PublishShowOptions
+	options     *PublishShowOptions
 }
 
-func NewPublishHeader(document *gedcom.Document, extraTab string, selectedTab string, options PublishShowOptions) *PublishHeader {
+func NewPublishHeader(document *gedcom.Document, extraTab string, selectedTab string, options *PublishShowOptions) *PublishHeader {
 	return &PublishHeader{
 		document:    document,
 		extraTab:    extraTab,
@@ -50,11 +40,7 @@ func (c *PublishHeader) WriteHTMLTo(w io.Writer) (int64, error) {
 	items := []*core.NavItem{}
 
 	if c.options.ShowIndividuals {
-		var badge core.Component = core.NewEmpty()
-		if !c.options.Checksum {
-			badge = core.NewCountBadge(len(c.document.Individuals()))
-		}
-
+		badge := core.NewCountBadge(len(c.document.Individuals()))
 		title := core.NewComponents(core.NewText("Individuals "), badge)
 		item := core.NewNavItem(
 			title,
@@ -65,11 +51,7 @@ func (c *PublishHeader) WriteHTMLTo(w io.Writer) (int64, error) {
 	}
 
 	if c.options.ShowPlaces {
-		var badge core.Component = core.NewEmpty()
-		if !c.options.Checksum {
-			badge = core.NewCountBadge(len(GetPlaces(c.document)))
-		}
-
+		badge := core.NewCountBadge(len(GetPlaces(c.document)))
 		item := core.NewNavItem(
 			core.NewComponents(core.NewText("Places "), badge),
 			c.selectedTab == selectedPlacesTab,
@@ -79,11 +61,7 @@ func (c *PublishHeader) WriteHTMLTo(w io.Writer) (int64, error) {
 	}
 
 	if c.options.ShowFamilies {
-		var badge core.Component = core.NewEmpty()
-		if !c.options.Checksum {
-			badge = core.NewCountBadge(len(c.document.Families()))
-		}
-
+		badge := core.NewCountBadge(len(c.document.Families()))
 		item := core.NewNavItem(
 			core.NewComponents(core.NewText("Families "), badge),
 			c.selectedTab == selectedFamiliesTab,
@@ -93,11 +71,7 @@ func (c *PublishHeader) WriteHTMLTo(w io.Writer) (int64, error) {
 	}
 
 	if c.options.ShowSurnames {
-		var badge core.Component = core.NewEmpty()
-		if !c.options.Checksum {
-			badge = core.NewCountBadge(getSurnames(c.document).Len())
-		}
-
+		badge := core.NewCountBadge(getSurnames(c.document).Len())
 		item := core.NewNavItem(
 			core.NewComponents(core.NewText("Surnames "), badge),
 			c.selectedTab == selectedSurnamesTab,
@@ -107,11 +81,7 @@ func (c *PublishHeader) WriteHTMLTo(w io.Writer) (int64, error) {
 	}
 
 	if c.options.ShowSources {
-		var badge core.Component = core.NewEmpty()
-		if !c.options.Checksum {
-			badge = core.NewCountBadge(len(c.document.Sources()))
-		}
-
+		badge := core.NewCountBadge(len(c.document.Sources()))
 		item := core.NewNavItem(
 			core.NewComponents(core.NewText("Sources "), badge),
 			c.selectedTab == selectedSourcesTab,

--- a/html/publish_test.go
+++ b/html/publish_test.go
@@ -1,0 +1,59 @@
+package html_test
+
+import (
+	"testing"
+
+	"github.com/elliotchance/gedcom/html"
+	"github.com/elliotchance/gedcom"
+	"github.com/stretchr/testify/assert"
+)
+
+var publisherTests = map[string]struct {
+	options *html.PublishShowOptions
+	files   []string
+}{
+	"Empty": {
+		options: &html.PublishShowOptions{
+			LivingVisibility: html.LivingVisibilityShow,
+		},
+	},
+	"All": {
+		options: &html.PublishShowOptions{
+			ShowIndividuals:  true,
+			ShowPlaces:       true,
+			ShowFamilies:     true,
+			ShowSurnames:     true,
+			ShowSources:      true,
+			ShowStatistics:   true,
+			LivingVisibility: html.LivingVisibilityShow,
+		},
+		files: []string{
+			"individuals-e.html",
+			"elliot-chance.html",
+			"places.html",
+			"families.html",
+			"surnames.html",
+			"statistics.html",
+		},
+	},
+}
+
+func TestPublisher_Files(t *testing.T) {
+	for testName, test := range publisherTests {
+		t.Run(testName, func(t *testing.T) {
+			doc := gedcom.NewDocument()
+			p1 := doc.AddIndividual("P1")
+			p1.AddName("Elliot /Chance/")
+			doc.AddFamilyWithHusbandAndWife("F1", p1, nil)
+
+			publisher := html.NewPublisher(doc, test.options)
+
+			var files []string
+			for file := range publisher.Files(1) {
+				files = append(files, file.Name)
+			}
+
+			assert.Equal(t, test.files, files)
+		})
+	}
+}

--- a/html/source_list_page.go
+++ b/html/source_list_page.go
@@ -9,10 +9,10 @@ import (
 type SourceListPage struct {
 	document          *gedcom.Document
 	googleAnalyticsID string
-	options           PublishShowOptions
+	options           *PublishShowOptions
 }
 
-func NewSourceListPage(document *gedcom.Document, googleAnalyticsID string, options PublishShowOptions) *SourceListPage {
+func NewSourceListPage(document *gedcom.Document, googleAnalyticsID string, options *PublishShowOptions) *SourceListPage {
 	return &SourceListPage{
 		document:          document,
 		googleAnalyticsID: googleAnalyticsID,

--- a/html/source_page.go
+++ b/html/source_page.go
@@ -10,10 +10,10 @@ type SourcePage struct {
 	document          *gedcom.Document
 	source            *gedcom.SourceNode
 	googleAnalyticsID string
-	options           PublishShowOptions
+	options           *PublishShowOptions
 }
 
-func NewSourcePage(document *gedcom.Document, source *gedcom.SourceNode, googleAnalyticsID string, options PublishShowOptions) *SourcePage {
+func NewSourcePage(document *gedcom.Document, source *gedcom.SourceNode, googleAnalyticsID string, options *PublishShowOptions) *SourcePage {
 	return &SourcePage{
 		document:          document,
 		source:            source,

--- a/html/statistics_page.go
+++ b/html/statistics_page.go
@@ -9,16 +9,14 @@ import (
 type StatisticsPage struct {
 	document          *gedcom.Document
 	googleAnalyticsID string
-	options           PublishShowOptions
-	visibility        LivingVisibility
+	options           *PublishShowOptions
 }
 
-func NewStatisticsPage(document *gedcom.Document, googleAnalyticsID string, options PublishShowOptions, visibility LivingVisibility) *StatisticsPage {
+func NewStatisticsPage(document *gedcom.Document, googleAnalyticsID string, options *PublishShowOptions) *StatisticsPage {
 	return &StatisticsPage{
 		document:          document,
 		googleAnalyticsID: googleAnalyticsID,
 		options:           options,
-		visibility:        visibility,
 	}
 }
 
@@ -31,7 +29,7 @@ func (c *StatisticsPage) WriteHTMLTo(w io.Writer) (int64, error) {
 			core.NewSpace(),
 			core.NewRow(
 				core.NewColumn(core.HalfRow, core.NewComponents(
-					NewIndividualStatistics(c.document, c.visibility),
+					NewIndividualStatistics(c.document, c.options.LivingVisibility),
 					core.NewSpace(),
 					NewFamilyStatistics(c.document),
 					core.NewSpace(),

--- a/html/surname_list_page.go
+++ b/html/surname_list_page.go
@@ -9,10 +9,10 @@ import (
 type SurnameListPage struct {
 	document          *gedcom.Document
 	googleAnalyticsID string
-	options           PublishShowOptions
+	options           *PublishShowOptions
 }
 
-func NewSurnameListPage(document *gedcom.Document, googleAnalyticsID string, options PublishShowOptions) *SurnameListPage {
+func NewSurnameListPage(document *gedcom.Document, googleAnalyticsID string, options *PublishShowOptions) *SurnameListPage {
 	return &SurnameListPage{
 		document:          document,
 		googleAnalyticsID: googleAnalyticsID,


### PR DESCRIPTION
The code to publish a website has now been moved into the html package as Publisher. This means that the gedcom2html is much lighter.

The Publisher can now be customised to write to the file system, or any other storage mechanism and it can now render the website in parallel making it much faster. This can be configured with the new "-jobs" option.

The "-checksum" option has been removed from the gedcom2html because it was already problematic at best and not needed now that the rendering process is much faster.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/gedcom/266)
<!-- Reviewable:end -->
