### PR TITLE
decoder: Added AllowInvalidIndents

### DIFF
--- a/decoder_test.go
+++ b/decoder_test.go
@@ -379,6 +379,29 @@ func TestDecoder_Decode(t *testing.T) {
 			assertDocumentEqual(t, doc, actual)
 		}
 	})
+
+	t.Run("IndentTooBig", func(t *testing.T) {
+		decoder := gedcom.NewDecoder(strings.NewReader("0 @I59238932@ INDI\n2 NPFX Mrs William Cornens\n1 SEX F"))
+
+		assert.PanicsWithValue(t, "indent is too large - missing parent? at line 2: 2 NPFX Mrs William Cornens", func() {
+			_, _ = decoder.Decode()
+		})
+	})
+
+	t.Run("IndentTooBigAllowed", func(t *testing.T) {
+		decoder := gedcom.NewDecoder(strings.NewReader("0 @I59238932@ INDI\n2 NPFX Mrs William Cornens\n1 SEX F"))
+		decoder.AllowInvalidIndents = true
+
+		actual, err := decoder.Decode()
+		if assert.NoError(t, err) {
+			doc := gedcom.NewDocument()
+			doc.AddIndividual("I59238932",
+				gedcom.NewNode(gedcom.TagFromString("NPFX"), "Mrs William Cornens", ""),
+				gedcom.NewNode(gedcom.TagFromString("SEX"), "F", ""))
+
+			assertDocumentEqual(t, doc, actual)
+		}
+	})
 }
 
 func trimSpaces(s string) string {

--- a/gedcomdiff/main.go
+++ b/gedcomdiff/main.go
@@ -36,6 +36,7 @@ var (
 	optionSort                      string // see optionSort constants.
 	optionPreferPointerAbove        float64
 	optionAllowMultiLine            bool
+	optionAllowInvalidIndents       bool
 )
 
 var filterFlags = &gedcom.FilterFlags{}
@@ -54,6 +55,7 @@ func newDocumentFromGEDCOMFile(path string) (*gedcom.Document, error) {
 
 	decoder := gedcom.NewDecoder(file)
 	decoder.AllowMultiLine = optionAllowMultiLine
+	decoder.AllowInvalidIndents = optionAllowInvalidIndents
 
 	return decoder.Decode()
 }
@@ -263,6 +265,21 @@ func parseCLIFlags() {
 
 			When enabled any line than cannot be parsed will be considered an
 			extension of the previous line (including the new line character).
+			`))
+
+	flag.BoolVar(&optionAllowInvalidIndents, "allow-invalid-indents", false,
+		util.CLIDescription(`
+			When enabled, -allow-invalid-indents allows a child node to have an
+            indent greater than +1 of the parent. -allow-invalid-indents is
+            disabled by default because if this happens the GEDCOM file is
+            broken in some possibly serious way and certainly not a valid GEDCOM
+            file.
+
+            The biggest problem with having the indents wrongly aligned is that
+            nodes that are expected to be a certain depth (such as NPFX inside a
+            NAME) will probably break or interfere with a traversal algorithm
+            that is not expecting the node to be there/at that level. This may
+            lead to unexpected behavior.
 			`))
 
 	filterFlags.SetupCLI()


### PR DESCRIPTION
AllowInvalidIndents allows a child node to have an indent greater than +1 of the parent. AllowInvalidIndents is disabled by default because if this happens the GEDCOM file is broken in some possibly serious way and certainly not a valid GEDCOM file.

The biggest problem with having the indents wrongly aligned is that nodes that are expected to be a certain depth (such as NPFX inside a NAME) will probably break or interfere with a traversal algorithm that is not expecting the node to be there/at that level.

Another important thing to note is that the incorrect indent level will not be retained when writing the Document back to a GEDCOM.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/gedcom/278)
<!-- Reviewable:end -->
