### PR TITLE
ResidenceNode: Equality without dates

### DIFF
--- a/residence_node.go
+++ b/residence_node.go
@@ -50,6 +50,16 @@ func (node *ResidenceNode) Equals(node2 Node) bool {
 				}
 			}
 		}
+
+		// Residences are equal if they contain the same place but both do not
+		// specify a date. NodesWithTag would be expensive to run all the time,
+		// so only use it when we know both sides do not have a date.
+		if len(leftDates)+len(rightDates) == 0 {
+			leftPlaces := NodesWithTag(node, TagPlace)
+			rightPlaces := NodesWithTag(node2, TagPlace)
+
+			return DeepEqualNodes(leftPlaces, rightPlaces)
+		}
 	}
 
 	return false

--- a/residence_node_test.go
+++ b/residence_node_test.go
@@ -63,10 +63,22 @@ func TestResidenceNode_Equals(t *testing.T) {
 	Equals(n1, gedcom.NewNameNode("foo")).Returns(false)
 
 	// General cases.
-	Equals(n1, n1).Returns(false)
-	Equals(n1, n2).Returns(false)
+	Equals(n1, n1).Returns(true)
+	Equals(n1, n2).Returns(true)
 	Equals(n1, n3).Returns(false)
 	Equals(n3, n4).Returns(true)
+
+	// Residences are equal if they contain the same place but both do not
+	// specify a date.
+	r1 := gedcom.NewResidenceNode("",
+		gedcom.NewSourceNode("@S619368194@", ""),
+		gedcom.NewPlaceNode("Worcestershire"),
+	)
+	r2 := gedcom.NewResidenceNode("",
+		gedcom.NewPlaceNode("Worcestershire"),
+		gedcom.NewSourceNode("@S619368193@", "", gedcom.NewNode(gedcom.TagFromString("_APID"), "1,2056::540816", "")),
+	)
+	Equals(r1, r2).Returns(true)
 }
 
 func TestResidenceNode_Years(t *testing.T) {


### PR DESCRIPTION
This bug was caught when differences showed up after comparing the same file to itself.

Residences are equal if they contain the same place but both do not specify a date. Previously it was only if they share the same date.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/gedcom/285)
<!-- Reviewable:end -->
