### PR TITLE
Publish: Fix surname index and missing children

### DIFF
--- a/html/individual_index_header.go
+++ b/html/individual_index_header.go
@@ -49,7 +49,7 @@ func GetIndexLetters(document *gedcom.Document, livingVisibility LivingVisibilit
 }
 
 func getIndexLetter(individual *gedcom.IndividualNode) rune {
-	name := strings.ToLower(individual.Name().String())
+	name := strings.ToLower(individual.Name().Surname())
 
 	switch {
 	case name == "", name[0] < 'a', name[0] > 'z':

--- a/html/publish_test.go
+++ b/html/publish_test.go
@@ -28,7 +28,7 @@ var publisherTests = map[string]struct {
 			LivingVisibility: html.LivingVisibilityShow,
 		},
 		files: []string{
-			"individuals-e.html",
+			"individuals-c.html",
 			"elliot-chance.html",
 			"places.html",
 			"families.html",

--- a/individual_node.go
+++ b/individual_node.go
@@ -103,11 +103,11 @@ func (node *IndividualNode) Spouses() (spouses IndividualNodes) {
 			continue
 		}
 
-		if husband.Pointer() == node.Pointer() {
+		if husband.IsIndividual(node) {
 			spouses = append(spouses, wife.Individual())
 		}
 
-		if wife.Pointer() == node.Pointer() {
+		if wife.IsIndividual(node) {
 			spouses = append(spouses, husband.Individual())
 		}
 	}


### PR DESCRIPTION
Two bugs fixed:

1. One bug was caused by taking the first letter of the name, which may not be the first letter of the surname. So these individuals were not appearing on the index.

2. Children with an unknown spouse were not being displayed becuase it was incorrectly comparing the family pointer instead of the individual pointer.

Fixes #276

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/gedcom/293)
<!-- Reviewable:end -->
