### PR TITLE
Publish: Fix missing additional names

### DIFF
--- a/html/individual_additional_names.go
+++ b/html/individual_additional_names.go
@@ -20,16 +20,16 @@ func NewIndividualAdditionalNames(individual *gedcom.IndividualNode) *Individual
 
 func (c *IndividualAdditionalNames) WriteHTMLTo(w io.Writer) (int64, error) {
 	rows := []core.Component{}
-	names := c.individual.Names()
+	names := c.individual.Names()[1:]
 
 	for _, name := range names {
-		row := core.NewKeyedTableRow(name.Type().String(), core.NewText(name.String()),
-			name.Type() != "")
+		row := core.NewKeyedTableRow(
+			name.Type().String(), core.NewText(name.String()), true)
 		rows = append(rows, row)
 	}
 
 	table := core.NewTable("", rows...)
 
-	return core.NewCard(core.NewText("Additional Names"), len(names)-1, table).
+	return core.NewCard(core.NewText("Additional Names"), len(names), table).
 		WriteHTMLTo(w)
 }


### PR DESCRIPTION
Names would not show as additional names if they were "Normal" names (ie. not married name, etc). Now it shows all names excluding the first name.

Fixes #275

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/gedcom/294)
<!-- Reviewable:end -->
