### PR TITLE
Added "-no-duplicate-names"

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -88,6 +88,10 @@ func filter(root Node, fn FilterFunction, entityMap entityMap) Node {
 				result.AddNode(newNode)
 			}
 		}
+	} else {
+		for _, child := range newRoot.Nodes() {
+			result.AddNode(child)
+		}
 	}
 
 	return result
@@ -209,6 +213,34 @@ func RemoveEmptyDeathTagFilter() FilterFunction {
 			return nil, false
 		}
 
+		return node, true
+	}
+}
+
+func RemoveDuplicateNamesFilter() FilterFunction {
+	return func(node Node) (Node, bool) {
+		if individual, ok := node.(*IndividualNode); ok {
+			newIndividual := newIndividualNode(individual.Document(),
+				individual.Pointer())
+			names := map[string]bool{}
+
+			for _, n := range individual.children {
+				if name, isName := n.(*NameNode); isName {
+					nameString := name.String()
+					if names[nameString] == true {
+						continue
+					}
+
+					names[nameString] = true
+				}
+				newIndividual.AddNode(n)
+			}
+
+			return newIndividual, false
+		}
+
+		// Individuals can only exist on the root level so there's no need to
+		// recurse.
 		return node, true
 	}
 }

--- a/filter_flags.go
+++ b/filter_flags.go
@@ -7,16 +7,17 @@ import (
 
 type FilterFlags struct {
 	// Specific exclusions.
-	NoEvents      bool
-	NoResidences  bool
-	NoPlaces      bool
-	NoSources     bool
-	NoMaps        bool
-	NoChanges     bool
-	NoObjects     bool
-	NoLabels      bool
-	NoCensuses    bool
-	NoEmptyDeaths bool
+	NoEvents         bool
+	NoResidences     bool
+	NoPlaces         bool
+	NoSources        bool
+	NoMaps           bool
+	NoChanges        bool
+	NoObjects        bool
+	NoLabels         bool
+	NoCensuses       bool
+	NoEmptyDeaths    bool
+	NoDuplicateNames bool
 
 	// Only vitals (name, birth, baptism, death and burial).
 	OnlyVitals bool
@@ -41,6 +42,7 @@ func (ff *FilterFlags) SetupCLI() {
 	flag.BoolVar(&ff.NoObjects, "no-objects", false, "Exclude objects.")
 	flag.BoolVar(&ff.NoLabels, "no-labels", false, "Exclude labels.")
 	flag.BoolVar(&ff.NoCensuses, "no-censuses", false, "Exclude censuses.")
+	flag.BoolVar(&ff.NoDuplicateNames, "no-duplicate-names", false, "Exclude names that are duplicates.")
 
 	flag.BoolVar(&ff.NoEmptyDeaths, "no-empty-deaths", false, util.CLIDescription(
 		`Remove death nodes (DEAT) that do not have children. This is caused by
@@ -101,6 +103,12 @@ func (ff *FilterFlags) FilterFunctions() []FilterFunction {
 
 	if ff.OnlyOfficial {
 		filters = append(filters, OfficialTagFilter())
+	}
+
+	// This must be before NameFormat because NameFormat may simplify/destroy
+	// NAME nodes.
+	if ff.NoDuplicateNames {
+		filters = append(filters, RemoveDuplicateNamesFilter())
 	}
 
 	if ff.NameFormat != "unmodified" {

--- a/filter_flags_test.go
+++ b/filter_flags_test.go
@@ -1,0 +1,51 @@
+package gedcom_test
+
+import (
+	"github.com/elliotchance/gedcom"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestFilterFlags_Filter(t *testing.T) {
+	t.Run("NoDuplicateNames", func(t *testing.T) {
+		doc1 := gedcom.NewDocument()
+		doc1.AddIndividual("P1",
+			gedcom.NewNameNode("Bob /Smith/"),
+			gedcom.NewNameNode("Jane /Smith/"),
+			gedcom.NewNameNode("Bob /Smith/"))
+
+		doc2 := gedcom.NewDocument()
+		doc2.AddIndividual("P1",
+			gedcom.NewNameNode("Bob /Smith/"),
+			gedcom.NewNameNode("Jane /Smith/"))
+
+		ff := &gedcom.FilterFlags{
+			NoDuplicateNames: true,
+			NameFormat:       "unmodified",
+		}
+
+		assert.Equal(t, doc2.Nodes()[0].GEDCOMString(0),
+			ff.Filter(doc1.Nodes()[0]).GEDCOMString(0))
+	})
+
+	t.Run("NoDuplicateNamesWithModifiedNames", func(t *testing.T) {
+		doc1 := gedcom.NewDocument()
+		doc1.AddIndividual("P1",
+			gedcom.NewNameNode("Bob /Smith/"),
+			gedcom.NewNameNode("Jane /Smith/"),
+			gedcom.NewNameNode("Bob /Smith/"))
+
+		doc2 := gedcom.NewDocument()
+		doc2.AddIndividual("P1",
+			gedcom.NewNameNode("Bob /Smith/"),
+			gedcom.NewNameNode("Jane /Smith/"))
+
+		ff := &gedcom.FilterFlags{
+			NoDuplicateNames: true,
+			NameFormat:       string(gedcom.NameFormatGEDCOM),
+		}
+
+		assert.Equal(t, doc2.Nodes()[0].GEDCOMString(0),
+			ff.Filter(doc1.Nodes()[0]).GEDCOMString(0))
+	})
+}

--- a/filter_test.go
+++ b/filter_test.go
@@ -37,7 +37,30 @@ func TestFilter(t *testing.T) {
 		},
 		{
 			filter: func(node gedcom.Node) (gedcom.Node, bool) {
+				return node.ShallowCopy(), false
+			},
+			expected: `0 @P1@ INDI
+`,
+		},
+		{
+			filter: func(node gedcom.Node) (gedcom.Node, bool) {
 				return node, false
+			},
+			expected: `0 @P1@ INDI
+1 NAME Elliot /Chance/
+1 BIRT
+2 DATE 6 MAY 1989
+`,
+		},
+		{
+			filter: func(node gedcom.Node) (gedcom.Node, bool) {
+				if node.Tag().Is(gedcom.TagIndividual) {
+					// false means it will not traverse children, since an
+					// individual can never be inside of another individual.
+					return node.ShallowCopy(), false
+				}
+
+				return nil, false
 			},
 			expected: `0 @P1@ INDI
 `,
@@ -53,6 +76,9 @@ func TestFilter(t *testing.T) {
 				return nil, false
 			},
 			expected: `0 @P1@ INDI
+1 NAME Elliot /Chance/
+1 BIRT
+2 DATE 6 MAY 1989
 `,
 		},
 		{


### PR DESCRIPTION
Also provides RemoveDuplicateNamesFilter filter function, and fixes a bug with returning children from a filter function being mistakenly truncated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/gedcom/299)
<!-- Reviewable:end -->
