### PR TITLE
Adding NodesWithTagPath() to q

### DIFF
--- a/q/doc.go
+++ b/q/doc.go
@@ -113,6 +113,28 @@
 //
 // Merges two documents while also merging similar individuals.
 //
+//   NodesWithTagPaths(Tags...)
+//
+// NodesWithTagPath returns all of the nodes that have an exact tag path. The
+// number of nodes returned can be zero and tag must match the tag path
+// completely and exactly.
+//
+// Find all Death nodes that belong to all individuals:
+//
+//   .Individuals | NodesWithTagPath("DEAT")
+//
+// From the individuals find all the Date nodes within only the Birth nodes.
+//
+//   .Individuals | NodesWithTagPath("BIRT", "DATE")
+//
+// Combine all of the birth and death dates:
+//
+//   Births are .Individuals | NodesWithTagPath("BIRT", "DATE") | {type: "birth", date: .String};
+//   Deaths are .Individuals | NodesWithTagPath("DEAT", "DATE") | {type: "death", date: .String};
+//   Combine(Births, Deaths)
+//
+// If the node is nil the result will also be nil.
+//
 //   Only(condition)
 //
 // The Only function returns a new slice that only contains the entities that

--- a/q/functions.go
+++ b/q/functions.go
@@ -10,5 +10,6 @@ var Functions = map[string]Expression{
 	"Last":                         &LastExpr{},
 	"Length":                       &LengthExpr{},
 	"MergeDocumentsAndIndividuals": &MergeDocumentsAndIndividualsExpr{},
+	"NodesWithTagPath":             &NodesWithTagPathExpr{},
 	"Only":                         &OnlyExpr{},
 }

--- a/q/nodes_with_tag_path.go
+++ b/q/nodes_with_tag_path.go
@@ -1,0 +1,70 @@
+package q
+
+import (
+	"fmt"
+	"github.com/elliotchance/gedcom"
+	"reflect"
+)
+
+// NodesWithTagPathExpr is a function. See Evaluate.
+type NodesWithTagPathExpr struct{}
+
+// NodesWithTagPath returns all of the nodes that have an exact tag path. The
+// number of nodes returned can be zero and tag must match the tag path
+// completely and exactly.
+//
+// If the node is nil the result will also be nil.
+//
+// Find all Death nodes that belong to all individuals:
+//
+//   .Individuals | NodesWithTagPath("DEAT")
+//
+// From the individuals find all the Date nodes within only the Birth nodes.
+//
+//   .Individuals | NodesWithTagPath("BIRT", "DATE")
+//
+// Combine all of the birth and death dates:
+//
+//   Births are .Individuals | NodesWithTagPath("BIRT", "DATE") | {type: "birth", date: .String};
+//   Deaths are .Individuals | NodesWithTagPath("DEAT", "DATE") | {type: "death", date: .String};
+//   Combine(Births, Deaths)
+//
+func (e *NodesWithTagPathExpr) Evaluate(engine *Engine, input interface{}, args []*Statement) (interface{}, error) {
+	in := reflect.ValueOf(input)
+
+	if input == nil || in.IsNil() {
+		return gedcom.Nodes(nil), nil
+	}
+
+	// Convert into a slice if needed.
+	if in.Kind() != reflect.Slice {
+		s := reflect.MakeSlice(reflect.SliceOf(in.Type()), 1, 1)
+		s.Index(0).Set(in)
+		in = reflect.ValueOf(s.Interface())
+	}
+
+	// Process args.
+	var argValues []gedcom.Tag
+	for _, arg := range args {
+		argValue, err := arg.Evaluate(engine, nil)
+		if err != nil {
+			return gedcom.Nodes(nil), err
+		}
+
+		stringForTag, ok := argValue.(string)
+		if !ok {
+			stringForTag = fmt.Sprintf("%s", argValue)
+		}
+
+		argValues = append(argValues, gedcom.TagFromString(stringForTag))
+	}
+
+	// Process slice input.
+	var results gedcom.Nodes
+	for i := 0; i < in.Len(); i++ {
+		node := in.Index(i).Interface().(gedcom.Node)
+		results = append(results, gedcom.NodesWithTagPath(node, argValues...)...)
+	}
+
+	return results, nil
+}

--- a/q/nodes_with_tag_path_test.go
+++ b/q/nodes_with_tag_path_test.go
@@ -1,0 +1,103 @@
+package q_test
+
+import (
+	"github.com/elliotchance/gedcom"
+	"github.com/elliotchance/gedcom/q"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestNodesWithTagPathExpr_Evaluate(t *testing.T) {
+	engine := &q.Engine{}
+
+	doc := gedcom.NewDocument()
+	individual := doc.AddIndividual("P1")
+	individual.AddBirthDate("16 Apr 1973")
+	individual2 := doc.AddIndividual("P2")
+	individual2.AddBirthDate("8 Mar 1884")
+
+	for testName, test := range map[string]struct {
+		input          interface{}
+		args           []*q.Statement
+		expectedGEDCOM string
+	}{
+		"Nil": {
+			input:          nil,
+			args:           nil,
+			expectedGEDCOM: "",
+		},
+		"IndividualNone": {
+			input:          individual,
+			args:           nil,
+			expectedGEDCOM: "",
+		},
+		"IndividualBIRT": {
+			input: individual,
+			args: []*q.Statement{
+				{Expressions: []q.Expression{&q.ConstantExpr{Value: "BIRT"}}},
+			},
+			expectedGEDCOM: "0 BIRT\n1 DATE 16 Apr 1973\n",
+		},
+		"IndividualDATE": {
+			input: individual,
+			args: []*q.Statement{
+				{Expressions: []q.Expression{&q.ConstantExpr{Value: "DATE"}}},
+			},
+			expectedGEDCOM: "",
+		},
+		"IndividualBIRTDATE": {
+			input: individual,
+			args: []*q.Statement{
+				{Expressions: []q.Expression{&q.ConstantExpr{Value: "BIRT"}}},
+				{Expressions: []q.Expression{&q.ConstantExpr{Value: "DATE"}}},
+			},
+			expectedGEDCOM: "0 DATE 16 Apr 1973\n",
+		},
+		"IndividualBIRTDEAT": {
+			input: individual,
+			args: []*q.Statement{
+				{Expressions: []q.Expression{&q.ConstantExpr{Value: "BIRT"}}},
+				{Expressions: []q.Expression{&q.ConstantExpr{Value: "DEAT"}}},
+			},
+			expectedGEDCOM: "",
+		},
+		"IndividualsBIRT": {
+			input: doc.Individuals(),
+			args: []*q.Statement{
+				{Expressions: []q.Expression{&q.ConstantExpr{Value: "BIRT"}}},
+			},
+			expectedGEDCOM: "0 BIRT\n1 DATE 16 Apr 1973\n0 BIRT\n1 DATE 8 Mar 1884\n",
+		},
+		"IndividualsDATE": {
+			input: doc.Individuals(),
+			args: []*q.Statement{
+				{Expressions: []q.Expression{&q.ConstantExpr{Value: "DATE"}}},
+			},
+			expectedGEDCOM: "",
+		},
+		"IndividualsBIRTDATE": {
+			input: doc.Individuals(),
+			args: []*q.Statement{
+				{Expressions: []q.Expression{&q.ConstantExpr{Value: "BIRT"}}},
+				{Expressions: []q.Expression{&q.ConstantExpr{Value: "DATE"}}},
+			},
+			expectedGEDCOM: "0 DATE 16 Apr 1973\n0 DATE 8 Mar 1884\n",
+		},
+		"IndividualsBIRTDEAT": {
+			input: doc.Individuals(),
+			args: []*q.Statement{
+				{Expressions: []q.Expression{&q.ConstantExpr{Value: "BIRT"}}},
+				{Expressions: []q.Expression{&q.ConstantExpr{Value: "DEAT"}}},
+			},
+			expectedGEDCOM: "",
+		},
+	} {
+		t.Run(testName, func(t *testing.T) {
+			actual, err := (&q.NodesWithTagPathExpr{}).Evaluate(engine, test.input, test.args)
+			require.NoError(t, err)
+
+			assert.Equal(t, test.expectedGEDCOM, gedcom.NewDocumentWithNodes(actual.(gedcom.Nodes)).String())
+		})
+	}
+}

--- a/q/question_mark_expr_test.go
+++ b/q/question_mark_expr_test.go
@@ -31,6 +31,7 @@ var functionAndVariableChoices = []string{
 	"Last",
 	"Length",
 	"MergeDocumentsAndIndividuals",
+	"NodesWithTagPath",
 	"Only",
 }
 


### PR DESCRIPTION
NodesWithTagPath returns all of the nodes that have an exact tag path.
The number of nodes returned can be zero and tag must match the tag path
completely and exactly.

Find all Death nodes that belong to all individuals:

    .Individuals | NodesWithTagPath("DEAT")

From the individuals find all the Date nodes within only the Birth nodes.

    .Individuals | NodesWithTagPath("BIRT", "DATE")

Combine all of the birth and death dates:

    Births are .Individuals | NodesWithTagPath("BIRT", "DATE") | {type: "birth", date: .String};
    Deaths are .Individuals | NodesWithTagPath("DEAT", "DATE") | {type: "death", date: .String};
    Combine(Births, Deaths)

Fixes #300

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/gedcom/303)
<!-- Reviewable:end -->
