### PR TITLE
Adding "gedcom warnings"

### DIFF
--- a/cmd/gedcom/main.go
+++ b/cmd/gedcom/main.go
@@ -25,6 +25,7 @@ func usage() string {
 		fmt.Sprintf("\t%s query     - Query with gedcomq", os.Args[0]),
 		fmt.Sprintf("\t%s tune      - Used to calculate ideal weights and similarities", os.Args[0]),
 		fmt.Sprintf("\t%s version   - Show version and exit", os.Args[0]),
+		fmt.Sprintf("\t%s warnings  - Show warnings for a gedcom file", os.Args[0]),
 	}
 
 	return strings.Join(lines, "\n")
@@ -50,6 +51,9 @@ func main() {
 
 	case "version":
 		runVersionCommand()
+
+	case "warnings":
+		runWarningsCommand()
 
 	default:
 		fatalln("unknown command:", os.Args[1])

--- a/cmd/gedcom/warnings.go
+++ b/cmd/gedcom/warnings.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"github.com/elliotchance/gedcom"
+	"os"
+)
+
+func runWarningsCommand() {
+	err := flag.CommandLine.Parse(os.Args[2:])
+	if err != nil {
+		fatalln(err)
+	}
+
+	gedcomFile := flag.Arg(0)
+	if gedcomFile == "" {
+		fatalln("you must provide a gedcom file")
+	}
+
+	doc, err := gedcom.NewDocumentFromGEDCOMFile(gedcomFile)
+	if err != nil {
+		fatalln(err)
+	}
+
+	for _, warning := range doc.Warnings() {
+		fmt.Println(warning)
+	}
+}


### PR DESCRIPTION
Since the refactoring into a single CLI tool the warnings were kind of
forgotten about. It is possible to get the warnings through query, but
that's difficult and problematic. This makes the warnings command a
first class citizen:

  gedcom warnings myfile.ged

https://github.com/elliotchance/gedcom/wiki/Warnings

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/gedcom/304)
<!-- Reviewable:end -->
