### PR TITLE
Add FAMS code in individual nodes when made a spouse in a family.

### DIFF
--- a/child_node.go
+++ b/child_node.go
@@ -1,7 +1,5 @@
 package gedcom
 
-import "fmt"
-
 // ChildNode is the natural, adopted, or sealed (LDS) child of a father and a
 // mother.
 type ChildNode struct {
@@ -18,7 +16,11 @@ func newChildNode(family *FamilyNode, value string, children ...Node) *ChildNode
 
 func newChildNodeWithIndividual(family *FamilyNode, individual *IndividualNode) *ChildNode {
 	// TODO: check individual belongs to the same document as family
-	return newChildNode(family, fmt.Sprintf("@%s@", individual.Pointer()))
+
+	famChild := NewNode(TagFamilyChild, family.Identifier(), "")
+	individual.AddNode(famChild)
+	
+	return newChildNode(family, individual.Identifier())
 }
 
 func (node *ChildNode) Family() *FamilyNode {

--- a/family_node.go
+++ b/family_node.go
@@ -139,23 +139,48 @@ func (node *FamilyNode) AddChild(individual *IndividualNode) *ChildNode {
 
 func (node *FamilyNode) SetHusband(individual *IndividualNode) *FamilyNode {
 	if individual == nil {
-		DeleteNodesWithTag(node, TagHusband)
+		husband := node.Husband().Individual()
+		nodes := husband.Nodes()
 
+		for _, subNode := range nodes {
+			if subNode.Tag() == TagFamilySpouse && subNode.Value() == node.Identifier() {
+				husband.DeleteNode(subNode)
+			}
+		}
+		
+		DeleteNodesWithTag(node, TagHusband)
+		node.husband = nil
+		node.cachedHusband = true
 		return node
 	}
+	
+	n := NewNode(TagFamilySpouse, node.Identifier(), "")
+	individual.AddNode(n)
 
 	return node.SetHusbandPointer(individual.Pointer())
 }
 
 func (node *FamilyNode) SetWife(individual *IndividualNode) *FamilyNode {
 	if individual == nil {
-		DeleteNodesWithTag(node, TagWife)
+		wife := node.Wife().Individual()
+		nodes := wife.Nodes()
 
+		for _, subNode := range nodes {
+			if subNode.Tag() == TagFamilySpouse && subNode.Value() == node.Identifier() {
+				wife.DeleteNode(subNode)
+			}
+		}
+		
+		DeleteNodesWithTag(node, TagWife)
+		node.wife = nil
+		node.cachedWife = true
 		return node
 	}
 
-	return node.SetWifePointer(individual.Pointer())
-}
+	n := NewNode(TagFamilySpouse, node.Identifier(), "")
+	individual.AddNode(n)
+	
+	return node.SetWifePointer(individual.Pointer())}
 
 func (node *FamilyNode) SetWifePointer(pointer string) *FamilyNode {
 	wife := node.Wife()

--- a/family_node_test.go
+++ b/family_node_test.go
@@ -640,7 +640,3 @@ func TestFamilyNode_Warnings(t *testing.T) {
 		})
 	}
 }
-
-func TestSetHusband(t *testing.T) {
-
-}

--- a/family_node_test.go
+++ b/family_node_test.go
@@ -38,6 +38,31 @@ var familyTests = []struct {
 		husband: nil,
 		wife:    jane,
 	},
+	{
+		doc: func(doc *gedcom.Document) {
+			jane := individual(doc, "P2", "Jane /Doe/", "3 Mar 1803", "14 June 1877")
+			elliot := individual(doc, "P1", "Elliot /Chance/", "4 Jan 1843", "17 Mar 1907")
+			f3 := doc.AddFamily("F3")
+			f3.SetWife(jane)
+			f3.SetHusband(elliot)
+			f3.SetWife(nil)
+		},
+		husband: elliot,
+		wife: nil,
+	},
+	{
+		doc: func(doc *gedcom.Document) {
+			jane := individual(doc, "P2", "Jane /Doe/", "3 Mar 1803", "14 June 1877")
+			elliot := individual(doc, "P1", "Elliot /Chance/", "4 Jan 1843", "17 Mar 1907")
+			f3 := doc.AddFamily("F3")
+			f3.SetHusband(elliot)
+			f3.SetWife(jane)
+			f3.SetHusband(nil)
+
+		},
+		husband: nil,
+		wife: jane,
+	},
 }
 
 func TestFamilyNode_Husband(t *testing.T) {
@@ -614,4 +639,8 @@ func TestFamilyNode_Warnings(t *testing.T) {
 			assertEqual(t, f1.Warnings().Strings(), test.expected)
 		})
 	}
+}
+
+func TestSetHusband(t *testing.T) {
+
 }

--- a/nodes.go
+++ b/nodes.go
@@ -161,7 +161,7 @@ func (nodes Nodes) FlattenAll(document *Document, result Nodes) {
 func (nodes Nodes) deleteNode(n Node) (Nodes, bool) {
 	for i, node2 := range nodes {
 		if node2 == n {
-			return append(nodes[:i], nodes[i+2:]...), true
+			return append(nodes[:i], nodes[i+1:]...), true
 		}
 	}
 

--- a/simple_node.go
+++ b/simple_node.go
@@ -56,6 +56,15 @@ func (node *SimpleNode) Pointer() string {
 	return node.pointer
 }
 
+// Identifier returns the identifier for the node; empty string if the node is nil
+func (node *SimpleNode) Identifier() string {
+	if node == nil {
+		return ""
+	}
+	
+	return fmt.Sprintf("@%s@", node.pointer)
+}
+
 // Equals compares two nodes for value equality.
 //
 // 1. If either or both nodes are nil then false is always returned.


### PR DESCRIPTION
These changes should add a FAMS record to the individual when they are added as a spouse to a family node.   See https://github.com/elliotchance/gedcom/issues/309   I hope I handled the cache values appropriately, originally that was confusing me as to why my delete tests were failing, although GEDCOMString() was showing what I expected.

I'll tackle children (FAMC) codes separately, soon.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/gedcom/310)
<!-- Reviewable:end -->
