### PR TITLE
If spouse is already nil, short-circuit out.

### DIFF
--- a/family_node.go
+++ b/family_node.go
@@ -140,8 +140,11 @@ func (node *FamilyNode) AddChild(individual *IndividualNode) *ChildNode {
 func (node *FamilyNode) SetHusband(individual *IndividualNode) *FamilyNode {
 	if individual == nil {
 		husband := node.Husband().Individual()
+		if husband == nil {
+			return node
+		}
 		nodes := husband.Nodes()
-
+		
 		for _, subNode := range nodes {
 			if subNode.Tag() == TagFamilySpouse && subNode.Value() == node.Identifier() {
 				husband.DeleteNode(subNode)
@@ -163,6 +166,9 @@ func (node *FamilyNode) SetHusband(individual *IndividualNode) *FamilyNode {
 func (node *FamilyNode) SetWife(individual *IndividualNode) *FamilyNode {
 	if individual == nil {
 		wife := node.Wife().Individual()
+		if wife == nil {
+			return node
+		}
 		nodes := wife.Nodes()
 
 		for _, subNode := range nodes {
@@ -180,7 +186,8 @@ func (node *FamilyNode) SetWife(individual *IndividualNode) *FamilyNode {
 	n := NewNode(TagFamilySpouse, node.Identifier(), "")
 	individual.AddNode(n)
 	
-	return node.SetWifePointer(individual.Pointer())}
+	return node.SetWifePointer(individual.Pointer())
+}
 
 func (node *FamilyNode) SetWifePointer(pointer string) *FamilyNode {
 	wife := node.Wife()

--- a/family_node.go
+++ b/family_node.go
@@ -138,9 +138,9 @@ func (node *FamilyNode) AddChild(individual *IndividualNode) *ChildNode {
 }
 
 func (node *FamilyNode) SetHusband(individual *IndividualNode) *FamilyNode {
-	if individual == nil {
+	if IsNil(individual) {
 		husband := node.Husband().Individual()
-		if husband == nil {
+		if IsNil(husband) {
 			return node
 		}
 		nodes := husband.Nodes()
@@ -164,9 +164,9 @@ func (node *FamilyNode) SetHusband(individual *IndividualNode) *FamilyNode {
 }
 
 func (node *FamilyNode) SetWife(individual *IndividualNode) *FamilyNode {
-	if individual == nil {
+	if IsNil(individual) {
 		wife := node.Wife().Individual()
-		if wife == nil {
+		if IsNil(wife) {
 			return node
 		}
 		nodes := wife.Nodes()

--- a/family_node_test.go
+++ b/family_node_test.go
@@ -63,6 +63,31 @@ var familyTests = []struct {
 		husband: nil,
 		wife: jane,
 	},
+	{
+		doc: func(doc *gedcom.Document) {
+				jane := individual(doc, "P2", "Jane /Doe/", "3 Mar 1803", "14 June 1877")
+				elliot := individual(doc, "P1", "Elliot /Chance/", "4 Jan 1843", "17 Mar 1907")
+				doc.AddFamilyWithHusbandAndWife("F3", elliot, jane)
+		},
+		husband: elliot,
+		wife: jane,
+	},
+	{
+		doc: func(doc *gedcom.Document) {
+				elliot := individual(doc, "P1", "Elliot /Chance/", "4 Jan 1843", "17 Mar 1907")
+				doc.AddFamilyWithHusbandAndWife("F3", elliot, nil)
+		},
+		husband: elliot,
+		wife: nil,
+	},
+	{
+		doc: func(doc *gedcom.Document) {
+				jane := individual(doc, "P2", "Jane /Doe/", "3 Mar 1803", "14 June 1877")	
+				doc.AddFamilyWithHusbandAndWife("F3", nil, jane)
+		},
+		husband: nil,
+		wife: jane,
+	},
 }
 
 func TestFamilyNode_Husband(t *testing.T) {


### PR DESCRIPTION
So I thought I had run all of the tests, but I obviously hadn't as the test for child_node is now failing -- with the actual failure being the doc.AddFamilyWithHusbandAndWife("F1", p1, nil) call.  

This fixes that problem, by quietly returning if you try to SetWife() or SetHusband() with nil and it's already nil.   While I was there I fixed some formatting, and used IsNil() for my tests.

Also added some explicit tests for AddFamilyWithHusbandAndWife() in the familyTests.

So really, really sorry about this -- I tripled checked that the tests were all OK this time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/gedcom/311)
<!-- Reviewable:end -->
